### PR TITLE
refactor: load view with provided context

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.androidBuildTool = '29.0.2'
-    ext.androidx_appcompat = '1.1.0'
+    ext.androidx_appcompat = '1.2.0-rc01'
     ext.androidx_constraintLayout = '1.1.3'
     ext.androidx_coreKtx = '1.2.0'
     ext.androidx_lifecycle = '2.2.0'

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -5,6 +5,7 @@ import androidx.annotation.VisibleForTesting
 import com.rakuten.tech.mobile.miniapp.api.ApiClient
 import com.rakuten.tech.mobile.miniapp.api.ApiClientRepository
 import com.rakuten.tech.mobile.miniapp.display.Displayer
+import com.rakuten.tech.mobile.miniapp.display.MiniAppDisplay
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.miniapp.storage.FileWriter
 import com.rakuten.tech.mobile.miniapp.storage.MiniAppStatus
@@ -110,7 +111,7 @@ abstract class MiniApp internal constructor() {
 
             instance = RealMiniApp(
                 apiClientRepository = apiClientRepository,
-                displayer = Displayer(context),
+                displayer = Displayer(),
                 miniAppDownloader = MiniAppDownloader(storage, apiClient, miniAppStatus),
                 miniAppInfoFetcher = MiniAppInfoFetcher(apiClient)
             )

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -4,6 +4,7 @@ import androidx.annotation.VisibleForTesting
 import com.rakuten.tech.mobile.miniapp.api.ApiClient
 import com.rakuten.tech.mobile.miniapp.api.ApiClientRepository
 import com.rakuten.tech.mobile.miniapp.display.Displayer
+import com.rakuten.tech.mobile.miniapp.display.MiniAppDisplay
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 
 internal class RealMiniApp(

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
@@ -1,21 +1,16 @@
 package com.rakuten.tech.mobile.miniapp.display
 
-import android.content.Context
-import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
-internal class Displayer(private val context: Context) {
+internal class Displayer() {
 
-    suspend fun createMiniAppDisplay(
+    fun createMiniAppDisplay(
         basePath: String,
         appId: String,
         miniAppMessageBridge: MiniAppMessageBridge
-    ): MiniAppDisplay =
-        withContext(Dispatchers.Main) {
-            context?.let {
-                RealMiniAppDisplay(context, basePath, appId, miniAppMessageBridge)
-            }
-        }
+    ): MiniAppDisplay = object : MiniAppDisplay {
+        override val basePath = basePath
+        override val appId = appId
+        override val miniAppMessageBridge = miniAppMessageBridge
+    }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
@@ -2,7 +2,7 @@ package com.rakuten.tech.mobile.miniapp.display
 
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 
-internal class Displayer() {
+internal class Displayer {
 
     fun createMiniAppDisplay(
         basePath: String,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppDisplay.kt
@@ -11,17 +11,16 @@ import kotlinx.coroutines.withContext
 /**
  * This represents the contract by which the host app can interact with the
  * display unit of the mini app.
- * This contract complies to Android's [LifecycleObserver] contract, and when made to observe
- * the lifecycle, it automatically clears up the view state and any services registered with.
  */
-interface MiniAppDisplay : LifecycleObserver {
+interface MiniAppDisplay {
     val basePath: String
     val appId: String
     val miniAppMessageBridge: MiniAppMessageBridge
 
     /**
      * Provides the view associated with the mini app to the caller for showing the mini app.
-     * Register the lifecycle as optional
+     * [LifecycleObserver] as optional. When made to observe the lifecycle,
+     * it automatically clears up the view state and any services registered with.
      * @return [View] as mini app's view with [LayoutParams] set to match
      * the parent's dimensions.
      */

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppDisplay.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.withContext
  * This contract complies to Android's [LifecycleObserver] contract, and when made to observe
  * the lifecycle, it automatically clears up the view state and any services registered with.
  */
-interface MiniAppDisplay: LifecycleObserver {
+interface MiniAppDisplay : LifecycleObserver {
     val basePath: String
     val appId: String
     val miniAppMessageBridge: MiniAppMessageBridge

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
@@ -2,7 +2,6 @@ package com.rakuten.tech.mobile.miniapp.display
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebView
 import android.widget.FrameLayout
@@ -10,7 +9,6 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.webkit.WebViewAssetLoader
-import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import java.io.File
 
@@ -20,9 +18,9 @@ private const val MINI_APP_INTERFACE = "MiniAppAndroid"
 @SuppressLint("SetJavaScriptEnabled")
 internal class RealMiniAppDisplay(
     context: Context,
-    val basePath: String,
-    val appId: String,
-    miniAppMessageBridge: MiniAppMessageBridge
+    override val basePath: String,
+    override val appId: String,
+    override val miniAppMessageBridge: MiniAppMessageBridge
 ) : MiniAppDisplay, WebView(context), WebViewListener {
 
     private val miniAppDomain = "mscheme.$appId"
@@ -45,8 +43,6 @@ internal class RealMiniAppDisplay(
 
         loadUrl(getLoadUrl())
     }
-
-    override fun getMiniAppView(): View = this
 
     @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
     override fun destroyView() {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
@@ -7,6 +7,7 @@ import android.webkit.WebView
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.webkit.WebViewAssetLoader
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
@@ -21,7 +22,7 @@ internal class RealMiniAppDisplay(
     override val basePath: String,
     override val appId: String,
     override val miniAppMessageBridge: MiniAppMessageBridge
-) : MiniAppDisplay, WebView(context), WebViewListener {
+) : MiniAppDisplay, WebView(context), WebViewListener, LifecycleObserver {
 
     private val miniAppDomain = "mscheme.$appId"
     private val customScheme = "$miniAppDomain://"

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerTest.kt
@@ -1,7 +1,6 @@
 package com.rakuten.tech.mobile.miniapp.display
 
 import android.content.Context
-import androidx.lifecycle.LifecycleObserver
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.mock
@@ -25,17 +24,10 @@ class DisplayerTest {
     }
 
     @Test
-    fun `for a given base path createMiniAppDisplay returns an implementer of MiniAppDisplay`() =
+    fun `for a given base path returns an implementer of MiniAppDisplay`() =
         runBlockingTest {
             val obtainedDisplay = getMiniAppDisplay()
             obtainedDisplay shouldBeInstanceOf MiniAppDisplay::class
-        }
-
-    @Test
-    fun `for a given base path createMiniAppDisplay returns an implementer of LifecycleObserver`() =
-        runBlockingTest {
-            val obtainedDisplay = getMiniAppDisplay()
-            obtainedDisplay shouldBeInstanceOf LifecycleObserver::class
         }
 
     private fun getMiniAppDisplay(): MiniAppDisplay =

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerTest.kt
@@ -28,7 +28,7 @@ class DisplayerTest {
     fun `for a given base path createMiniAppDisplay returns an implementer of MiniAppDisplay`() =
         runBlockingTest {
             val obtainedDisplay = getMiniAppDisplay()
-            obtainedDisplay shouldBeInstanceOf RealMiniAppDisplay::class
+            obtainedDisplay shouldBeInstanceOf MiniAppDisplay::class
         }
 
     @Test
@@ -38,8 +38,8 @@ class DisplayerTest {
             obtainedDisplay shouldBeInstanceOf LifecycleObserver::class
         }
 
-    private suspend fun getMiniAppDisplay(): MiniAppDisplay =
-        Displayer(context).createMiniAppDisplay(
+    private fun getMiniAppDisplay(): MiniAppDisplay =
+        Displayer().createMiniAppDisplay(
             basePath = context.filesDir.path,
             appId = TEST_MA_ID,
             miniAppMessageBridge = miniAppMessageBridge

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerTest.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.LifecycleObserver
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.mock
-import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
 import com.rakuten.tech.mobile.miniapp.TEST_MA_ID
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import kotlinx.coroutines.test.runBlockingTest

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplayTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplayTest.kt
@@ -107,11 +107,11 @@ class RealMiniAppDisplayTest {
     }
 
     @Test
-    fun `each mini app should have different domain`() {
+    fun `each mini app should have different domain`() = runBlockingTest {
         val realDisplayForMiniapp1 =
             RealMiniAppDisplay(context, realDisplay.basePath, "app-id-1", mMiniAppMessageBridge)
         val realDisplayForMiniapp2 =
-            RealMiniAppDisplay(context, realDisplay.basePath, "app-id-2", mMiniAppMessageBridge)
+            miniAppDisplay.getMiniAppView(context) as RealMiniAppDisplay
         realDisplayForMiniapp1.url shouldNotBeEqualTo realDisplayForMiniapp2.url
     }
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplayTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplayTest.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import androidx.core.net.toUri
+import androidx.lifecycle.LifecycleObserver
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.webkit.WebViewAssetLoader
@@ -147,6 +148,11 @@ class RealMiniAppDisplayTest {
             getWebResReq("mscheme.${realDisplay.appId}://".toUri()), mock())
 
         verify(displayer, times(1)).loadUrl(customDomain)
+    }
+
+    @Test
+    fun `for a given base path returns an implementer of LifecycleObserver`() {
+        realDisplay shouldBeInstanceOf LifecycleObserver::class
     }
 
     private fun getWebResReq(uriReq: Uri): WebResourceRequest {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -74,9 +74,16 @@ class MiniAppDisplayActivity : BaseActivity() {
             launch {
                 if (appId.isEmpty())
                     viewModel.obtainMiniAppView(
-                        intent.getParcelableExtra<MiniAppInfo>(miniAppTag)!!, miniAppMessageBridge)
+                        this@MiniAppDisplayActivity,
+                        intent.getParcelableExtra<MiniAppInfo>(miniAppTag)!!,
+                        miniAppMessageBridge
+                    )
                 else
-                    viewModel.obtainMiniAppView(appId, miniAppMessageBridge)
+                    viewModel.obtainMiniAppView(
+                        this@MiniAppDisplayActivity,
+                        appId,
+                        miniAppMessageBridge
+                    )
             }
         }
     }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
@@ -1,11 +1,13 @@
 package com.rakuten.tech.mobile.testapp.ui.display
 
+import android.content.Context
 import android.view.View
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.rakuten.tech.mobile.miniapp.*
+import com.rakuten.tech.mobile.miniapp.display.MiniAppDisplay
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
 
@@ -29,12 +31,11 @@ class MiniAppDisplayViewModel constructor(
     val isLoading: LiveData<Boolean>
         get() = _isLoading
 
-    suspend fun obtainMiniAppView(miniAppInfo: MiniAppInfo, miniAppMessageBridge: MiniAppMessageBridge) {
+    suspend fun obtainMiniAppView(context: Context, miniAppInfo: MiniAppInfo, miniAppMessageBridge: MiniAppMessageBridge) {
         try {
             _isLoading.postValue(true)
             miniAppDisplay = miniapp.create(miniAppInfo, miniAppMessageBridge)
-            hostLifeCycle?.addObserver(miniAppDisplay)
-            _miniAppView.postValue(miniAppDisplay.getMiniAppView())
+            _miniAppView.postValue(miniAppDisplay.getMiniAppView(context, hostLifeCycle))
         } catch (e: MiniAppSdkException) {
             e.printStackTrace()
             _errorData.postValue(e.message)
@@ -43,9 +44,9 @@ class MiniAppDisplayViewModel constructor(
         }
     }
 
-    suspend fun obtainMiniAppView(appId: String, miniAppMessageBridge: MiniAppMessageBridge) {
+    suspend fun obtainMiniAppView(context: Context, appId: String, miniAppMessageBridge: MiniAppMessageBridge) {
         try {
-            obtainMiniAppView(miniapp.fetchInfo(appId), miniAppMessageBridge)
+            obtainMiniAppView(context, miniapp.fetchInfo(appId), miniAppMessageBridge)
         } catch (e: MiniAppSdkException) {
             e.printStackTrace()
             _errorData.postValue(e.message)


### PR DESCRIPTION
# Description
The concept is only creating webview when calling `MiniAppDisplay.getMiniAppView(Context)`
- Load webview with provided context.
- Update the flow of lifecycle registration.

We can also achieve this goal in a simpler way by updating `create` method. Please do the evaluation to see which one is better.

## Links
[MINI-1020](https://jira.rakuten-it.com/jira/browse/MINI-1020)
Another PR by updating`MiniApp.create`:
https://github.com/rakutentech/android-miniapp/pull/91

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
