### PR TITLE
Setup Prod release to App Center

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init
+        # Retrieve Base64 Keystore from Env variable and save to testapp project
+      - run: base64 -d <<< $RELEASE_KEYSTORE_BASE64 > ./testapp/release-keystore.jks
       - restore_cache:
           key: *gradle_cache_key
       - run:
@@ -50,9 +52,9 @@ jobs:
           path: miniapp/build/outputs/aar
           destination: aar/
       - persist_to_workspace:
-          root: testapp/build/outputs/apk/debug
+          root: testapp/build/outputs
           paths:
-            - testapp-debug.apk
+            - apk/
       - persist_to_workspace:
           root: ~/code
           paths:
@@ -93,7 +95,7 @@ jobs:
               echo "Documentation not published for snapshot version"
             fi
 
-  deploy-test-app:
+  deploy-test-app-stg:
     docker:
       - image: circleci/node
     working_directory: ~/code
@@ -108,9 +110,30 @@ jobs:
           command: >
             npx appcenter distribute release
             --group Testers
-            --file testapp-debug.apk
+            --file apk/debug/testapp-debug.apk
             --app $APP_CENTER_APP_NAME
             --release-notes $CIRCLE_BUILD_URL
+            --token $APP_CENTER_TOKEN
+            --quiet
+
+  deploy-test-app-prod:
+    docker:
+      - image: circleci/node
+    working_directory: ~/code
+    steps:
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Install App Center CLI
+          command: npm init --yes && npm install appcenter-cli
+      - run:
+          name: Upload APK to App Center
+          command: >
+            npx appcenter distribute release
+            --group Production
+            --file apk/release/testapp-release.apk
+            --app $APP_CENTER_APP_NAME
+            --release-notes "Production build for Android SDK $CIRCLE_TAG"
             --token $APP_CENTER_TOKEN
             --quiet
 
@@ -124,6 +147,12 @@ workflows:
               only: /^v.*/
             branches:
               only: /.*/
+      - deploy-test-app-stg:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
       - release-verification:
           type: approval
           requires:
@@ -141,9 +170,11 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
-      - deploy-test-app:
+      - deploy-test-app-prod:
           requires:
-            - build
+            - publish-sdk
           filters:
+            tags:
+              only: /^v.*/
             branches:
-              only: master
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,10 @@ jobs:
       - checkout
       - run: git submodule update --init
         # Retrieve Base64 Keystore from Env variable and save to testapp project
-      - run: base64 -d <<< $RELEASE_KEYSTORE_BASE64 > ./testapp/release-keystore.jks
+      - run: |
+          if [[ $RELEASE_KEYSTORE_BASE64 != "" ]]; then
+            base64 -d <<< $RELEASE_KEYSTORE_BASE64 > ./testapp/release-keystore.jks
+          fi
       - restore_cache:
           key: *gradle_cache_key
       - run:

