### PR TITLE
perf: make url parsing concurrent and update the unit tests

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorage.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorage.kt
@@ -2,6 +2,8 @@ package com.rakuten.tech.mobile.miniapp.storage
 
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.legacy.core.utils.LocalUrlParser
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import java.io.File
 import java.io.InputStream
 
@@ -18,16 +20,19 @@ internal class MiniAppStorage(
         source: String,
         basePath: String,
         inputStream: InputStream
-    ) {
-        try {
-            val filePath = getFilePath(source)
-            val fileName = getFileName(source)
-            fileWriter.write(inputStream, getAbsoluteWritePath(basePath, filePath, fileName))
-        } catch (error: Exception) {
-            // This should not happen unless BE sends in a differently "constructed" URL
-            // which differs in logic as that of LocalUrlParser
-            throw MiniAppSdkException(error)
+    ) = try {
+        coroutineScope {
+            val filePath = async { getFilePath(source) }
+            val fileName = async { getFileName(source) }
+            fileWriter.write(
+                inputStream,
+                getAbsoluteWritePath(basePath, filePath.await(), fileName.await())
+            )
         }
+    } catch (error: Exception) {
+        // This should not happen unless BE sends in a differently "constructed" URL
+        // which differs in logic as that of LocalUrlParser
+        throw MiniAppSdkException(error)
     }
 
     fun getAbsoluteWritePath(
@@ -36,9 +41,9 @@ internal class MiniAppStorage(
         fileName: String
     ) = "$basePath$filePath$fileName"
 
-    fun getFilePath(file: String) = localUrlParser.getFilePath(file)
+    suspend fun getFilePath(file: String) = localUrlParser.getFilePath(file)
 
-    fun getFileName(file: String) = localUrlParser.getFileName(file)
+    suspend fun getFileName(file: String) = localUrlParser.getFileName(file)
 
     fun getSavePathForApp(appId: String, versionId: String) =
         "${basePath.path}/$SUB_DIR_MINIAPP/$appId/$versionId"

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageTest.kt
@@ -1,6 +1,5 @@
 package com.rakuten.tech.mobile.miniapp.storage
 
-import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
@@ -8,31 +7,33 @@ import com.rakuten.tech.mobile.miniapp.TEST_ID_MINIAPP
 import com.rakuten.tech.mobile.miniapp.TEST_ID_MINIAPP_VERSION
 import com.rakuten.tech.mobile.miniapp.TEST_URL_FILE
 import com.rakuten.tech.mobile.miniapp.legacy.core.utils.LocalUrlParser
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
+import kotlin.test.assertTrue
 
 class MiniAppStorageTest {
 
     @Test
-    fun `for a given set of app & version id formed base path is retured`() {
+    fun `for a given set of app & version id formed base path is returned`() {
         val miniAppStorage = getMockedMiniAppStorage()
-        assertThat(
+        assertTrue {
             miniAppStorage.getSavePathForApp(
                 TEST_ID_MINIAPP,
                 TEST_ID_MINIAPP_VERSION
-            )
-        )
-            .isEqualTo("null/miniapp/$TEST_ID_MINIAPP/$TEST_ID_MINIAPP_VERSION")
+            ) == "null/miniapp/$TEST_ID_MINIAPP/$TEST_ID_MINIAPP_VERSION"
+        }
     }
 
     @Test
-    fun `for a given set of base path & file path, formed parent path is retured`() {
+    fun `for a given set of base path & file path, formed parent path is returned`() {
         val miniAppStorage = getMockedMiniAppStorage()
-        assertThat(miniAppStorage.getAbsoluteWritePath("a", "b", "c"))
-            .isEqualTo("abc")
+        assertTrue {
+            miniAppStorage.getAbsoluteWritePath("a", "b", "c") == "abc"
+        }
     }
 
     @Test
-    fun `for a given url file path is retured via LocalUrlParser`() {
+    fun `for a given url file path is returned via LocalUrlParser`() = runBlockingTest {
         val localUrlParser = getMockedLocalUrlParser()
         val miniAppStorage = MiniAppStorage(mock(), mock(), localUrlParser)
         miniAppStorage.getFilePath(TEST_URL_FILE)
@@ -40,7 +41,7 @@ class MiniAppStorageTest {
     }
 
     @Test
-    fun `for a given url file name is retured via LocalUrlParser`() {
+    fun `for a given url file name is returned via LocalUrlParser`() = runBlockingTest {
         val localUrlParser = getMockedLocalUrlParser()
         val miniAppStorage = MiniAppStorage(mock(), mock(), localUrlParser)
         miniAppStorage.getFileName(TEST_URL_FILE)


### PR DESCRIPTION
This enables parsing for the name of the file and its path concurrently.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors