### PR TITLE
Feature/update impl

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -13,6 +13,7 @@ internal class MiniAppDownloader(
 ) {
 
     suspend fun getMiniApp(appId: String, versionId: String): String = when {
+        apiClient.fetchInfo(appId).version.versionId != versionId -> throw sdkExceptionForInvalidVersion()
         miniAppStatus.isVersionDownloaded(appId, versionId) -> storage.getSavePathForApp(appId, versionId)
         else -> startDownload(appId, versionId)
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -12,6 +12,7 @@ internal class MiniAppDownloader(
     private val miniAppStatus: MiniAppStatus
 ) {
 
+    /** Only run the latest version of specified MiniApp. **/
     suspend fun getMiniApp(appId: String, versionId: String): String = when {
         apiClient.fetchInfo(appId).version.versionId != versionId -> throw sdkExceptionForInvalidVersion()
         miniAppStatus.isVersionDownloaded(appId, versionId) -> storage.getSavePathForApp(appId, versionId)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
@@ -13,4 +13,4 @@ internal fun sdkExceptionForInternalServerError() = MiniAppSdkException("Interna
 
 internal fun sdkExceptionForInvalidArguments() = MiniAppSdkException("Invalid arguments")
 
-internal fun sdkExceptionForInvalidVersion() = MiniAppSdkException("Invalid Miniapp version")
+internal fun sdkExceptionForInvalidVersion() = MiniAppSdkException("Invalid or unpublished MiniApp version")

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
@@ -12,3 +12,5 @@ class MiniAppSdkException(message: String) : Exception(message) {
 internal fun sdkExceptionForInternalServerError() = MiniAppSdkException("Internal server error")
 
 internal fun sdkExceptionForInvalidArguments() = MiniAppSdkException("Invalid arguments")
+
+internal fun sdkExceptionForInvalidVersion() = MiniAppSdkException("Invalid Miniapp version")

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
@@ -89,6 +89,7 @@ class MiniAppDownloaderSpec {
             ) itReturns false
 
             setupValidManifestResponse(downloader, apiClient)
+            setupLatestMiniAppInfoResponse(apiClient, TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
 
             downloader.getMiniApp(TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
 
@@ -112,9 +113,18 @@ class MiniAppDownloaderSpec {
                 TEST_ID_MINIAPP_VERSION
             ) itReturns TEST_BASE_PATH
 
+            setupLatestMiniAppInfoResponse(apiClient, TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
+
             downloader.getMiniApp(TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION) shouldBe TEST_BASE_PATH
         }
     }
+
+    @Test(expected = MiniAppSdkException::class)
+    fun `should throw exception when the version of miniapp is not published`() =
+        runBlockingTest {
+            setupLatestMiniAppInfoResponse(apiClient, TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
+            downloader.getMiniApp(TEST_ID_MINIAPP, TEST_MA_VERSION_ID)
+        }
 
     private suspend fun setupValidManifestResponse(
         downloader: MiniAppDownloader,
@@ -127,5 +137,11 @@ class MiniAppDownloaderSpec {
 
         val mockResponseBody = TEST_BODY_CONTENT.toResponseBody(null)
         When calling apiClient.downloadFile(TEST_URL_HTTPS_1) itReturns mockResponseBody
+    }
+
+    private suspend fun setupLatestMiniAppInfoResponse(apiClient: ApiClient, appId: String, versionId: String) {
+        When calling apiClient.fetchInfo(appId) itReturns
+                MiniAppInfo(id = appId, displayName = TEST_MA_DISPLAY_NAME, icon = "",
+                    version = Version(versionTag = TEST_MA_VERSION_TAG, versionId = versionId))
     }
 }


### PR DESCRIPTION
# Description
Specification requirement:
> The Mobile Demo App should fail to render a webview for Mini Apps that are not currently published.
Including previously cached versions.

Adding the latest miniapp version checking. Only latest version of miniapp can be rendered.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors