### PR TITLE
fix: Update ManifestApi response to match spec

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -6,6 +6,7 @@ import com.rakuten.tech.mobile.miniapp.api.ManifestEntity
 import com.rakuten.tech.mobile.miniapp.api.UpdatableApiClient
 import com.rakuten.tech.mobile.miniapp.storage.MiniAppStatus
 import com.rakuten.tech.mobile.miniapp.storage.MiniAppStorage
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -14,7 +15,8 @@ import kotlinx.coroutines.withContext
 internal class MiniAppDownloader(
     private val storage: MiniAppStorage,
     private var apiClient: ApiClient,
-    private val miniAppStatus: MiniAppStatus
+    private val miniAppStatus: MiniAppStatus,
+    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : UpdatableApiClient {
 
     // Only run the latest version of specified MiniApp.
@@ -61,7 +63,7 @@ internal class MiniAppDownloader(
                     storage.saveFile(file, baseSavePath, response.byteStream())
                 }
                 miniAppStatus.setVersionDownloaded(appId, versionId, true)
-                withContext(Dispatchers.IO) {
+                withContext(coroutineDispatcher) {
                     launch(Job()) { storage.removeOutdatedVersionApp(appId, versionId) }
                 }
                 return baseSavePath

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ManifestApi.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ManifestApi.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.miniapp.api
 
+import com.google.gson.annotations.SerializedName
 import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Path
@@ -16,5 +17,5 @@ internal interface ManifestApi {
 }
 
 internal data class ManifestEntity(
-    val files: List<String>
+    @SerializedName("manifest") val files: List<String>
 )

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
@@ -9,9 +9,12 @@ import com.rakuten.tech.mobile.miniapp.api.ManifestEntity
 import com.rakuten.tech.mobile.miniapp.api.UpdatableApiClient
 import com.rakuten.tech.mobile.miniapp.storage.MiniAppStatus
 import com.rakuten.tech.mobile.miniapp.storage.MiniAppStorage
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.setMain
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.amshove.kluent.*
 import org.junit.Before
@@ -26,10 +29,11 @@ class MiniAppDownloaderSpec {
     private val storage: MiniAppStorage = mock()
     private val miniAppStatus: MiniAppStatus = mock()
     private lateinit var downloader: MiniAppDownloader
+    private val dispatcher = TestCoroutineDispatcher()
 
     @Before
     fun setup() {
-        downloader = MiniAppDownloader(storage, apiClient, miniAppStatus)
+        downloader = MiniAppDownloader(storage, apiClient, miniAppStatus, dispatcher)
     }
 
     @Test
@@ -122,7 +126,7 @@ class MiniAppDownloaderSpec {
 
     @Test
     fun `should execute old file deletion after downloading new version`() {
-        runBlocking {
+        runBlockingTest {
             When calling miniAppStatus.isVersionDownloaded(
                 TEST_ID_MINIAPP,
                 TEST_ID_MINIAPP_VERSION

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiSpec.kt
@@ -34,7 +34,7 @@ open class ManifestApiSpec private constructor(
     ): MockResponse = MockResponse().setBody(
         Gson().toJson(
             hashMapOf(
-                "files" to files
+                "manifest" to files
             )
         )
     )


### PR DESCRIPTION
# Description
The API specs have changed the `files` key to `manifest`.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors