### PR TITLE
Feature/1.0.0 compatibility

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -41,7 +41,7 @@ abstract class MiniApp internal constructor() {
     ): MiniAppDisplay
 
     /**
-     * @deprecated use {@link #create(info: MiniAppInfo, miniAppMessageBridge: MiniAppMessageBridge)} instead.
+     * @deprecated use {@link #create(MiniAppInfo, MiniAppMessageBridge)} instead.
      * Creates a mini app.
      * @param info metadata of a mini app.
      * The mini app is downloaded, saved and provides a [MiniAppDisplay] when successful

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -49,7 +49,7 @@ abstract class MiniApp internal constructor() {
      * downloading or creating the view.
      */
     @Throws(MiniAppSdkException::class)
-    @Deprecated(message = "Please replace with create(info: MiniAppInfo, miniAppMessageBridge: MiniAppMessageBridge)")
+    @Deprecated(message = "Please replace with create(MiniAppInfo, MiniAppMessageBridge)")
     abstract suspend fun create(info: MiniAppInfo): MiniAppDisplay
 
     /**

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -30,6 +30,7 @@ abstract class MiniApp internal constructor() {
      * Creates a mini app.
      * @param info metadata of a mini app.
      * The mini app is downloaded, saved and provides a [MiniAppDisplay] when successful
+     * @param miniAppMessageBridge the inferface for exchanging data between mobile hostapp & miniapp
      * @throws MiniAppSdkException when there is some issue during fetching,
      * downloading or creating the view.
      */
@@ -38,6 +39,18 @@ abstract class MiniApp internal constructor() {
         info: MiniAppInfo,
         miniAppMessageBridge: MiniAppMessageBridge
     ): MiniAppDisplay
+
+    /**
+     * @deprecated use {@link #create(info: MiniAppInfo, miniAppMessageBridge: MiniAppMessageBridge)} instead.
+     * Creates a mini app.
+     * @param info metadata of a mini app.
+     * The mini app is downloaded, saved and provides a [MiniAppDisplay] when successful
+     * @throws MiniAppSdkException when there is some issue during fetching,
+     * downloading or creating the view.
+     */
+    @Throws(MiniAppSdkException::class)
+    @Deprecated(message = "Please replace with create(info: MiniAppInfo, miniAppMessageBridge: MiniAppMessageBridge)")
+    abstract suspend fun create(info: MiniAppInfo): MiniAppDisplay
 
     /**
      * Fetches meta data information of a mini app.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppInfo.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppInfo.kt
@@ -27,6 +27,6 @@ data class MiniAppInfo(
  */
 @Parcelize
 data class Version(
-@SerializedName("versionTag") val versionTag: String,
-@SerializedName("versionId") internal val versionId: String
+    @SerializedName("versionTag") val versionTag: String,
+    @SerializedName("versionId") internal val versionId: String
 ) : Parcelable

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -23,7 +23,16 @@ internal class RealMiniApp(
     override suspend fun create(
         info: MiniAppInfo,
         miniAppMessageBridge: MiniAppMessageBridge
-    ): MiniAppDisplay = when {
+    ): MiniAppDisplay = executingCreate(info, miniAppMessageBridge)
+
+    override suspend fun create(info: MiniAppInfo): MiniAppDisplay =
+        executingCreate(info, object : MiniAppMessageBridge() {
+            override fun getUniqueId(): String = throw Exception()
+        })
+
+    private suspend fun executingCreate(
+        info: MiniAppInfo,
+        miniAppMessageBridge: MiniAppMessageBridge): MiniAppDisplay = when {
         info.id.isBlank() || info.version.versionId.isBlank() ->
             throw sdkExceptionForInvalidArguments()
         else -> {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -25,6 +25,7 @@ internal class RealMiniApp(
         miniAppMessageBridge: MiniAppMessageBridge
     ): MiniAppDisplay = executingCreate(info, miniAppMessageBridge)
 
+    @Suppress("TooGenericExceptionThrown")
     override suspend fun create(info: MiniAppInfo): MiniAppDisplay =
         executingCreate(info, object : MiniAppMessageBridge() {
             override fun getUniqueId(): String = throw Exception()
@@ -32,7 +33,8 @@ internal class RealMiniApp(
 
     private suspend fun executingCreate(
         info: MiniAppInfo,
-        miniAppMessageBridge: MiniAppMessageBridge): MiniAppDisplay = when {
+        miniAppMessageBridge: MiniAppMessageBridge
+    ): MiniAppDisplay = when {
         info.id.isBlank() || info.version.versionId.isBlank() ->
             throw sdkExceptionForInvalidArguments()
         else -> {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -28,7 +28,7 @@ internal class RealMiniApp(
     @Suppress("TooGenericExceptionThrown")
     override suspend fun create(info: MiniAppInfo): MiniAppDisplay =
         executingCreate(info, object : MiniAppMessageBridge() {
-            override fun getUniqueId(): String = throw Exception()
+            override fun getUniqueId(): String = throw Exception("MiniAppMessageBridge has not been implemented")
         })
 
     private suspend fun executingCreate(

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -65,6 +65,14 @@ class RealMiniAppSpec {
         }
 
     @Test
+    fun `should still be able to download miniapp for deprecated method`() =
+        runBlockingTest {
+            realMiniApp.create(miniAppInfo)
+
+            verify(miniAppDownloader, times(1)).getMiniApp(TEST_MA_ID, TEST_MA_VERSION_ID)
+        }
+
+    @Test
     fun `should invoke from MiniAppInfoFetcher when calling get miniapp info`() = runBlockingTest {
         realMiniApp.fetchInfo(TEST_MA_ID)
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -1,6 +1,5 @@
 package com.rakuten.tech.mobile.testapp.ui.display
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ApplicationInfo
@@ -69,7 +68,6 @@ class MiniAppDisplayActivity : BaseActivity() {
                 }
 
             val miniAppMessageBridge = object: MiniAppMessageBridge() {
-                @SuppressLint("HardwareIds")
                 override fun getUniqueId() = AppSettings.instance.uniqueId
             }
 


### PR DESCRIPTION
# Description
Backward compatibility for SDK v1.0.0. The target is method `MiniApp.create(...)` with deprecated documentation and implementation. 

## Links
[MINI-1037](https://jira.rakuten-it.com/jira/browse/MINI-1037)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
