### PR TITLE
feat: update implementation for new manifest endpoint

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/legacy/core/utils/LocalUrlParser.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/legacy/core/utils/LocalUrlParser.kt
@@ -9,38 +9,43 @@ class LocalUrlParser {
     // TODO: Add URL validator for each method.
 
     /**
-     * Returns the appId from the manifest URL. AppId is the string after "miniapp" in the URL.
+     * Returns the appId from the legacy manifest URL. AppId is the string after "miniapp" in the URL.
      * Returns empty String when not found.
      */
-    fun getAppId(manifestUrl: String): String {
+    fun getAppIdForLegacy(manifestUrl: String): String {
         val splitStrings: List<String> = manifestUrl.split(File.separator)
         return splitStrings[splitStrings.indexOf(MINI_APP_ID_KEY).plus(1)]
     }
 
     /**
-     * Returns the versionId from the file URL. VersionId is the string after "version" in the URL.
+     * Returns the versionId from the legacy file URL.
+     * VersionId is the string after "version" in the URL.
      * Returns empty String when not found.
      */
-    fun getVersionId(fileUrl: String): String {
+    fun getVersionIdForLegacy(fileUrl: String): String {
         val splitStrings: List<String> = fileUrl.split(File.separator)
         return splitStrings[splitStrings.indexOf(VERSION_KEY).plus(1)]
     }
 
     /**
      * Returns the path between versionId to file name.
-     * For example: In URL "http://version/123/foo/bar/foo.html", "/foo/bar/" will be returned.
+     * e.g. in
+     * "https://host.os.net/map-published/min-872f9172-804f-44e2-addd-ed612170dac9/
+     * >>ver-6181004c-a6aa-4eda-b145-a5ff73fc4ad0/foo/bar/asset-manifest.json",
+     * "/foo/bar/" will be returned.
      * Returns empty String when not found.
      */
+    @Suppress("MagicNumber")
     fun getFilePath(fileUrl: String): String {
         val splitStrings: List<String> = fileUrl.split(File.separator)
-        val versionStringIndex = splitStrings.indexOf(VERSION_KEY)
+        val versionStringIndex = splitStrings.indexOf(KEY_MAP_PUB)
         // If versionStringIndex = -1, version string was not found, then this URL is invalid.
         if (versionStringIndex < 0) {
             return ""
         }
 
         // The second string after "version" is the beginning of path.
-        val startIndex = versionStringIndex + 2
+        val startIndex = versionStringIndex + 3
         val lastIndex = splitStrings.lastIndex
 
         var path = "/"
@@ -67,5 +72,6 @@ class LocalUrlParser {
     companion object {
         private const val MINI_APP_ID_KEY = "miniapp"
         private const val VERSION_KEY = "version"
+        private const val KEY_MAP_PUB = "map-published"
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/legacy/download/utility/MiniAppFileWriter.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/legacy/download/utility/MiniAppFileWriter.kt
@@ -38,7 +38,7 @@ class MiniAppFileWriter {
     fun writeResponseBodyToDisk(response: ResponseBody, appId: String, fileUrl: String) {
 
         // Parse appID, versionId, and appropriate directories.
-        val versionId = localUrlParser.getVersionId(fileUrl)
+        val versionId = localUrlParser.getVersionIdForLegacy(fileUrl)
         val path = localUrlParser.getFilePath(fileUrl)
         val fileName = localUrlParser.getFileName(fileUrl)
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/legacy/download/work/worker/DownloadWorker.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/legacy/download/work/worker/DownloadWorker.kt
@@ -61,7 +61,7 @@ class DownloadWorker(context: Context, workerParams: WorkerParameters) :
                 retrofitClient.retrofit.create(MiniAppServiceApi::class.java).getFile(fixedUrl)
             fileDownloadRequest.enqueue(
                 FileDownloadListener(
-                    LocalUrlParser().getAppId(
+                    LocalUrlParser().getAppIdForLegacy(
                         manifestUrl
                     ),
                     fixedUrl

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/legacy/core/BaseTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/legacy/core/BaseTest.kt
@@ -20,8 +20,10 @@ open class BaseTest {
         const val INVALID_MANIFEST_ENDPOINT =
             "/78d85043-d04f-486a-8212-bf2601cb63a2/17bccee1-17f0-44fa-8cb8-2da89eb49905/manifest/"
 
-        const val VALID_FILE_URL_PATH = "https://version/78d85043-d04f-486a-8212-bf2601cb63a2/js" +
-                "/index.html"
+        const val VALID_FILE_URL_PATH =
+            "https://miniappsplatformdev.blob.core.windows.net/"
+                .plus("map-published/min-872f9172-804f-44e2-addd-ed612170dac9/")
+                .plus("ver-6181004c-a6aa-4eda-b145-a5ff73fc4ad0/a/b/index.html")
 
         const val INVALID_FILE_URL_PATH = "https://78d85043-d04f-486a-8212-bf2601cb63a2/js"
     }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/legacy/core/BaseTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/legacy/core/BaseTest.kt
@@ -21,7 +21,7 @@ open class BaseTest {
             "/78d85043-d04f-486a-8212-bf2601cb63a2/17bccee1-17f0-44fa-8cb8-2da89eb49905/manifest/"
 
         const val VALID_FILE_URL_PATH =
-            "https://miniappsplatformdev.blob.core.windows.net/"
+            "https://www.example.com/"
                 .plus("map-published/min-872f9172-804f-44e2-addd-ed612170dac9/")
                 .plus("ver-6181004c-a6aa-4eda-b145-a5ff73fc4ad0/a/b/index.html")
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/legacy/core/utils/LocalUrlParserTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/legacy/core/utils/LocalUrlParserTest.kt
@@ -18,29 +18,29 @@ class LocalUrlParserTest : BaseTest() {
 
     @Test
     fun shouldGetAppIdFromValidUrl() {
-        assertThat(urlParser.getAppId(VALID_MANIFEST_ENDPOINT))
+        assertThat(urlParser.getAppIdForLegacy(VALID_MANIFEST_ENDPOINT))
             .isEqualTo("78d85043-d04f-486a-8212-bf2601cb63a2")
     }
 
     @Test
     fun shouldGetEmptyAppIdFromInvalidUrl() {
-        assertThat(invalideUrlParser.getAppId(INVALID_MANIFEST_ENDPOINT)).isEqualTo("")
+        assertThat(invalideUrlParser.getAppIdForLegacy(INVALID_MANIFEST_ENDPOINT)).isEqualTo("")
     }
 
     @Test
     fun shouldGetVersionIdFromUrl() {
-        assertThat(urlParser.getVersionId(VALID_MANIFEST_ENDPOINT))
+        assertThat(urlParser.getVersionIdForLegacy(VALID_MANIFEST_ENDPOINT))
             .isEqualTo("17bccee1-17f0-44fa-8cb8-2da89eb49905")
     }
 
     @Test
     fun shouldGetEmptyVersionIdFromInvalidUrl() {
-        assertThat(invalideUrlParser.getVersionId(INVALID_MANIFEST_ENDPOINT)).isEqualTo("")
+        assertThat(invalideUrlParser.getVersionIdForLegacy(INVALID_MANIFEST_ENDPOINT)).isEqualTo("")
     }
 
     @Test
     fun shouldGetFilePathWithValidUrl() {
-        assertThat(urlParser.getFilePath(VALID_FILE_URL_PATH)).isEqualTo("/js/")
+        assertThat(urlParser.getFilePath(VALID_FILE_URL_PATH)).isEqualTo("/a/b/")
     }
 
     @Test


### PR DESCRIPTION
This PR updates the implementation for `manifest` API endpoint. 
Since the structure is somewhat the same, and only the URL parsing scheme has changed, the legacy implementation has been updated.

All changes for updating endpoints implementation are being pushed to a separate branch at this moment (`update-impl-api-endpoints`). The adapted URL scheme lengthens up the URL in comparison to the previous one (as such the receiving end, SDK in this case, only requires content and the intelligence in URL for the directory structure in the current system implementation. This was discussed with BE team yesterday and has been taken up by them to see if there's some quick way to address it). IF they are able to find some quick fix for it, the implementation could again see some minor change.

In refactoring exercise, dependency on legacy parser will be removed (along with code/build/tests etc.) (i.e., the next [ 🤞] step after updating endpoints) 

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors