### PR TITLE
Feat/app listing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,10 +13,11 @@ buildscript {
     ext.junit = '4.12'
     ext.kotlin_version = '1.3.50'
     ext.mockito = '2.28.2'
-    ext.retrofit = '2.6.1'
+    ext.retrofit = '2.6.3'
     ext.robolectric = '4.3'
     ext.timber = '4.7.1'
     ext.truth = '1.0'
+    ext.sdk_utils = '0.1.1'
 
 //  Build Config.
     apply from: 'config/index.gradle'

--- a/miniapp/build.gradle
+++ b/miniapp/build.gradle
@@ -43,25 +43,29 @@ dependencies {
     implementation "androidx.core:core-ktx:$androidx_coreKtx"
     implementation "androidx.work:work-runtime-ktx:$androidx_work"
 
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "com.jakewharton.timber:timber:$timber"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit"
     implementation "com.squareup.retrofit2:retrofit:$retrofit"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     kapt "com.google.dagger:dagger-compiler:$dagger"
     implementation "com.google.dagger:dagger:$dagger"
 
     kapt "com.rakuten.tech.mobile:manifest-config-processor:0.1.0"
     implementation "com.rakuten.tech.mobile:manifest-config-annotations:0.1.0"
+    implementation "com.rakuten.tech.mobile.sdkutils:sdk-utils:$sdk_utils"
 
     testImplementation "androidx.test.ext:junit:$androidx_test_ext"
     testImplementation "androidx.work:work-testing:$androidx_work"
     testImplementation "org.mockito:mockito-android:$mockito"
     testImplementation "org.mockito:mockito-core:$mockito"
+    testImplementation "org.amshove.kluent:kluent-android:1.48"
+    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
+    testImplementation "org.mockito:mockito-inline:2.23.0"
     testImplementation "org.robolectric:robolectric:$robolectric"
     testImplementation "com.google.truth:truth:$truth"
-    testImplementation "com.squareup.retrofit2:retrofit-mock:$retrofit"
-
+    testImplementation "com.squareup.okhttp3:mockwebserver:4.2.1"
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.3'
 }
 
 apply from: "../config/quality/checkstyle/android.gradle"

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -9,6 +9,7 @@ import com.rakuten.tech.mobile.miniapp.miniapp.Lister
  * by which operations in the mini app ecosystem are exposed.
  * Should be accessed via [MiniApp.instance].
  */
+@Suppress("UnnecessaryAbstractClass")
 abstract class MiniApp internal constructor() {
 
     /**

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -39,7 +39,7 @@ class MiniappSdkInitializer : ContentProvider() {
          * App Id assigned to host App.
          **/
         @MetaData(key = "com.rakuten.tech.mobile.ras.AppId")
-        fun appId(): String
+        fun rasAppId(): String
 
         /**
          * Subscription Key for the registered host app.
@@ -53,12 +53,17 @@ class MiniappSdkInitializer : ContentProvider() {
 
         val manifestConfig = AppManifestConfig(context)
         val storage = MiniAppStorage(FileWriter())
-        val apiClient = ApiClient()
+        val apiClient = ApiClient(
+            baseUrl = manifestConfig.baseUrl(),
+            rasAppId = manifestConfig.rasAppId(),
+            subscriptionKey = manifestConfig.subscriptionKey(),
+            hostAppVersion = manifestConfig.hostAppVersion()
+        )
 
         MiniApp.init(
             downloader = Downloader(storage, apiClient),
             displayer = Displayer(),
-            lister = Lister()
+            lister = Lister(apiClient)
         )
 
         return true

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -1,4 +1,78 @@
 package com.rakuten.tech.mobile.miniapp.api
 
-@SuppressWarnings("UseDataClass")
-internal class ApiClient
+import androidx.annotation.VisibleForTesting
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.HttpException
+import retrofit2.Response
+import retrofit2.Retrofit
+
+internal class ApiClient @VisibleForTesting constructor(
+    retrofit: Retrofit,
+    private val hostAppVersion: String,
+    private val requestExecutor: RetrofitRequestExecutor = RetrofitRequestExecutor(retrofit)
+) {
+
+    constructor(
+        baseUrl: String,
+        rasAppId: String,
+        subscriptionKey: String,
+        hostAppVersion: String
+    ) : this(
+        retrofit = createRetrofitClient(
+            baseUrl = baseUrl,
+            rasAppId = rasAppId,
+            subscriptionKey = subscriptionKey
+        ),
+        hostAppVersion = hostAppVersion
+    )
+}
+
+internal class RetrofitRequestExecutor(
+    retrofit: Retrofit
+) {
+
+    private val errorConvertor = retrofit.responseBodyConverter<ErrorResponse>(
+        ErrorResponse::class.java,
+        arrayOfNulls<Annotation>(0)
+    )
+
+    suspend fun <T> executeRequest(call: Call<T>): T {
+        val response = call.execute()
+
+        if (response.isSuccessful) {
+            return response.body()!! // Body can't be null if request was successful
+        } else {
+            val error = response.errorBody()!! // Error body can't be null if request wasn't successful
+            throw MiniAppHttpException(
+                response = response,
+                errorMessage = errorConvertor.convert(error)?.message
+                    ?: "No error message provided by server."
+            )
+        }
+    }
+}
+
+internal data class ErrorResponse(
+    val code: Int,
+    val message: String
+)
+
+/**
+ * Exception thrown when the Mini App API returns an error response.
+ * @param response Response from the server
+ * @param errorMessage Error message returned by the server
+ */
+class MiniAppHttpException(
+    response: Response<in Nothing>,
+    val errorMessage: String
+) : HttpException(response) {
+
+    /**
+     * Readable message of error response in the format
+     * "HTTP {CODE} {STATUS MESSAGE}: {ERROR MESSAGE}".
+     */
+    override fun message(): String {
+        return "${super.message()}: $errorMessage"
+    }
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -1,7 +1,6 @@
 package com.rakuten.tech.mobile.miniapp.api
 
 import androidx.annotation.VisibleForTesting
-import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.HttpException
 import retrofit2.Response
@@ -10,7 +9,8 @@ import retrofit2.Retrofit
 internal class ApiClient @VisibleForTesting constructor(
     retrofit: Retrofit,
     private val hostAppVersion: String,
-    private val requestExecutor: RetrofitRequestExecutor = RetrofitRequestExecutor(retrofit)
+    private val requestExecutor: RetrofitRequestExecutor = RetrofitRequestExecutor(retrofit),
+    private val listingApi: ListingApi = retrofit.create(ListingApi::class.java)
 ) {
 
     constructor(
@@ -26,6 +26,11 @@ internal class ApiClient @VisibleForTesting constructor(
         ),
         hostAppVersion = hostAppVersion
     )
+
+    suspend fun list(): List<ListingEntity> {
+        val request = listingApi.list(hostAppVersion = hostAppVersion)
+        return requestExecutor.executeRequest(request)
+    }
 }
 
 internal class RetrofitRequestExecutor(
@@ -72,7 +77,5 @@ class MiniAppHttpException(
      * Readable message of error response in the format
      * "HTTP {CODE} {STATUS MESSAGE}: {ERROR MESSAGE}".
      */
-    override fun message(): String {
-        return "${super.message()}: $errorMessage"
-    }
+    override fun message() = "${super.message()}: $errorMessage"
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ListingApi.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ListingApi.kt
@@ -1,15 +1,21 @@
 package com.rakuten.tech.mobile.miniapp.api
 
-internal class ListRequest
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Path
 
-internal class ListResponse
+internal interface ListingApi {
+    @GET("oneapp/android/{hostAppVersion}/miniapps")
+    fun list(
+        @Path("hostAppVersion") hostAppVersion: String
+    ): Call<List<ListingEntity>>
+}
 
-@Suppress("UndocumentedPublicClass")
-data class ListEntity(
+internal data class ListingEntity(
     val id: String,
-    val version: String,
     val name: String,
     val description: String,
     val icon: String,
-    val ref: String
+    val versionId: String,
+    val files: List<String>
 )

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtils.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtils.kt
@@ -1,0 +1,39 @@
+package com.rakuten.tech.mobile.miniapp.api
+
+import androidx.annotation.VisibleForTesting
+import com.rakuten.tech.mobile.miniapp.BuildConfig
+import com.rakuten.tech.mobile.sdkutils.RasSdkHeaders
+import com.rakuten.tech.mobile.sdkutils.okhttp.addHeaderInterceptor
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+internal fun createRetrofitClient(
+    baseUrl: String,
+    rasAppId: String,
+    subscriptionKey: String
+) = createRetrofitClient(
+    baseUrl = baseUrl,
+    headers = RasSdkHeaders(
+        appId = rasAppId,
+        subscriptionKey = subscriptionKey,
+        sdkName = "MiniApp",
+        sdkVersion = BuildConfig.VERSION_NAME
+    )
+)
+
+@VisibleForTesting
+internal fun createRetrofitClient(
+    baseUrl: String,
+    headers: RasSdkHeaders
+): Retrofit {
+    @Suppress("SpreadOperator")
+    val httpClient = OkHttpClient.Builder()
+        .addHeaderInterceptor(*headers.asArray())
+        .build()
+    return Retrofit.Builder()
+        .addConverterFactory(GsonConverterFactory.create())
+        .baseUrl(baseUrl)
+        .client(httpClient)
+        .build()
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/miniapp/Lister.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/miniapp/Lister.kt
@@ -1,3 +1,5 @@
 package com.rakuten.tech.mobile.miniapp.miniapp
 
-internal class Lister
+import com.rakuten.tech.mobile.miniapp.api.ApiClient
+
+internal class Lister(client: ApiClient)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
@@ -1,0 +1,127 @@
+package com.rakuten.tech.mobile.miniapp.api
+
+import junit.framework.TestCase
+import kotlinx.coroutines.test.runBlockingTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.amshove.kluent.*
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+open class ApiClientSpec
+
+open class RetrofitRequestExecutorSpec private constructor(
+    internal val mockServer: MockWebServer
+) : MockWebServerBaseTest(mockServer) {
+
+    constructor() : this(MockWebServer())
+
+    private lateinit var retrofit: Retrofit
+    private lateinit var baseUrl: String
+
+    @Before
+    fun baseSetup() {
+        baseUrl = mockServer.url("/").toString()
+
+        retrofit = Retrofit.Builder()
+            .addConverterFactory(GsonConverterFactory.create())
+            .baseUrl(baseUrl)
+            .build()
+    }
+
+    internal fun createApi() = retrofit.create(TestApi::class.java)
+
+    internal fun createRequestExecutor(
+        retrofit: Retrofit = this.retrofit
+    ) = RetrofitRequestExecutor(
+        retrofit = retrofit
+    )
+}
+
+open class RetrofitRequestExecutorNormalSpec : RetrofitRequestExecutorSpec() {
+
+    @Test
+    fun `should return the body`() = runBlockingTest {
+        mockServer.enqueue(createTestApiResponse(testValue = "test_value"))
+
+        val response = createRequestExecutor()
+            .executeRequest(createApi().fetch())
+
+        response.testKey shouldEqual "test_value"
+    }
+}
+
+open class RetrofitRequestExecutorErrorSpec : RetrofitRequestExecutorSpec() {
+
+    @Test(expected = MiniAppHttpException::class)
+    fun `should throw when server returns error response`() = runBlockingTest {
+        mockServer.enqueue(createErrorResponse())
+
+        createRequestExecutor()
+            .executeRequest(createApi().fetch())
+    }
+
+    @Test
+    fun `should throw exception with the error message returned by server`() = runBlockingTest {
+        mockServer.enqueue(createErrorResponse(message = "error_message"))
+
+        try {
+            createRequestExecutor()
+                .executeRequest(createApi().fetch())
+
+            TestCase.fail("Should have thrown ErrorResponseException.")
+        } catch (exception: MiniAppHttpException) {
+            exception.errorMessage shouldEqual "error_message"
+        }
+    }
+
+    @Test
+    fun `should append error message to base exception message`() = runBlockingTest {
+        mockServer.enqueue(createErrorResponse(message = "error_message"))
+
+        try {
+            createRequestExecutor()
+                .executeRequest(createApi().fetch())
+
+            TestCase.fail("Should have thrown ErrorResponseException.")
+        } catch (exception: MiniAppHttpException) {
+            exception.message() shouldContain "error_message"
+        }
+    }
+
+    @Test
+    fun `should append default message when server doesn't return error message`() = runBlockingTest {
+        mockServer.enqueue(
+            MockResponse()
+                .setResponseCode(400)
+                .setBody("{}")
+        )
+
+        try {
+            createRequestExecutor()
+                .executeRequest(createApi().fetch())
+
+            TestCase.fail("Should have thrown ErrorResponseException.")
+        } catch (exception: MiniAppHttpException) {
+            exception.message() shouldContain "No error message"
+        }
+    }
+
+    private fun createErrorResponse(
+        code: Int = 400,
+        message: String = "error_message"
+    ): MockResponse {
+        val error = """
+            {
+                "code": $code,
+                "message": "$message"
+            }
+        """.trimIndent()
+
+        return MockResponse()
+            .setResponseCode(code)
+            .setBody(error)
+    }
+}

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
@@ -1,16 +1,59 @@
 package com.rakuten.tech.mobile.miniapp.api
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
 import junit.framework.TestCase
 import kotlinx.coroutines.test.runBlockingTest
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
-import org.amshove.kluent.*
+import org.amshove.kluent.When
+import org.amshove.kluent.calling
+import org.amshove.kluent.itReturns
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldEqual
 import org.junit.Before
 import org.junit.Test
+import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
-open class ApiClientSpec
+open class ApiClientSpec {
+
+    private val mockRetrofitClient: Retrofit = mock()
+    private val mockRequestExecutor: RetrofitRequestExecutor = mock()
+    private val mockListingApi: ListingApi = mock()
+
+    @Test
+    fun `should fetch the list of mini apps`() = runBlockingTest {
+        val listingEntity = ListingEntity(
+            id = "test_id",
+            versionId = "test_version",
+            name = "test_name",
+            description = "test_description",
+            icon = "test_icon",
+            files = listOf("https://www.example.com")
+        )
+        val mockCall: Call<List<ListingEntity>> = mock()
+        When calling mockListingApi.list(any()) itReturns mockCall
+        When calling mockRequestExecutor.executeRequest(mockCall) itReturns listOf(listingEntity)
+
+        val apiClient = createApiClient(listingApi = mockListingApi)
+
+        apiClient.list()[0] shouldEqual listingEntity
+    }
+
+    private fun createApiClient(
+        retrofit: Retrofit = mockRetrofitClient,
+        hostAppVersion: String = "test_version",
+        requestExecutor: RetrofitRequestExecutor = mockRequestExecutor,
+        listingApi: ListingApi = mockListingApi
+    ) = ApiClient(
+        retrofit = retrofit,
+        hostAppVersion = hostAppVersion,
+        requestExecutor = requestExecutor,
+        listingApi = listingApi
+    )
+}
 
 open class RetrofitRequestExecutorSpec private constructor(
     internal val mockServer: MockWebServer

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ListingApiSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ListingApiSpec.kt
@@ -1,0 +1,137 @@
+package com.rakuten.tech.mobile.miniapp.api
+
+import com.google.gson.Gson
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.amshove.kluent.*
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+open class ListingApiSpec private constructor(
+    internal val mockServer: MockWebServer
+) : MockWebServerBaseTest(mockServer) {
+
+    constructor() : this(MockWebServer())
+
+    private lateinit var baseUrl: String
+    internal lateinit var retrofit: Retrofit
+
+    @Before
+    fun baseSetup() {
+        baseUrl = mockServer.url("/").toString()
+        retrofit = Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+
+    internal fun createResponse(
+        id: String = "test_id",
+        version: String = "test_version",
+        name: String = "test_name",
+        description: String = "test_description",
+        icon: String = "test_icon",
+        files: List<String> = listOf("https://www.example.com/1", "https://www.example.com/2")
+    ): MockResponse {
+        val appInfo = hashMapOf(
+            "id" to id,
+            "versionId" to version,
+            "name" to name,
+            "description" to description,
+            "icon" to icon,
+            "files" to files
+        )
+
+        return MockResponse().setBody("[${Gson().toJson(appInfo)}]")
+    }
+}
+
+class ListingApiRequestSpec : ListingApiSpec() {
+
+    @Test
+    fun `should fetch mini apps using the 'miniapps' endpoint`() {
+        mockServer.enqueue(createResponse())
+
+        retrofit.create(ListingApi::class.java)
+            .list(hostAppVersion = "test_version")
+            .execute()
+
+        mockServer.takeRequest().requestUrl!!.encodedPath shouldEndWith "miniapps"
+    }
+
+    @Test
+    fun `should fetch mini apps for the 'android' platform`() {
+        mockServer.enqueue(createResponse())
+
+        retrofit.create(ListingApi::class.java)
+            .list(hostAppVersion = "test_version")
+            .execute()
+
+        mockServer.takeRequest().path!! shouldStartWith "/oneapp/android/"
+    }
+
+    @Test
+    fun `should fetch mini apps for the provided host app version`() {
+        mockServer.enqueue(createResponse())
+
+        retrofit.create(ListingApi::class.java)
+            .list(hostAppVersion = "test_version")
+            .execute()
+
+        mockServer.takeRequest().path!! shouldContain "android/test_version/"
+    }
+}
+
+class ListingApiResponseSpec : ListingApiSpec() {
+
+    private lateinit var listing: ListingEntity
+
+    @Before
+    fun setup() {
+        mockServer.enqueue(createResponse(
+            id = "test_id",
+            version = "test_version",
+            name = "test_name",
+            description = "test_description",
+            icon = "test_icon",
+            files = listOf("https://www.example.com/1", "https://www.example.com/2")
+        ))
+
+        listing = retrofit.create(ListingApi::class.java)
+            .list(hostAppVersion = "test_version")
+            .execute().body()!![0]
+    }
+
+    @Test
+    fun `should parse the 'id' from response`() {
+        listing.id shouldEqual "test_id"
+    }
+
+    @Test
+    fun `should parse the 'version' from response`() {
+        listing.versionId shouldEqual "test_version"
+    }
+
+    @Test
+    fun `should parse the 'name' from response`() {
+        listing.name shouldEqual "test_name"
+    }
+
+    @Test
+    fun `should parse the 'description' from response`() {
+        listing.description shouldEqual "test_description"
+    }
+
+    @Test
+    fun `should parse the 'icon' from response`() {
+        listing.icon shouldEqual "test_icon"
+    }
+
+    @Test
+    fun `should parse the 'files' from response`() {
+        listing.files shouldContain "https://www.example.com/1"
+        listing.files shouldContain "https://www.example.com/2"
+    }
+}

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/MockWebServerBaseTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/MockWebServerBaseTest.kt
@@ -1,0 +1,27 @@
+package com.rakuten.tech.mobile.miniapp.api
+
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import java.util.logging.Level
+import java.util.logging.LogManager
+
+open class MockWebServerBaseTest(private val mockServer: MockWebServer) {
+    private lateinit var baseUrl: String
+
+    init {
+        LogManager.getLogManager()
+            .getLogger(MockWebServer::class.java.name).level = Level.OFF
+    }
+
+    @Before
+    fun mockServerSetup() {
+        mockServer.start()
+        baseUrl = mockServer.url("/").toString()
+    }
+
+    @After
+    fun mockServerTeardown() {
+        mockServer.shutdown()
+    }
+}

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtilsSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtilsSpec.kt
@@ -1,0 +1,57 @@
+package com.rakuten.tech.mobile.miniapp.api
+
+import com.nhaarman.mockitokotlin2.mock
+import com.rakuten.tech.mobile.sdkutils.RasSdkHeaders
+import okhttp3.mockwebserver.MockWebServer
+import org.amshove.kluent.*
+import org.junit.Before
+import org.junit.Test
+
+class RetrofitCreatorUtilsSpec private constructor(
+    private val mockServer: MockWebServer
+) : MockWebServerBaseTest(mockServer) {
+
+    constructor() : this(MockWebServer())
+
+    private val mockRasSdkHeaders: RasSdkHeaders = mock()
+    lateinit var baseUrl: String
+
+    @Before
+    fun setup() {
+        baseUrl = mockServer.url("/").toString()
+
+        mockServer.enqueue(createTestApiResponse())
+
+        When calling mockRasSdkHeaders.asArray() itReturns emptyArray()
+    }
+
+    @Test
+    fun `should attach the RAS headers to requests`() {
+        When calling mockRasSdkHeaders.asArray() itReturns
+            arrayOf("ras_header_name" to "ras_header_value")
+
+        createClient()
+            .create(TestApi::class.java)
+            .fetch()
+            .execute()
+
+        mockServer.takeRequest().getHeader("ras_header_name") shouldEqual "ras_header_value"
+    }
+
+    @Test
+    fun `should parse a JSON response`() {
+        mockServer.enqueue(createTestApiResponse(testValue = "test_value"))
+
+        val response = createClient()
+            .create(TestApi::class.java)
+            .fetch()
+            .execute()
+
+        response.body()!!.testKey shouldEqual "test_value"
+    }
+
+    private fun createClient() = createRetrofitClient(
+        baseUrl = baseUrl,
+        headers = mockRasSdkHeaders
+    )
+}

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/TestApi.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/TestApi.kt
@@ -1,0 +1,22 @@
+package com.rakuten.tech.mobile.miniapp.api
+
+import okhttp3.mockwebserver.MockResponse
+import retrofit2.Call
+import retrofit2.http.GET
+
+interface TestApi {
+    @GET("testendpoint")
+    fun fetch(): Call<TestResponse>
+}
+
+data class TestResponse(
+    val testKey: String
+)
+
+fun createTestApiResponse(
+    testValue: String = "test_value"
+) = MockResponse().setBody("""
+        {
+            "testKey": "$testValue"
+        }
+    """.trimIndent())

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/legacy/download/network/client/RetrofitClientTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/legacy/download/network/client/RetrofitClientTest.kt
@@ -23,6 +23,6 @@ class RetrofitClientTest : DownloadBaseTest() {
 
     @Test
     fun shouldSetBaseURLInRetrofit() {
-        assertThat(retrofitClient.retrofit.baseUrl().url().toString()).isEqualTo(BASE_URL)
+        assertThat(retrofitClient.retrofit.baseUrl().toUrl().toString()).isEqualTo(BASE_URL)
     }
 }


### PR DESCRIPTION
Create Retrofit utils and add to ApiClient
- RetrofitCreatorUtils for creating the Retrofit client. RetrofitRequestExecutor is for executing requests, handling error response, and returning the body of the sucessful response. Also added SDK Utils library for adding the RAS headers to all requests.
- I pulled the request execution out into a separate `RetrofitRequestExecutor` class so that the success/error handling can be tested separately. Otherwise, we need to rewrite the same success/error tests for every method in the `ApiClient`. I kind of don't really like to have it as a separate class because it should be part of the `ApiClient`, but this is the best compromise I could think of to make it more testable. Do you have any other ideas?

feat: Add 'list' to ApiClient for returning list of mini apps
- Also added implementation for ListingApi