--- a/miniapp/build.gradle
+++ b/miniapp/build.gradle
@@ -7,6 +7,7 @@ android {
 
     defaultConfig {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles 'proguard-rules.pro'
     }
 
     compileOptions {

--- a/miniapp/proguard-rules.pro
+++ b/miniapp/proguard-rules.pro
@@ -1,0 +1,28 @@
+##---------------Begin: proguard configuration for Gson  ----------
+# Gson uses generic type information stored in a class file when working with fields. Proguard
+# removes such information by default, so configure it to keep all of it.
+-keepattributes Signature
+
+# For using GSON @Expose annotation
+-keepattributes *Annotation*
+
+# Gson specific classes
+-dontwarn sun.misc.**
+#-keep class com.google.gson.stream.** { *; }
+
+# Application classes that will be serialized/deserialized over Gson
+-keep class com.google.gson.examples.android.model.** { <fields>; }
+
+# Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
+# JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
+-keep class * extends com.google.gson.TypeAdapter
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer
+
+# Prevent R8 from leaving Data object members always null
+-keepclassmembers,allowobfuscation class * {
+  @com.google.gson.annotations.SerializedName <fields>;
+}
+
+##---------------End: proguard configuration for Gson  ----------

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppInfo.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppInfo.kt
@@ -1,6 +1,7 @@
 package com.rakuten.tech.mobile.miniapp
 
 import android.os.Parcelable
+import com.google.gson.annotations.SerializedName
 import kotlinx.android.parcel.Parcelize
 
 /**
@@ -12,10 +13,11 @@ import kotlinx.android.parcel.Parcelize
  */
 @Parcelize
 data class MiniAppInfo(
-    val id: String,
-    val displayName: String,
-    val icon: String,
-    val version: Version
+    // Must use @SerializedName on all properties for compatibility with Proguard obfuscation
+    @SerializedName("id") val id: String,
+    @SerializedName("displayName") val displayName: String,
+    @SerializedName("icon") val icon: String,
+    @SerializedName("version") val version: Version
 ) : Parcelable
 
 /**
@@ -25,6 +27,6 @@ data class MiniAppInfo(
  */
 @Parcelize
 data class Version(
-    val versionTag: String,
-    internal val versionId: String
+@SerializedName("versionTag") val versionTag: String,
+@SerializedName("versionId") internal val versionId: String
 ) : Parcelable

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -1,6 +1,7 @@
 package com.rakuten.tech.mobile.miniapp.api
 
 import androidx.annotation.VisibleForTesting
+import com.google.gson.annotations.SerializedName
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.MiniAppNetException
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
@@ -140,13 +141,13 @@ internal class RetrofitRequestExecutor(
 }
 
 internal data class HttpErrorResponse(
-    val code: Int,
-    override val message: String
+    @SerializedName("code") val code: Int,
+    @SerializedName("message") override val message: String
 ) : ErrorResponse
 
 internal data class AuthErrorResponse(
-    val code: String,
-    override val message: String
+    @SerializedName("code") val code: String,
+    @SerializedName("message") override val message: String
 ) : ErrorResponse
 
 internal interface ErrorResponse {

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -22,13 +22,21 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    signingConfigs {
-        release {
-            keyAlias 'miniapp'
-            keyPassword "$System.env.MINIAPP_RELEASE_KEY_PASSWORD"
+    // Set signing config only if the keystore file exists
+    def keystoreFile = file('release-keystore.jks')
+    if (keystoreFile.exists()) {
+        signingConfigs {
+            release {
+                keyAlias 'miniapp'
+                keyPassword "$System.env.MINIAPP_RELEASE_KEY_PASSWORD"
 
-            storeFile file('release-keystore.jks')
-            storePassword "$System.env.MINIAPP_KEYSTORE_PASSWORD"
+                storeFile keystoreFile
+                storePassword "$System.env.MINIAPP_KEYSTORE_PASSWORD"
+            }
+        }
+
+        buildTypes.release {
+            signingConfig signingConfigs.release
         }
     }
 
@@ -38,7 +46,6 @@ android {
             minifyEnabled false
         }
         release {
-            signingConfig signingConfigs.release
             debuggable true
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -22,15 +22,33 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        release {
+            keyAlias 'miniapp'
+            keyPassword "$System.env.MINIAPP_RELEASE_KEY_PASSWORD"
+
+            storeFile file('release-keystore-test.jks')
+            storePassword "$System.env.MINIAPP_KEYSTORE_PASSWORD"
+        }
+    }
+
     buildTypes {
         debug {
             debuggable true
             minifyEnabled false
         }
         release {
-            minifyEnabled true
+            signingConfig signingConfigs.release
             debuggable true
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+
+            manifestPlaceholders = [
+                    baseUrl        : property("MINIAPP_PROD_SERVER_BASE_URL") ?: "https://www.example.com/",
+                    hostAppVersion : property("HOST_APP_PROD_VERSION") ?: "test-host-app-version",
+                    appId          : property("HOST_APP_PROD_ID") ?: "test-host-app-id",
+                    subscriptionKey: property("HOST_APP_PROD_SUBSCRIPTION_KEY") ?: "test-subs-key"
+            ]
         }
     }
 

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -27,7 +27,7 @@ android {
             keyAlias 'miniapp'
             keyPassword "$System.env.MINIAPP_RELEASE_KEY_PASSWORD"
 
-            storeFile file('release-keystore-test.jks')
+            storeFile file('release-keystore.jks')
             storePassword "$System.env.MINIAPP_KEYSTORE_PASSWORD"
         }
     }


### PR DESCRIPTION
# Description
Add signing config for release build (the keystore is set as a base64 environment variable on CI), add prod settings, and publish release build to app center when releasing new versions of the SDK.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
