### PR TITLE
ci: Remove debug output for App Center upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,6 @@ jobs:
             --release-notes $CIRCLE_BUILD_URL
             --token $APP_CENTER_TOKEN
             --quiet
-            --debug
 
 workflows:
   version: 2


### PR DESCRIPTION
The debug output displays some sensitive information in the logs on CI