### PR TITLE
base implementation for download & save of a mini app

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -19,12 +19,13 @@ abstract class MiniApp internal constructor() {
     abstract suspend fun listMiniApp(): List<MiniAppInfo>
 
     /**
-     * Creates a mini app for the given [appId]. The mini app is downloaded and saved.
-     * Provides [MiniAppView] when successful and an [error] when there is some issue
-     * during fetching, downloading or creating a view.
+     * Creates a mini app from the metadata [MiniAppInfo] object.
+     * The mini app is downloaded, saved and provides a [MiniAppView] when successful
+     * @throws MiniAppSdkException when there is some issue during fetching,
+     * downloading or creating the view.
      */
     abstract suspend fun create(
-        appId: String,
+        miniAppInfo: MiniAppInfo,
         success: (MiniAppView) -> Unit,
         error: (Exception) -> Unit
     )

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -31,9 +31,7 @@ internal class MiniAppDownloader(
         val baseSavePath = storage.getSavePathForApp(appId, versionId)
         for (file in manifest.files) {
             val response = apiClient.downloadFile(file)
-            val filePath = storage.getFilePathFromUrl(file)
-            val fileName = storage.getFileName(file)
-            storage.saveFile(response.byteStream(), baseSavePath, filePath, fileName)
+            storage.saveFile(file, baseSavePath, response.byteStream())
         }
         return baseSavePath
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -1,10 +1,41 @@
 package com.rakuten.tech.mobile.miniapp
 
 import com.rakuten.tech.mobile.miniapp.api.ApiClient
+import com.rakuten.tech.mobile.miniapp.api.ManifestEntity
 import com.rakuten.tech.mobile.miniapp.storage.MiniAppStorage
+import java.lang.Exception
 
 @SuppressWarnings("UseDataClass")
 internal class MiniAppDownloader(
     val storage: MiniAppStorage,
     val apiClient: ApiClient
-)
+) {
+
+    suspend fun startDownload(appId: String, versionId: String) {
+        try {
+            val manifest = fetchManifest(appId, versionId)
+            downloadMiniApp(appId, versionId, manifest)
+        } catch (error : Exception) {
+            throw MiniAppSdkException(error)
+        }
+    }
+
+    suspend fun fetchManifest(
+        appId: String,
+        versionId: String
+    ) = apiClient.fetchFileList(appId, versionId)
+
+    private suspend fun downloadMiniApp(
+        appId: String,
+        versionId: String,
+        manifest: ManifestEntity
+    ) {
+        val baseSavePath = storage.getSavePathForApp(appId, versionId)
+        for (file in manifest.files) {
+            val response = apiClient.downloadFile(file)
+            val filePath = storage.getFilePathFromUrl(file)
+            val fileName = storage.getFileName(file)
+            storage.saveFile(response, baseSavePath, filePath, fileName)
+        }
+    }
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -3,9 +3,7 @@ package com.rakuten.tech.mobile.miniapp
 import com.rakuten.tech.mobile.miniapp.api.ApiClient
 import com.rakuten.tech.mobile.miniapp.api.ManifestEntity
 import com.rakuten.tech.mobile.miniapp.storage.MiniAppStorage
-import java.lang.Exception
 
-@SuppressWarnings("UseDataClass")
 internal class MiniAppDownloader(
     val storage: MiniAppStorage,
     val apiClient: ApiClient
@@ -14,8 +12,8 @@ internal class MiniAppDownloader(
     suspend fun startDownload(appId: String, versionId: String) {
         try {
             val manifest = fetchManifest(appId, versionId)
-            downloadMiniApp(appId, versionId, manifest)
-        } catch (error : Exception) {
+            val downloadedPath = downloadMiniApp(appId, versionId, manifest)
+        } catch (error: Exception) {
             throw MiniAppSdkException(error)
         }
     }
@@ -29,13 +27,14 @@ internal class MiniAppDownloader(
         appId: String,
         versionId: String,
         manifest: ManifestEntity
-    ) {
+    ): String {
         val baseSavePath = storage.getSavePathForApp(appId, versionId)
         for (file in manifest.files) {
             val response = apiClient.downloadFile(file)
             val filePath = storage.getFilePathFromUrl(file)
             val fileName = storage.getFileName(file)
-            storage.saveFile(response, baseSavePath, filePath, fileName)
+            storage.saveFile(response.byteStream(), baseSavePath, filePath, fileName)
         }
+        return baseSavePath
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
@@ -4,4 +4,7 @@ package com.rakuten.tech.mobile.miniapp
  * A custom exception class which treats the purpose of providing
  * error information to the consumer app in an unified way.
  */
-class MiniAppSdkException(message: String) : Exception(message)
+class MiniAppSdkException(message: String) : Exception(message) {
+
+    constructor(e: Exception) : this("Found some problem, $e.message")
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -48,9 +48,9 @@ class MiniappSdkInitializer : ContentProvider() {
 
     override fun onCreate(): Boolean {
         val context = context ?: return false
-
         val manifestConfig = AppManifestConfig(context)
-        val storage = MiniAppStorage(FileWriter())
+        val storage = MiniAppStorage(FileWriter(), context.filesDir)
+
         val apiClient = ApiClient(
             baseUrl = manifestConfig.baseUrl(),
             rasAppId = manifestConfig.rasAppId(),
@@ -59,14 +59,9 @@ class MiniappSdkInitializer : ContentProvider() {
         )
 
         MiniApp.init(
-            miniAppDownloader = MiniAppDownloader(
-                storage,
-                apiClient
-            ),
+            miniAppDownloader = MiniAppDownloader(storage, apiClient),
             displayer = Displayer(),
-            miniAppLister = MiniAppLister(
-                apiClient
-            )
+            miniAppLister = MiniAppLister(apiClient)
         )
 
         return true

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -12,10 +12,13 @@ internal class RealMiniApp(
     override suspend fun listMiniApp(): List<MiniAppInfo> = miniAppLister.fetchMiniAppList()
 
     override suspend fun create(
-        appId: String,
+        miniAppInfo: MiniAppInfo,
         success: (MiniAppView) -> Unit,
         error: (Exception) -> Unit
     ) {
-        TODO("not implemented")
+        miniAppDownloader.startDownload(
+            appId = miniAppInfo.id,
+            versionId = miniAppInfo.versionId
+        )
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -58,6 +58,7 @@ internal class RetrofitRequestExecutor(
         arrayOfNulls<Annotation>(0)
     )
 
+    @Suppress("TooGenericExceptionCaught")
     suspend fun <T> executeRequest(call: Call<T>): T {
         try {
             val response = call.execute()
@@ -69,7 +70,7 @@ internal class RetrofitRequestExecutor(
                 throw sdkExceptionFromHttpException(response, error)
             }
         } catch (error: Exception) { // hotfix to catch the case when response is not Type T
-            throw MiniAppSdkException("Found some problem, ${error.localizedMessage}")
+            throw MiniAppSdkException(error)
         }
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/FileWriter.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/FileWriter.kt
@@ -1,3 +1,47 @@
 package com.rakuten.tech.mobile.miniapp.storage
 
-internal class FileWriter
+import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
+import okhttp3.ResponseBody
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+
+private const val FILE_WRITE_BATCH_SIZE = 4096
+
+internal class FileWriter {
+
+    suspend fun write(response: ResponseBody, path: String) {
+        try {
+            File(path).mkdirs()
+            val file = File(path)
+            var inputStream: InputStream? = null
+            var outputStream: OutputStream? = null
+
+            try {
+                val byteArray = ByteArray(FILE_WRITE_BATCH_SIZE)
+                var fileSizeDownloaded: Long = 0
+                inputStream = response.byteStream()
+                outputStream = FileOutputStream(file)
+
+                while (true) {
+                    val read = inputStream.read(byteArray)
+                    if (read == -1) {
+                        break
+                    }
+                    outputStream.write(byteArray, 0, read)
+                    fileSizeDownloaded += read
+                    outputStream.flush()
+                }
+            } catch (e: IOException) {
+                throw MiniAppSdkException(e)
+            } finally {
+                inputStream?.close()
+                outputStream?.close()
+            }
+        } catch (e: IOException) {
+            throw MiniAppSdkException(e)
+        }
+    }
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/FileWriter.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/FileWriter.kt
@@ -1,48 +1,18 @@
 package com.rakuten.tech.mobile.miniapp.storage
 
-import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
-import java.io.FileOutputStream
-import java.io.IOException
 import java.io.InputStream
-import java.io.OutputStream
-
-private const val FILE_WRITE_BATCH_SIZE = 4096
 
 internal class FileWriter {
 
     suspend fun write(inputStream: InputStream, path: String) {
         withContext(Dispatchers.IO) {
-            try {
-                File(path).mkdirs()
-                val file = File(path)
-                var outputStream: OutputStream? = null
-
-                try {
-                    val byteArray = ByteArray(FILE_WRITE_BATCH_SIZE)
-                    var fileSizeDownloaded: Long = 0
-                    outputStream = FileOutputStream(file)
-
-                    while (true) {
-                        val read = inputStream.read(byteArray)
-                        if (read == -1) {
-                            break
-                        }
-                        outputStream.write(byteArray, 0, read)
-                        fileSizeDownloaded += read
-                        outputStream.flush()
-                    }
-                } catch (e: IOException) {
-                    throw MiniAppSdkException(e)
-                } finally {
-                    inputStream.close()
-                    outputStream?.close()
-                }
-            } catch (e: IOException) {
-                throw MiniAppSdkException(e)
-            }
+            File(path).mkdirs()
+            val file = File(path)
+            inputStream.use { it.copyTo(file.outputStream()) }
+            file.outputStream().close()
         }
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorage.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorage.kt
@@ -1,8 +1,8 @@
 package com.rakuten.tech.mobile.miniapp.storage
 
 import com.rakuten.tech.mobile.miniapp.legacy.core.utils.LocalUrlParser
-import okhttp3.ResponseBody
 import java.io.File
+import java.io.InputStream
 
 private const val SUB_DIR_MINIAPP = "miniapp"
 
@@ -14,11 +14,11 @@ internal class MiniAppStorage(
 ) {
 
     suspend fun saveFile(
-        response: ResponseBody,
+        inputStream: InputStream,
         basePath: String,
         filePath: String,
         fileName: String
-    ) = fileWriter.write(response, getAbsoluteWritePath(basePath, filePath, fileName))
+    ) = fileWriter.write(inputStream, getAbsoluteWritePath(basePath, filePath, fileName))
 
     fun getAbsoluteWritePath(
         basePath: String,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorage.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorage.kt
@@ -1,4 +1,35 @@
 package com.rakuten.tech.mobile.miniapp.storage
 
+import com.rakuten.tech.mobile.miniapp.legacy.core.utils.LocalUrlParser
+import okhttp3.ResponseBody
+import java.io.File
+
+private const val SUB_DIR_MINIAPP = "miniapp"
+
 @SuppressWarnings("UseDataClass")
-internal class MiniAppStorage(val fileWriter: FileWriter)
+internal class MiniAppStorage(
+    val fileWriter: FileWriter,
+    val basePath: File,
+    val localUrlParser: LocalUrlParser = LocalUrlParser()
+) {
+
+    suspend fun saveFile(
+        response: ResponseBody,
+        basePath: String,
+        filePath: String,
+        fileName: String
+    ) = fileWriter.write(response, getAbsoluteWritePath(basePath, filePath, fileName))
+
+    fun getAbsoluteWritePath(
+        basePath: String,
+        filePath: String,
+        fileName: String
+    ) = "$basePath$filePath$fileName"
+
+    fun getFilePathFromUrl(file: String) = localUrlParser.getFilePath(file)
+
+    fun getFileName(file: String) = localUrlParser.getFileName(file)
+
+    fun getSavePathForApp(appId: String, versionId: String) =
+        "${basePath.path}/$SUB_DIR_MINIAPP/$appId/$versionId/"
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorage.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorage.kt
@@ -14,11 +14,14 @@ internal class MiniAppStorage(
 ) {
 
     suspend fun saveFile(
-        inputStream: InputStream,
+        source: String,
         basePath: String,
-        filePath: String,
-        fileName: String
-    ) = fileWriter.write(inputStream, getAbsoluteWritePath(basePath, filePath, fileName))
+        inputStream: InputStream
+    ) {
+        val filePath = getFilePath(source)
+        val fileName = getFileName(source)
+        fileWriter.write(inputStream, getAbsoluteWritePath(basePath, filePath, fileName))
+    }
 
     fun getAbsoluteWritePath(
         basePath: String,
@@ -26,7 +29,7 @@ internal class MiniAppStorage(
         fileName: String
     ) = "$basePath$filePath$fileName"
 
-    fun getFilePathFromUrl(file: String) = localUrlParser.getFilePath(file)
+    fun getFilePath(file: String) = localUrlParser.getFilePath(file)
 
     fun getFileName(file: String) = localUrlParser.getFileName(file)
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
@@ -5,8 +5,6 @@ import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.rakuten.tech.mobile.miniapp.api.ApiClient
 import com.rakuten.tech.mobile.miniapp.api.ManifestEntity
-import com.rakuten.tech.mobile.miniapp.api.TEST_ID_MINIAPP
-import com.rakuten.tech.mobile.miniapp.api.TEST_ID_MINIAPP_VERSION
 import com.rakuten.tech.mobile.miniapp.storage.MiniAppStorage
 import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.When
@@ -22,20 +20,28 @@ class MiniAppDownloaderSpec {
             val apiClient: ApiClient = mock()
             val storage: MiniAppStorage = mock()
             val downloader = MiniAppDownloader(storage, apiClient)
-            When calling
-                    downloader.fetchManifest(
-                        TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION
-                    ) itReturns ManifestEntity(listOf())
+            When calling downloader.fetchManifest(
+                TEST_ID_MINIAPP,
+                TEST_ID_MINIAPP_VERSION
+            ) itReturns ManifestEntity(listOf())
 
-            downloader.startDownload(TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
-            verify(apiClient, times(1))
-                .fetchFileList(TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
+            downloader.startDownload(
+                TEST_ID_MINIAPP,
+                TEST_ID_MINIAPP_VERSION
+            )
+            verify(apiClient, times(1)).fetchFileList(
+                TEST_ID_MINIAPP,
+                TEST_ID_MINIAPP_VERSION
+            )
         }
 
     @Test(expected = MiniAppSdkException::class)
     fun `when fetching manifest fails then downloader should throw exception`() =
         runBlockingTest {
             val downloader = MiniAppDownloader(mock(), mock())
-            downloader.startDownload(TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
+            downloader.startDownload(
+                TEST_ID_MINIAPP,
+                TEST_ID_MINIAPP_VERSION
+            )
         }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
@@ -1,0 +1,41 @@
+package com.rakuten.tech.mobile.miniapp
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.rakuten.tech.mobile.miniapp.api.ApiClient
+import com.rakuten.tech.mobile.miniapp.api.ManifestEntity
+import com.rakuten.tech.mobile.miniapp.api.TEST_ID_MINIAPP
+import com.rakuten.tech.mobile.miniapp.api.TEST_ID_MINIAPP_VERSION
+import com.rakuten.tech.mobile.miniapp.storage.MiniAppStorage
+import kotlinx.coroutines.test.runBlockingTest
+import org.amshove.kluent.When
+import org.amshove.kluent.calling
+import org.amshove.kluent.itReturns
+import org.junit.Test
+
+class MiniAppDownloaderSpec {
+
+    @Test
+    fun `when downloading a mini app then downloader should fetch manifest at first`() =
+        runBlockingTest {
+            val apiClient: ApiClient = mock()
+            val storage: MiniAppStorage = mock()
+            val downloader = MiniAppDownloader(storage, apiClient)
+            When calling
+                    downloader.fetchManifest(
+                        TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION
+                    ) itReturns ManifestEntity(listOf())
+
+            downloader.startDownload(TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
+            verify(apiClient, times(1))
+                .fetchFileList(TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
+        }
+
+    @Test(expected = MiniAppSdkException::class)
+    fun `when fetching manifest fails then downloader should throw exception`() =
+        runBlockingTest {
+            val downloader = MiniAppDownloader(mock(), mock())
+            downloader.startDownload(TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
+        }
+}

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppListerSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppListerSpec.kt
@@ -1,9 +1,9 @@
-package com.rakuten.tech.mobile.miniapp.api
+package com.rakuten.tech.mobile.miniapp
 
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
-import com.rakuten.tech.mobile.miniapp.MiniAppLister
+import com.rakuten.tech.mobile.miniapp.api.ApiClient
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
@@ -1,0 +1,18 @@
+package com.rakuten.tech.mobile.miniapp
+
+internal const val TEST_BODY_CONTENT = "lorem ipsum"
+internal const val TEST_ERROR_MSG = "error_message"
+internal const val TEST_VALUE = "test_value"
+
+internal const val TEST_ID_MINIAPP = "5f0ed952-36ab-43e2-a285-b237c11e23cb"
+internal const val TEST_ID_MINIAPP_VERSION = "fa7e1522-adf2-4322-8146-84dca1f812a5"
+
+internal const val TEST_URL_FILE = "file.storage/test/file.abc"
+internal const val TEST_URL_HTTPS_1 = "https://www.example.com/1"
+internal const val TEST_URL_HTTPS_2 = "https://www.example.com/2"
+
+internal const val TEST_MA_ID = "test_id"
+internal const val TEST_MA_VERSION = "test_version"
+internal const val TEST_MA_NAME = "test_name"
+internal const val TEST_MA_DESCRIPTION = "test_description"
+internal const val TEST_MA_ICON = "test_icon"

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
@@ -2,8 +2,7 @@ package com.rakuten.tech.mobile.miniapp.api
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
-import com.rakuten.tech.mobile.miniapp.MiniAppInfo
-import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
+import com.rakuten.tech.mobile.miniapp.*
 import junit.framework.TestCase
 import kotlinx.coroutines.test.runBlockingTest
 import okhttp3.ResponseBody
@@ -20,10 +19,6 @@ import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
-internal const val TEST_ID_MINIAPP = "5f0ed952-36ab-43e2-a285-b237c11e23cb"
-internal const val TEST_ID_MINIAPP_VERSION = "fa7e1522-adf2-4322-8146-84dca1f812a5"
-internal const val TEST_URL = "file.storage/test/file.abc"
-
 open class ApiClientSpec {
 
     private val mockRetrofitClient: Retrofit = mock()
@@ -35,12 +30,12 @@ open class ApiClientSpec {
     @Test
     fun `should fetch the list of mini apps`() = runBlockingTest {
         val miniAppInfo = MiniAppInfo(
-            id = "test_id",
-            versionId = "test_version",
-            name = "test_name",
-            description = "test_description",
-            icon = "test_icon",
-            files = listOf("https://www.example.com")
+            id = TEST_MA_ID,
+            versionId = TEST_MA_VERSION,
+            name = TEST_MA_NAME,
+            description = TEST_MA_DESCRIPTION,
+            icon = TEST_MA_ICON,
+            files = listOf(TEST_URL_HTTPS_1)
         )
         val mockCall: Call<List<MiniAppInfo>> = mock()
         When calling mockListingApi.list(any()) itReturns mockCall
@@ -53,7 +48,7 @@ open class ApiClientSpec {
 
     @Test
     fun `should fetch the file list of a mini app`() = runBlockingTest {
-        val fileList = listOf("https://www.example.com", "https://www.example1.com")
+        val fileList = listOf(TEST_URL_HTTPS_1, TEST_URL_HTTPS_2)
         val manifestEntity = ManifestEntity(fileList)
         val mockCall: Call<ManifestEntity> = mock()
         When calling
@@ -75,23 +70,23 @@ open class ApiClientSpec {
     @Test
     fun `should download a file from the given url`() = runBlockingTest {
         val mockCall: Call<ResponseBody> = mock()
-        val mockResponseBody = ResponseBody.create(null, "lorem ipsum")
+        val mockResponseBody = ResponseBody.create(null, TEST_BODY_CONTENT)
         When calling
                 mockDownloadApi
-                    .downloadFile(TEST_URL) itReturns mockCall
+                    .downloadFile(TEST_URL_FILE) itReturns mockCall
         When calling
                 mockRequestExecutor
                     .executeRequest(mockCall) itReturns mockResponseBody
 
         val apiClient = createApiClient(downloadApi = mockDownloadApi)
         val response = apiClient
-            .downloadFile(TEST_URL) shouldEqual mockResponseBody
+            .downloadFile(TEST_URL_FILE) shouldEqual mockResponseBody
         response.contentLength() shouldEqual mockResponseBody.contentLength()
     }
 
     private fun createApiClient(
         retrofit: Retrofit = mockRetrofitClient,
-        hostAppVersion: String = "test_version",
+        hostAppVersion: String = TEST_MA_VERSION,
         requestExecutor: RetrofitRequestExecutor = mockRequestExecutor,
         listingApi: ListingApi = mockListingApi,
         manifestApi: ManifestApi = mockManifestApi,
@@ -138,12 +133,12 @@ open class RetrofitRequestExecutorNormalSpec : RetrofitRequestExecutorSpec() {
 
     @Test
     fun `should return the body`() = runBlockingTest {
-        mockServer.enqueue(createTestApiResponse(testValue = "test_value"))
+        mockServer.enqueue(createTestApiResponse(testValue = TEST_VALUE))
 
         val response = createRequestExecutor()
             .executeRequest(createApi().fetch())
 
-        response.testKey shouldEqual "test_value"
+        response.testKey shouldEqual TEST_VALUE
     }
 }
 
@@ -167,7 +162,7 @@ open class RetrofitRequestExecutorErrorSpec : RetrofitRequestExecutorSpec() {
 
     @Test
     fun `should throw exception with the error message returned by server`() = runBlockingTest {
-        mockServer.enqueue(createErrorResponse(message = "error_message"))
+        mockServer.enqueue(createErrorResponse(message = TEST_ERROR_MSG))
 
         try {
             createRequestExecutor()
@@ -175,13 +170,13 @@ open class RetrofitRequestExecutorErrorSpec : RetrofitRequestExecutorSpec() {
 
             TestCase.fail("Should have thrown ErrorResponseException.")
         } catch (exception: MiniAppSdkException) {
-            exception.message.toString() shouldContain "error_message"
+            exception.message.toString() shouldContain TEST_ERROR_MSG
         }
     }
 
     @Test
     fun `should append error message to base exception message`() = runBlockingTest {
-        mockServer.enqueue(createErrorResponse(message = "error_message"))
+        mockServer.enqueue(createErrorResponse(message = TEST_ERROR_MSG))
 
         try {
             createRequestExecutor()
@@ -189,7 +184,7 @@ open class RetrofitRequestExecutorErrorSpec : RetrofitRequestExecutorSpec() {
 
             TestCase.fail("Should have thrown ErrorResponseException.")
         } catch (exception: MiniAppSdkException) {
-            exception.message.toString() shouldContain "error_message"
+            exception.message.toString() shouldContain TEST_ERROR_MSG
         }
     }
 
@@ -214,7 +209,7 @@ open class RetrofitRequestExecutorErrorSpec : RetrofitRequestExecutorSpec() {
 
     private fun createErrorResponse(
         code: Int = 400,
-        message: String = "error_message"
+        message: String = TEST_ERROR_MSG
     ): MockResponse {
         val error = """
             {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/DownloadApiSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/DownloadApiSpec.kt
@@ -1,6 +1,8 @@
 package com.rakuten.tech.mobile.miniapp.api
 
 import com.google.gson.Gson
+import com.rakuten.tech.mobile.miniapp.TEST_BODY_CONTENT
+import com.rakuten.tech.mobile.miniapp.TEST_URL_FILE
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.amshove.kluent.shouldContain
@@ -29,7 +31,7 @@ open class DownloadApiSpec private constructor(
     }
 
     internal fun createResponse(
-        fileData: ByteArray = "lorem ipsum".toByteArray(Charset.defaultCharset())
+        fileData: ByteArray = TEST_BODY_CONTENT.toByteArray(Charset.defaultCharset())
     ) = MockResponse().setBody(Gson().toJson(fileData))
 }
 
@@ -40,9 +42,9 @@ class DownloadApiRequestSpec : DownloadApiSpec() {
         mockServer.enqueue(createResponse())
 
         retrofit.create(DownloadApi::class.java)
-            .downloadFile(TEST_URL)
+            .downloadFile(TEST_URL_FILE)
             .execute()
 
-        mockServer.takeRequest().path.toString() shouldContain TEST_URL
+        mockServer.takeRequest().path.toString() shouldContain TEST_URL_FILE
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ListingApiSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ListingApiSpec.kt
@@ -1,10 +1,13 @@
 package com.rakuten.tech.mobile.miniapp.api
 
 import com.google.gson.Gson
-import com.rakuten.tech.mobile.miniapp.MiniAppInfo
+import com.rakuten.tech.mobile.miniapp.*
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
-import org.amshove.kluent.*
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldEndWith
+import org.amshove.kluent.shouldEqual
+import org.amshove.kluent.shouldStartWith
 import org.junit.Before
 import org.junit.Test
 import retrofit2.Retrofit
@@ -29,12 +32,12 @@ open class ListingApiSpec private constructor(
     }
 
     internal fun createResponse(
-        id: String = "test_id",
-        version: String = "test_version",
-        name: String = "test_name",
-        description: String = "test_description",
-        icon: String = "test_icon",
-        files: List<String> = listOf("https://www.example.com/1", "https://www.example.com/2")
+        id: String = TEST_MA_ID,
+        version: String = TEST_MA_VERSION,
+        name: String = TEST_MA_NAME,
+        description: String = TEST_MA_DESCRIPTION,
+        icon: String = TEST_MA_ICON,
+        files: List<String> = listOf(TEST_URL_HTTPS_1, TEST_URL_HTTPS_2)
     ): MockResponse {
         val appInfo = hashMapOf(
             "id" to id,
@@ -56,7 +59,7 @@ class ListingApiRequestSpec : ListingApiSpec() {
         mockServer.enqueue(createResponse())
 
         retrofit.create(ListingApi::class.java)
-            .list(hostAppVersion = "test_version")
+            .list(hostAppVersion = TEST_MA_VERSION)
             .execute()
 
         mockServer.takeRequest().requestUrl!!.encodedPath shouldEndWith "miniapps"
@@ -67,7 +70,7 @@ class ListingApiRequestSpec : ListingApiSpec() {
         mockServer.enqueue(createResponse())
 
         retrofit.create(ListingApi::class.java)
-            .list(hostAppVersion = "test_version")
+            .list(hostAppVersion = TEST_MA_VERSION)
             .execute()
 
         mockServer.takeRequest().path!! shouldStartWith "/oneapp/android/"
@@ -78,7 +81,7 @@ class ListingApiRequestSpec : ListingApiSpec() {
         mockServer.enqueue(createResponse())
 
         retrofit.create(ListingApi::class.java)
-            .list(hostAppVersion = "test_version")
+            .list(hostAppVersion = TEST_MA_VERSION)
             .execute()
 
         mockServer.takeRequest().path!! shouldContain "android/test_version/"
@@ -91,48 +94,41 @@ class ListingApiResponseSpec : ListingApiSpec() {
 
     @Before
     fun setup() {
-        mockServer.enqueue(createResponse(
-            id = "test_id",
-            version = "test_version",
-            name = "test_name",
-            description = "test_description",
-            icon = "test_icon",
-            files = listOf("https://www.example.com/1", "https://www.example.com/2")
-        ))
+        mockServer.enqueue(createResponse())
 
         miniAppInfo = retrofit.create(ListingApi::class.java)
-            .list(hostAppVersion = "test_version")
+            .list(hostAppVersion = TEST_MA_VERSION)
             .execute().body()!![0]
     }
 
     @Test
     fun `should parse the 'id' from response`() {
-        miniAppInfo.id shouldEqual "test_id"
+        miniAppInfo.id shouldEqual TEST_MA_ID
     }
 
     @Test
     fun `should parse the 'version' from response`() {
-        miniAppInfo.versionId shouldEqual "test_version"
+        miniAppInfo.versionId shouldEqual TEST_MA_VERSION
     }
 
     @Test
     fun `should parse the 'name' from response`() {
-        miniAppInfo.name shouldEqual "test_name"
+        miniAppInfo.name shouldEqual TEST_MA_NAME
     }
 
     @Test
     fun `should parse the 'description' from response`() {
-        miniAppInfo.description shouldEqual "test_description"
+        miniAppInfo.description shouldEqual TEST_MA_DESCRIPTION
     }
 
     @Test
     fun `should parse the 'icon' from response`() {
-        miniAppInfo.icon shouldEqual "test_icon"
+        miniAppInfo.icon shouldEqual TEST_MA_ICON
     }
 
     @Test
     fun `should parse the 'files' from response`() {
-        miniAppInfo.files shouldContain "https://www.example.com/1"
-        miniAppInfo.files shouldContain "https://www.example.com/2"
+        miniAppInfo.files shouldContain TEST_URL_HTTPS_1
+        miniAppInfo.files shouldContain TEST_URL_HTTPS_2
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiSpec.kt
@@ -64,7 +64,8 @@ class ManifestApiRequestSpec : ManifestApiSpec() {
                 versionId = TEST_ID_MINIAPP_VERSION
             ).execute()
 
-        mockServer.takeRequest().path!! shouldContain "miniapp/$TEST_ID_MINIAPP/version/$TEST_ID_MINIAPP_VERSION/"
+        mockServer.takeRequest().path!! shouldContain
+                "miniapp/$TEST_ID_MINIAPP/version/$TEST_ID_MINIAPP_VERSION/"
     }
 }
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiSpec.kt
@@ -1,6 +1,10 @@
 package com.rakuten.tech.mobile.miniapp.api
 
 import com.google.gson.Gson
+import com.rakuten.tech.mobile.miniapp.TEST_ID_MINIAPP
+import com.rakuten.tech.mobile.miniapp.TEST_ID_MINIAPP_VERSION
+import com.rakuten.tech.mobile.miniapp.TEST_URL_HTTPS_1
+import com.rakuten.tech.mobile.miniapp.TEST_URL_HTTPS_2
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.amshove.kluent.shouldContain
@@ -29,7 +33,7 @@ open class ManifestApiSpec private constructor(
     }
 
     internal fun createResponse(
-        files: List<String> = listOf("https://www.example.com/1", "https://www.example.com/2")
+        files: List<String> = listOf(TEST_URL_HTTPS_1, TEST_URL_HTTPS_2)
     ): MockResponse {
         val manifestInfo = hashMapOf(
             "files" to files
@@ -78,13 +82,16 @@ class ManifestApiResponseSpec : ManifestApiSpec() {
         mockServer.enqueue(createResponse())
 
         manifestEntity = retrofit.create(ManifestApi::class.java)
-            .fetchFileListFromManifest(TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
+            .fetchFileListFromManifest(
+                TEST_ID_MINIAPP,
+                TEST_ID_MINIAPP_VERSION
+            )
             .execute().body()!!
     }
 
     @Test
     fun `should parse the 'files' from response`() {
-        manifestEntity.files shouldContain "https://www.example.com/1"
-        manifestEntity.files shouldContain "https://www.example.com/2"
+        manifestEntity.files shouldContain TEST_URL_HTTPS_1
+        manifestEntity.files shouldContain TEST_URL_HTTPS_2
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtilsSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtilsSpec.kt
@@ -1,9 +1,13 @@
 package com.rakuten.tech.mobile.miniapp.api
 
 import com.nhaarman.mockitokotlin2.mock
+import com.rakuten.tech.mobile.miniapp.TEST_VALUE
 import com.rakuten.tech.mobile.sdkutils.RasSdkHeaders
 import okhttp3.mockwebserver.MockWebServer
-import org.amshove.kluent.*
+import org.amshove.kluent.When
+import org.amshove.kluent.calling
+import org.amshove.kluent.itReturns
+import org.amshove.kluent.shouldEqual
 import org.junit.Before
 import org.junit.Test
 
@@ -28,7 +32,7 @@ class RetrofitCreatorUtilsSpec private constructor(
     @Test
     fun `should attach the RAS headers to requests`() {
         When calling mockRasSdkHeaders.asArray() itReturns
-            arrayOf("ras_header_name" to "ras_header_value")
+                arrayOf("ras_header_name" to "ras_header_value")
 
         createClient()
             .create(TestApi::class.java)
@@ -40,14 +44,14 @@ class RetrofitCreatorUtilsSpec private constructor(
 
     @Test
     fun `should parse a JSON response`() {
-        mockServer.enqueue(createTestApiResponse(testValue = "test_value"))
+        mockServer.enqueue(createTestApiResponse(testValue = TEST_VALUE))
 
         val response = createClient()
             .create(TestApi::class.java)
             .fetch()
             .execute()
 
-        response.body()!!.testKey shouldEqual "test_value"
+        response.body()!!.testKey shouldEqual TEST_VALUE
     }
 
     private fun createClient() = createRetrofitClient(

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/TestApi.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/TestApi.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.miniapp.api
 
+import com.rakuten.tech.mobile.miniapp.TEST_VALUE
 import okhttp3.mockwebserver.MockResponse
 import retrofit2.Call
 import retrofit2.http.GET
@@ -14,17 +15,21 @@ data class TestResponse(
 )
 
 fun createTestApiResponse(
-    testValue: String = "test_value"
-) = MockResponse().setBody("""
+    testValue: String = TEST_VALUE
+) = MockResponse().setBody(
+    """
         {
             "testKey": "$testValue"
         }
-    """.trimIndent())
+    """.trimIndent()
+)
 
 fun createInvalidTestApiResponse(
-    testValue: String = "test_value"
-) = MockResponse().setBody("""
+    testValue: String = TEST_VALUE
+) = MockResponse().setBody(
+    """
         {
             "testKey": {"$testValue"},
         }
-    """.trimIndent())
+    """.trimIndent()
+)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageTest.kt
@@ -4,20 +4,23 @@ import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
-import com.rakuten.tech.mobile.miniapp.api.TEST_ID_MINIAPP
-import com.rakuten.tech.mobile.miniapp.api.TEST_ID_MINIAPP_VERSION
+import com.rakuten.tech.mobile.miniapp.TEST_ID_MINIAPP
+import com.rakuten.tech.mobile.miniapp.TEST_ID_MINIAPP_VERSION
+import com.rakuten.tech.mobile.miniapp.TEST_URL_FILE
 import com.rakuten.tech.mobile.miniapp.legacy.core.utils.LocalUrlParser
-import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 
 class MiniAppStorageTest {
 
-    private val TEST_URL = "https://www.example.com/1"
-
     @Test
     fun `for a given set of app & version id formed base path is retured`() {
         val miniAppStorage = getMockedMiniAppStorage()
-        assertThat(miniAppStorage.getSavePathForApp(TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION))
+        assertThat(
+            miniAppStorage.getSavePathForApp(
+                TEST_ID_MINIAPP,
+                TEST_ID_MINIAPP_VERSION
+            )
+        )
             .isEqualTo("null/miniapp/$TEST_ID_MINIAPP/$TEST_ID_MINIAPP_VERSION/")
     }
 
@@ -31,21 +34,20 @@ class MiniAppStorageTest {
     @Test
     fun `for a given url file path is retured via LocalUrlParser`() {
         val localUrlParser = getMockedLocalUrlParser()
-        val miniAppStorage = MiniAppStorage (mock(), mock(), localUrlParser)
-        miniAppStorage.getFilePathFromUrl(TEST_URL)
-        verify(localUrlParser, times(1)).getFilePath(TEST_URL)
+        val miniAppStorage = MiniAppStorage(mock(), mock(), localUrlParser)
+        miniAppStorage.getFilePathFromUrl(TEST_URL_FILE)
+        verify(localUrlParser, times(1)).getFilePath(TEST_URL_FILE)
     }
 
     @Test
     fun `for a given url file name is retured via LocalUrlParser`() {
         val localUrlParser = getMockedLocalUrlParser()
-        val miniAppStorage = MiniAppStorage (mock(), mock(), localUrlParser)
-        miniAppStorage.getFileName(TEST_URL)
-        verify(localUrlParser, times(1)).getFileName(TEST_URL)
+        val miniAppStorage = MiniAppStorage(mock(), mock(), localUrlParser)
+        miniAppStorage.getFileName(TEST_URL_FILE)
+        verify(localUrlParser, times(1)).getFileName(TEST_URL_FILE)
     }
 
-    private fun getMockedMiniAppStorage() = MiniAppStorage (mock(), mock(), mock())
+    private fun getMockedMiniAppStorage() = MiniAppStorage(mock(), mock(), mock())
 
     private fun getMockedLocalUrlParser() = mock<LocalUrlParser>()
-
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageTest.kt
@@ -35,7 +35,7 @@ class MiniAppStorageTest {
     fun `for a given url file path is retured via LocalUrlParser`() {
         val localUrlParser = getMockedLocalUrlParser()
         val miniAppStorage = MiniAppStorage(mock(), mock(), localUrlParser)
-        miniAppStorage.getFilePathFromUrl(TEST_URL_FILE)
+        miniAppStorage.getFilePath(TEST_URL_FILE)
         verify(localUrlParser, times(1)).getFilePath(TEST_URL_FILE)
     }
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageTest.kt
@@ -1,0 +1,51 @@
+package com.rakuten.tech.mobile.miniapp.storage
+
+import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.rakuten.tech.mobile.miniapp.api.TEST_ID_MINIAPP
+import com.rakuten.tech.mobile.miniapp.api.TEST_ID_MINIAPP_VERSION
+import com.rakuten.tech.mobile.miniapp.legacy.core.utils.LocalUrlParser
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Test
+
+class MiniAppStorageTest {
+
+    private val TEST_URL = "https://www.example.com/1"
+
+    @Test
+    fun `for a given set of app & version id formed base path is retured`() {
+        val miniAppStorage = getMockedMiniAppStorage()
+        assertThat(miniAppStorage.getSavePathForApp(TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION))
+            .isEqualTo("null/miniapp/$TEST_ID_MINIAPP/$TEST_ID_MINIAPP_VERSION/")
+    }
+
+    @Test
+    fun `for a given set base & file path with file's name, formed absolute path is retured`() {
+        val miniAppStorage = getMockedMiniAppStorage()
+        assertThat(miniAppStorage.getAbsoluteWritePath("a", "b", "c"))
+            .isEqualTo("abc")
+    }
+
+    @Test
+    fun `for a given url file path is retured via LocalUrlParser`() {
+        val localUrlParser = getMockedLocalUrlParser()
+        val miniAppStorage = MiniAppStorage (mock(), mock(), localUrlParser)
+        miniAppStorage.getFilePathFromUrl(TEST_URL)
+        verify(localUrlParser, times(1)).getFilePath(TEST_URL)
+    }
+
+    @Test
+    fun `for a given url file name is retured via LocalUrlParser`() {
+        val localUrlParser = getMockedLocalUrlParser()
+        val miniAppStorage = MiniAppStorage (mock(), mock(), localUrlParser)
+        miniAppStorage.getFileName(TEST_URL)
+        verify(localUrlParser, times(1)).getFileName(TEST_URL)
+    }
+
+    private fun getMockedMiniAppStorage() = MiniAppStorage (mock(), mock(), mock())
+
+    private fun getMockedLocalUrlParser() = mock<LocalUrlParser>()
+
+}


### PR DESCRIPTION
Please note:
- At this time, the `create` takes in an object of type `MiniAppInfo` as version information is internal to SDK and the host app can not access it after receiving it from the response of the listing API.
- The module will most likely see changes and be converted into a state machine (right now it just makes use of legacy implementation), hence, the unit tests around `FileWriter` and some for Downloader is a TBD later