### PR TITLE
Change app id and app name for each build type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
           command: >
             npx appcenter distribute release
             --group Testers
-            --file apk/debug/testapp-debug.apk
+            --file apk/staging/testapp-staging.apk
             --app $APP_CENTER_APP_NAME
             --release-notes $CIRCLE_BUILD_URL
             --token $APP_CENTER_TOKEN

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -11,14 +11,6 @@ android {
     defaultConfig {
         versionCode 1
         versionName project.version
-
-        manifestPlaceholders = [
-                baseUrl        : property("MINIAPP_SERVER_BASE_URL") ?: "https://www.example.com/",
-                hostAppVersion : property("HOST_APP_VERSION") ?: "test-host-app-version",
-                appId          : property("HOST_APP_ID") ?: "test-host-app-id",
-                subscriptionKey: property("HOST_APP_SUBSCRIPTION_KEY") ?: "test-subs-key"
-        ]
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -40,22 +32,45 @@ android {
         }
     }
 
+    def appName = "Mini App Sample"
+    def stagingManifestPlaceholders = [
+            baseUrl        : property("MINIAPP_SERVER_BASE_URL") ?: "https://www.example.com/",
+            hostAppVersion : property("HOST_APP_VERSION") ?: "test-host-app-version",
+            appId          : property("HOST_APP_ID") ?: "test-host-app-id",
+            subscriptionKey: property("HOST_APP_SUBSCRIPTION_KEY") ?: "test-subs-key"
+    ]
+    def prodManifestPlaceholders = [
+            baseUrl        : property("MINIAPP_PROD_SERVER_BASE_URL") ?: "https://www.example.com/",
+            hostAppVersion : property("HOST_APP_PROD_VERSION") ?: "test-host-app-version",
+            appId          : property("HOST_APP_PROD_ID") ?: "test-host-app-id",
+            subscriptionKey: property("HOST_APP_PROD_SUBSCRIPTION_KEY") ?: "test-subs-key"
+    ]
     buildTypes {
         debug {
+            applicationIdSuffix '.debug'
+            versionNameSuffix '-DEBUG'
+            resValue "string", "app_name", "$appName DEBUG"
             debuggable true
             minifyEnabled false
+
+            manifestPlaceholders = stagingManifestPlaceholders
         }
         release {
+            resValue "string", "app_name", appName
             debuggable true
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 
-            manifestPlaceholders = [
-                    baseUrl        : property("MINIAPP_PROD_SERVER_BASE_URL") ?: "https://www.example.com/",
-                    hostAppVersion : property("HOST_APP_PROD_VERSION") ?: "test-host-app-version",
-                    appId          : property("HOST_APP_PROD_ID") ?: "test-host-app-id",
-                    subscriptionKey: property("HOST_APP_PROD_SUBSCRIPTION_KEY") ?: "test-subs-key"
-            ]
+            manifestPlaceholders = prodManifestPlaceholders
+        }
+        staging {
+            initWith release
+            applicationIdSuffix '.staging'
+            versionNameSuffix '-STG'
+            resValue "string", "app_name", "$appName STG"
+            matchingFallbacks = ['release', 'debug']
+
+            manifestPlaceholders = stagingManifestPlaceholders
         }
     }
 

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
         tools:ignore="GoogleAppIndexingWarning">
 
         <activity
-            android:name="com.rakuten.tech.mobile.testapp.ui.miniapplist.MiniAppListActivity"
-            android:label="@string/action_display_list">
+            android:name="com.rakuten.tech.mobile.testapp.ui.miniapplist.MiniAppListActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">Mini App Sample</string>
     <string name="lb_version">Version</string>
     <string name="lb_description">Description</string>
     <string name="lb_app_id">App ID</string>


### PR DESCRIPTION
# Description
This is so all of the build types can be installed on a single device at one time. Also added the 'staging' build type so we can have a release build with staging settings.

Publish staging build to App Center instead of debug build. This is so QA will be testing the SDK in the same setting as it will be used by Users - in a release build minified with proguard

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
