### PR TITLE
fix: Ensure error messages from the server are passed along for 'MiniApp.create'

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppInfoFetcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppInfoFetcher.kt
@@ -5,17 +5,11 @@ import com.rakuten.tech.mobile.miniapp.api.UpdatableApiClient
 
 internal class MiniAppInfoFetcher(private var apiClient: ApiClient) : UpdatableApiClient {
 
+    @Throws(MiniAppSdkException::class)
     suspend fun fetchMiniAppList() = apiClient.list()
 
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
-    suspend fun getInfo(appId: String) = run {
-        try {
-            apiClient.fetchInfo(appId)
-        } catch (error: Exception) {
-            // If backend functions correctly, this should never happen
-            throw sdkExceptionForInternalServerError()
-        }
-    }
+    @Throws(MiniAppSdkException::class)
+    suspend fun getInfo(appId: String) = apiClient.fetchInfo(appId)
 
     override fun updateApiClient(apiClient: ApiClient) {
         this.apiClient = apiClient

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -37,11 +37,13 @@ internal class ApiClient @VisibleForTesting constructor(
         hostAppId = rasAppId
     )
 
+    @Throws(MiniAppSdkException::class)
     suspend fun list(): List<MiniAppInfo> {
         val request = appInfoApi.list(hostAppId, hostAppVersionId)
         return requestExecutor.executeRequest(request)
     }
 
+    @Throws(MiniAppSdkException::class)
     suspend fun fetchInfo(appId: String): MiniAppInfo {
         val request = appInfoApi.fetchInfo(hostAppId, hostAppVersionId, appId)
         return requestExecutor.executeRequest(request).first()

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -46,7 +46,13 @@ internal class ApiClient @VisibleForTesting constructor(
     @Throws(MiniAppSdkException::class)
     suspend fun fetchInfo(appId: String): MiniAppInfo {
         val request = appInfoApi.fetchInfo(hostAppId, hostAppVersionId, appId)
-        return requestExecutor.executeRequest(request).first()
+        val info = requestExecutor.executeRequest(request)
+
+        if (info.isNotEmpty()) {
+            return info.first()
+        } else {
+            throw MiniAppSdkException("Server returned no info for the Mini App Id: $appId")
+        }
     }
 
     suspend fun fetchFileList(miniAppId: String, versionId: String): ManifestEntity {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
@@ -105,6 +105,18 @@ open class ApiClientSpec {
         apiClient.fetchInfo(TEST_MA_ID) shouldNotBe secondItem
     }
 
+    @Test(expected = MiniAppSdkException::class)
+    fun `fetchInfo should throw MiniAppSdkException when the API returns zero items`() = runBlockingTest {
+        val mockCall: Call<List<MiniAppInfo>> = mock()
+
+        When calling mockAppInfoApi.fetchInfo(any(), any(), any()) itReturns mockCall
+        When calling mockRequestExecutor.executeRequest(mockCall) itReturns emptyList<MiniAppInfo>()
+
+        val apiClient = createApiClient(appInfoApi = mockAppInfoApi)
+
+        apiClient.fetchInfo("test-app-id")
+    }
+
     private fun createApiClient(
         retrofit: Retrofit = mockRetrofitClient,
         hostAppId: String = TEST_HA_ID_APP,


### PR DESCRIPTION
# Description
Some error messages were getting swallowed because there was a redundant try catch in 'MiniAppInfoFetcher#getInfo'. The exceptions are already handled and wrapped as 'MiniAppSdkException' by the ApiClient, so there is no need to handle exceptions in the other class.

## Links
MINI-827

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [ x] I ran `./gradlew check` without errors