### PR TITLE
build: Update Jacoco to v0.8.5

### DIFF
--- a/miniapp/build.gradle
+++ b/miniapp/build.gradle
@@ -72,7 +72,7 @@ dependencies {
 
 apply from: '../config/quality/jacoco/android.gradle'
 jacoco {
-    toolVersion = "0.8.3"
+    toolVersion = "0.8.5"
 }
 
 apply from: '../gradle/documentation.gradle'


### PR DESCRIPTION
# Description
I noticed that the code coverage being reported didn't seem to be accurate, so I tried updating the Jacoco version. It seems that the older version was not ignoring some of the code generated by the Kotlin compiler.

## Links
Add links to github/jira issues, design documents and other relevant resources (e.g. previous discussions, platform/tool documentation etc.)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors