### PR TITLE
fix: Change init order of SdkUtils

### DIFF
--- a/miniapp/src/main/AndroidManifest.xml
+++ b/miniapp/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.rakuten.tech.mobile.miniapp">
+    package="com.rakuten.tech.mobile.miniapp"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -10,5 +11,13 @@
             android:authorities="${applicationId}.MiniappSdkInitializer"
             android:exported="false"
             android:initOrder="99" />
+
+        <!-- Change init order for sdk-utils so it's initialized first -->
+        <provider
+          android:name="com.rakuten.tech.mobile.sdkutils.SdkUtilsInitProvider"
+          android:authorities="${applicationId}.SdkUtilsInitProvider"
+          android:exported="false"
+          android:initOrder="100"
+          tools:replace="android:initOrder" />
     </application>
 </manifest>


### PR DESCRIPTION
It needs to be initialized before the Mini App SDK

Cherry-picking this fix from the `poc` branch.