### PR TITLE
feat: auto clear up WebView resources for usual lifecycle scenarios

### DIFF
--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -78,15 +78,41 @@ class MiniAppActivity : Activity(), CoroutineScope {
 
         val context = this
         launch {
-            val miniApp = withContext(Dispatchers.Default) {
+            val miniAppDisplay = withContext(Dispatchers.Default) {
                 MiniApp.instance().create("mini_app_id", "mini_app_version_id")
             }
-            val miniAppView = miniApp.obtainView(context)
+            val miniAppView = miniAppDisplay.getMiniAppView()
 
             setContentView(miniAppView)
         }
     }
 }
 ```
+
+## Advanced
+
+### Clearing up mini app display
+
+For a mini app, it is required to destroy necessary view state and any services registered with, either automatically or manually. `MiniAppDisplay` complies to Android's `LifecycleObserver` contract. It is quite easy to setup for automatic clean up of resources.
+
+```kotlin
+class MiniAppActivity : Activity(), CoroutineScope {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+    //...
+        launch {
+            val miniAppDisplay = withContext(Dispatchers.Default) {
+                MiniApp.instance().create("mini_app_id", "mini_app_version_id")
+            }
+            lifeCycle.addObserver(miniAppDisplay)
+    //...
+        }
+    }
+}
+```
+
+To read more about `Lifecycle` please see [link](https://developer.android.com/topic/libraries/architecture/lifecycle#lc). 
+
+On the other hand, when the consuming app manages resources manually or where it has more control on the lifecycle of views `MiniAppDisplay.destroyView` should be called upon e.g. when removing a view from the view system, yet within the same state of parent's lifecycle.
 
 ## Changelog

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDisplay.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.LifecycleObserver
  * This contract complies to Android's [LifecycleObserver] contract, and when made to observe
  * the lifecycle, it automatically clears up the view state and any services registered with.
  */
-// This contract keeps the display of a mini app implementation agnostic
 interface MiniAppDisplay: LifecycleObserver {
 
     /**

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDisplay.kt
@@ -1,12 +1,16 @@
 package com.rakuten.tech.mobile.miniapp
 
 import android.view.View
+import androidx.lifecycle.LifecycleObserver
 
 /**
  * This represents the contract by which the host app can interact with the
  * display unit of the mini app.
+ * This contract complies to Android's [LifecycleObserver] contract, and when made to observe
+ * the lifecycle, it automatically clears up the view state and any services registered with.
  */
-interface MiniAppDisplay { // This contract keeps the display of a mini app implementation agnostic
+// This contract keeps the display of a mini app implementation agnostic
+interface MiniAppDisplay: LifecycleObserver {
 
     /**
      * Provides the view associated with the mini app to the caller for showing the mini app.
@@ -16,9 +20,14 @@ interface MiniAppDisplay { // This contract keeps the display of a mini app impl
     fun getMiniAppView(): View
 
     /**
-     * Destroy necessary view state and any services registered with.
+     * Upon invocation, destroys necessary view state and any services registered with.
      * When the consumer has finished consuming, it is advisable to release the resources.
      * Usual scenarios are when the app components are amidst their destroy cycle.
+     * @see [link][https://developer.android.com/topic/libraries/architecture/lifecycle#lc]
+     * on how to setup automatic clearing based on [LifecycleObserver] for usual scenarios.
+     * To be called when resources are managed manually or where consumer app has more control
+     * on the lifecycle of views e.g. removal of the view from the view system, yet
+     * within the same state of parent's lifecycle.
      */
     fun destroyView()
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
@@ -47,10 +47,8 @@ internal class RealMiniAppDisplay(
 
     override fun getMiniAppView(): View = this
 
-    override fun destroyView() = clearUp()
-
     @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-    fun clearUp() {
+    override fun destroyView() {
         stopLoading()
         webViewClient = null
         destroy()

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
@@ -10,6 +10,8 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.OnLifecycleEvent
 import androidx.webkit.WebViewAssetLoader
 import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
 import java.io.File
@@ -45,7 +47,10 @@ internal class RealMiniAppDisplay(
 
     override fun getMiniAppView(): View = this
 
-    override fun destroyView() {
+    override fun destroyView() = clearUp()
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    fun clearUp() {
         stopLoading()
         webViewClient = null
         destroy()
@@ -53,10 +58,12 @@ internal class RealMiniAppDisplay(
 
     private fun getWebViewAssetLoader() = WebViewAssetLoader.Builder()
         .setDomain(miniAppDomain)
-        .addPathHandler("/$SUB_DOMAIN_PATH/", WebViewAssetLoader.InternalStoragePathHandler(
-            context,
-            File(basePath)
-        ))
+        .addPathHandler(
+            "/$SUB_DOMAIN_PATH/", WebViewAssetLoader.InternalStoragePathHandler(
+                context,
+                File(basePath)
+            )
+        )
         .build()
 
     @VisibleForTesting

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerTest.kt
@@ -1,8 +1,10 @@
 package com.rakuten.tech.mobile.miniapp.display
 
 import android.content.Context
+import androidx.lifecycle.LifecycleObserver
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
 import com.rakuten.tech.mobile.miniapp.TEST_MA_ID
 import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.shouldBeInstanceOf
@@ -23,10 +25,20 @@ class DisplayerTest {
     @Test
     fun `for a given base path createMiniAppDisplay returns an implementer of MiniAppDisplay`() =
         runBlockingTest {
-            val obtainedDisplay = Displayer(context).createMiniAppDisplay(
-                basePath = context.filesDir.path,
-                appId = TEST_MA_ID
-            )
+            val obtainedDisplay = getMiniAppDisplay()
             obtainedDisplay shouldBeInstanceOf RealMiniAppDisplay::class
         }
+
+    @Test
+    fun `for a given base path createMiniAppDisplay returns an implementer of LifecycleObserver`() =
+        runBlockingTest {
+            val obtainedDisplay = getMiniAppDisplay()
+            obtainedDisplay shouldBeInstanceOf LifecycleObserver::class
+        }
+
+    private suspend fun getMiniAppDisplay(): MiniAppDisplay =
+        Displayer(context).createMiniAppDisplay(
+            basePath = context.filesDir.path,
+            appId = TEST_MA_ID
+        )
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -44,6 +44,7 @@ class MiniAppDisplayActivity: BaseActivity() {
             viewModel = ViewModelProviders.of(this)
                 .get(MiniAppDisplayViewModel::class.java).apply {
 
+                    setHostLifeCycle(lifecycle)
                     miniAppView.observe(this@MiniAppDisplayActivity, Observer {
                         if (ApplicationInfo.FLAG_DEBUGGABLE == 2)
                             WebView.setWebContentsDebuggingEnabled(true)
@@ -64,11 +65,6 @@ class MiniAppDisplayActivity: BaseActivity() {
                 viewModel.obtainMiniAppView(appId, versionId)
             }
         }
-    }
-
-    override fun onDestroy() {
-        viewModel.destroyMiniAppView()
-        super.onDestroy()
     }
 
     private fun toggleProgressLoading(isOn: Boolean) {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -14,7 +14,7 @@ import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import kotlinx.android.synthetic.main.mini_app_display_activity.*
 import kotlinx.coroutines.launch
 
-class MiniAppDisplayActivity: BaseActivity() {
+class MiniAppDisplayActivity : BaseActivity() {
 
     private lateinit var appId: String
     private lateinit var versionId: String

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
@@ -1,6 +1,7 @@
 package com.rakuten.tech.mobile.testapp.ui.display
 
 import android.view.View
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -14,10 +15,12 @@ class MiniAppDisplayViewModel constructor(
 
     constructor() : this(MiniApp.instance())
 
+    private lateinit var miniAppDisplay: MiniAppDisplay
+    private lateinit var hostLifeCycle: Lifecycle
+
     private val _miniAppView = MutableLiveData<View>()
     private val _errorData = MutableLiveData<String>()
     private val _isLoading = MutableLiveData<Boolean>()
-    private lateinit var miniAppDisplay: MiniAppDisplay
 
     val miniAppView: LiveData<View>
         get() = _miniAppView
@@ -30,6 +33,7 @@ class MiniAppDisplayViewModel constructor(
         try {
             _isLoading.postValue(true)
             miniAppDisplay = miniapp.create(appId, versionId)
+            hostLifeCycle?.addObserver(miniAppDisplay)
             _miniAppView.postValue(miniAppDisplay.getMiniAppView())
         } catch (e: MiniAppSdkException) {
             e.printStackTrace()
@@ -39,8 +43,7 @@ class MiniAppDisplayViewModel constructor(
         }
     }
 
-    fun destroyMiniAppView() {
-        if (::miniAppDisplay.isInitialized)
-            miniAppDisplay.destroyView()
+    fun setHostLifeCycle(lifecycle: Lifecycle) {
+        this.hostLifeCycle = lifecycle
     }
 }


### PR DESCRIPTION
# Description
Adds an alternative for the automatic clearing of WebView in the display unit for the usual lifecycle oriented scenarios.

## Links
[MINI-499](https://jira.rakuten-it.com/jira/browse/MINI-499)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors