### PR TITLE
Fix KDoc generation

### DIFF
--- a/gradle/documentation.gradle
+++ b/gradle/documentation.gradle
@@ -7,6 +7,7 @@ dokka {
     outputDirectory = "$docsBuildDirectory"
     configuration {
         includeNonPublic = false
+        skipEmptyPackages = true
     }
 }
 

--- a/miniapp/build.gradle
+++ b/miniapp/build.gradle
@@ -92,6 +92,11 @@ dokka {
         sourceRoot {
             path = "miniapp/src/main"
         }
+
+        perPackageOption {
+            prefix = "com.rakuten.tech.mobile.miniapp.legacy"
+            suppress = true
+        }
     }
 }
 

--- a/miniapp/build.gradle
+++ b/miniapp/build.gradle
@@ -87,6 +87,13 @@ jacoco {
 }
 
 apply from: '../gradle/documentation.gradle'
+dokka {
+    configuration {
+        sourceRoot {
+            path = "miniapp/src/main"
+        }
+    }
+}
 
 apply from: '../config/publish/android.gradle'
 publishing {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -14,6 +14,8 @@ import com.rakuten.tech.mobile.miniapp.storage.MiniAppStorage
 /**
  * This initializes the SDK module automatically as the Content Providers are initialized
  * at first before other initializations happen in the application's ecosystem.
+ *
+ * @suppress
  */
 @Suppress("UndocumentedPublicClass")
 class MiniappSdkInitializer : ContentProvider() {


### PR DESCRIPTION
- build: Fix KDoc generation
  - Dokka had some breaking changes in v0.10.0. We need to specify the path to the source files. They also changed skipEmptyPackages to false by default.
- docs: Exclude unnecessary classes from KDocs
