### PR TITLE
base implementation for displayer module (#25)

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -25,10 +25,8 @@ abstract class MiniApp internal constructor() {
      * downloading or creating the view.
      */
     abstract suspend fun create(
-        miniAppInfo: MiniAppInfo,
-        success: (MiniAppView) -> Unit,
-        error: (Exception) -> Unit
-    )
+        miniAppInfo: MiniAppInfo
+    ): MiniAppView
 
     companion object {
         private lateinit var instance: MiniApp

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -9,13 +9,9 @@ internal class MiniAppDownloader(
     val apiClient: ApiClient
 ) {
 
-    suspend fun startDownload(appId: String, versionId: String) {
-        try {
-            val manifest = fetchManifest(appId, versionId)
-            val downloadedPath = downloadMiniApp(appId, versionId, manifest)
-        } catch (error: Exception) {
-            throw MiniAppSdkException(error)
-        }
+    suspend fun startDownload(appId: String, versionId: String): String {
+        val manifest = fetchManifest(appId, versionId)
+        return downloadMiniApp(appId, versionId, manifest)
     }
 
     suspend fun fetchManifest(

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppView.kt
@@ -1,6 +1,22 @@
 package com.rakuten.tech.mobile.miniapp
 
+import android.content.Context
+import android.webkit.WebView
+
 /**
  * This represents the contract by which a mini app is rendered to display.
  */
-interface MiniAppView
+interface MiniAppView {
+
+    /**
+     * Provides the actual view for a mini app to the caller.
+     * The caller must provide a valid [Context] object (used to access application assets).
+     * @return [WebView] as mini app's view.
+     */
+    suspend fun obtainView(activityContext: Context): WebView
+
+    /**
+     * Destroys the WebView associated to the mini app.
+     */
+    fun destroyView(webView: WebView)
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -11,13 +11,12 @@ internal class RealMiniApp(
     override suspend fun listMiniApp(): List<MiniAppInfo> = miniAppLister.fetchMiniAppList()
 
     override suspend fun create(
-        miniAppInfo: MiniAppInfo,
-        success: (MiniAppView) -> Unit,
-        error: (Exception) -> Unit
-    ) {
-        miniAppDownloader.startDownload(
+        miniAppInfo: MiniAppInfo
+    ): MiniAppView {
+        val basePath = miniAppDownloader.startDownload(
             appId = miniAppInfo.id,
             versionId = miniAppInfo.versionId
         )
+        return displayer.getViewForMiniApp(basePath)
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtils.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtils.kt
@@ -1,6 +1,7 @@
 package com.rakuten.tech.mobile.miniapp.api
 
 import androidx.annotation.VisibleForTesting
+import com.google.gson.GsonBuilder
 import com.rakuten.tech.mobile.miniapp.BuildConfig
 import com.rakuten.tech.mobile.sdkutils.RasSdkHeaders
 import com.rakuten.tech.mobile.sdkutils.okhttp.addHeaderInterceptor
@@ -32,7 +33,11 @@ internal fun createRetrofitClient(
         .addHeaderInterceptor(*headers.asArray())
         .build()
     return Retrofit.Builder()
-        .addConverterFactory(GsonConverterFactory.create())
+        .addConverterFactory(GsonConverterFactory.create(
+            GsonBuilder()
+                .setLenient()
+                .create()
+        ))
         .baseUrl(baseUrl)
         .client(httpClient)
         .build()

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
@@ -1,4 +1,8 @@
 package com.rakuten.tech.mobile.miniapp.display
 
-@SuppressWarnings("UseDataClass")
-internal class Displayer
+import com.rakuten.tech.mobile.miniapp.MiniAppView
+
+internal class Displayer {
+
+    suspend fun getViewForMiniApp(basePath: String): MiniAppView = RealMiniAppView(basePath)
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppView.kt
@@ -1,7 +1,46 @@
 package com.rakuten.tech.mobile.miniapp.display
 
+import android.annotation.SuppressLint
+import android.content.Context
+import android.view.ViewGroup
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.FrameLayout
 import com.rakuten.tech.mobile.miniapp.MiniAppView
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 internal class RealMiniAppView(
-    val miniAppWebView: MiniAppWebView
-) : MiniAppView
+    val basePath: String
+) : MiniAppView {
+
+    @SuppressLint("SetJavaScriptEnabled")
+    override suspend fun obtainView(context: Context): WebView = withContext(Dispatchers.Main) {
+        WebView(context).apply {
+            setLayoutParams(
+                FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
+            )
+            settings.javaScriptEnabled = true
+            setWebViewClient(object : WebViewClient() {
+                override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
+                    view.loadUrl(url)
+                    return true
+                }
+            })
+
+            loadUrl("file://${basePath}index.html")
+        }
+    }
+
+    override fun destroyView(webView: WebView) {
+        webView.apply {
+            stopLoading()
+            webViewClient = null
+            clearHistory()
+            destroy()
+        }
+    }
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/FileWriter.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/FileWriter.kt
@@ -7,10 +7,14 @@ import java.io.InputStream
 
 internal class FileWriter {
 
-    suspend fun write(inputStream: InputStream, path: String) {
+    suspend fun write(
+        inputStream: InputStream,
+        parentPath: String,
+        fileName: String
+    ) {
         withContext(Dispatchers.IO) {
-            File(path).mkdirs()
-            val file = File(path)
+            File(parentPath).mkdirs()
+            val file = File(parentPath, fileName)
             inputStream.use { it.copyTo(file.outputStream()) }
             file.outputStream().close()
         }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorage.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorage.kt
@@ -19,14 +19,13 @@ internal class MiniAppStorage(
     ) {
         val filePath = getFilePath(source)
         val fileName = getFileName(source)
-        fileWriter.write(inputStream, getAbsoluteWritePath(basePath, filePath, fileName))
+        fileWriter.write(inputStream, getParentPath(basePath, filePath), fileName)
     }
 
-    fun getAbsoluteWritePath(
+    fun getParentPath(
         basePath: String,
-        filePath: String,
-        fileName: String
-    ) = "$basePath$filePath$fileName"
+        filePath: String
+    ) = "$basePath$filePath"
 
     fun getFilePath(file: String) = localUrlParser.getFilePath(file)
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
@@ -34,14 +34,4 @@ class MiniAppDownloaderSpec {
                 TEST_ID_MINIAPP_VERSION
             )
         }
-
-    @Test(expected = MiniAppSdkException::class)
-    fun `when fetching manifest fails then downloader should throw exception`() =
-        runBlockingTest {
-            val downloader = MiniAppDownloader(mock(), mock())
-            downloader.startDownload(
-                TEST_ID_MINIAPP,
-                TEST_ID_MINIAPP_VERSION
-            )
-        }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageTest.kt
@@ -25,10 +25,10 @@ class MiniAppStorageTest {
     }
 
     @Test
-    fun `for a given set base & file path with file's name, formed absolute path is retured`() {
+    fun `for a given set of base path & file path, formed parent path is retured`() {
         val miniAppStorage = getMockedMiniAppStorage()
-        assertThat(miniAppStorage.getAbsoluteWritePath("a", "b", "c"))
-            .isEqualTo("abc")
+        assertThat(miniAppStorage.getParentPath("a", "b"))
+            .isEqualTo("ab")
     }
 
     @Test

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListViewModel.kt
@@ -1,11 +1,14 @@
 package com.rakuten.tech.mobile.testapp.ui.miniapplist
 
+import android.content.Context
+import android.webkit.WebView
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.rakuten.tech.mobile.miniapp.MiniApp
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
+import com.rakuten.tech.mobile.miniapp.MiniAppView
 
 class MiniAppListViewModel constructor(
     private val miniapp: MiniApp
@@ -17,11 +20,16 @@ class MiniAppListViewModel constructor(
         MutableLiveData<List<MiniAppInfo>>().apply { value = emptyList() }
     private val _errorData = MutableLiveData<String>()
 
+    private val _miniAppView = MutableLiveData<WebView>()
+
     val miniAppListData: LiveData<List<MiniAppInfo>>
         get() = _miniAppListData
 
     val errorData: LiveData<String>
         get() = _errorData
+
+    val miniAppView: LiveData<WebView>
+        get() = _miniAppView
 
     //for brevity
     suspend fun getMiniAppList() {
@@ -31,6 +39,11 @@ class MiniAppListViewModel constructor(
         } catch (error: MiniAppSdkException) {
             _errorData.postValue((error.message))
         }
+    }
+
+    suspend fun obtainMiniAppView(miniAppInfo: MiniAppInfo, context: Context) {
+        val miniAppView: MiniAppView = miniapp.create(miniAppInfo)
+        _miniAppView.postValue(miniAppView.obtainView(context))
     }
 
 }


### PR DESCRIPTION
* implementation for displayer module

* integrate the sample app view model with the #create call + minor refactor

* migrate to parent and child file api for creating directories and writing downloaded files

* gson lenient

* Update webview display

Co-authored-by: Minh Nguyen (ミン） <60589925+minh-rakuten@users.noreply.github.com>