### PR TITLE
base commit for activity's context injection into the mini app display

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.androidBuildTool = '29.0.2'
-    ext.androidx_appcompat = '1.1.0'
+    ext.androidx_appcompat = '1.2.0-rc01'
     ext.androidx_constraintLayout = '1.1.3'
     ext.androidx_coreKtx = '1.2.0'
     ext.androidx_lifecycle = '2.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.androidBuildTool = '29.0.2'
+    // AndroidX Appcompat 1.1.0 results in crash on Android 5
+    // https://issuetracker.google.com/issues/141132133
     ext.androidx_appcompat = '1.2.0-rc01'
     ext.androidx_constraintLayout = '1.1.3'
     ext.androidx_coreKtx = '1.2.0'

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -160,6 +160,15 @@ To read more about `Lifecycle` please see [link](https://developer.android.com/t
 
 On the other hand, when the consuming app manages resources manually or where it has more control on the lifecycle of views `MiniAppDisplay.destroyView` should be called upon e.g. when removing a view from the view system, yet within the same state of parent's lifecycle.
 
+## Troubleshooting
+
+### AppCompat Version
+
+`androidx.appcompat:appcompat`
+
+The stable version of AndroidX AppCompat library `1.1.0` had issues on old Android OS when creating `Webview` with `ActivityContext`.  
+We recommend using the updated versions of this library.
+
 ## Changelog
 
 ### 1.1.0 (2020-06-02)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -30,7 +30,7 @@ abstract class MiniApp internal constructor() {
      * Creates a mini app.
      * @param info metadata of a mini app.
      * The mini app is downloaded, saved and provides a [MiniAppDisplay] when successful
-     * @param miniAppMessageBridge the inferface for exchanging data between mobile hostapp & miniapp
+     * @param miniAppMessageBridge the interface for communicating between host app & mini app
      * @throws MiniAppSdkException when there is some issue during fetching,
      * downloading or creating the view.
      */
@@ -110,7 +110,7 @@ abstract class MiniApp internal constructor() {
 
             instance = RealMiniApp(
                 apiClientRepository = apiClientRepository,
-                displayer = Displayer(context),
+                displayer = Displayer(),
                 miniAppDownloader = MiniAppDownloader(storage, apiClient, miniAppStatus),
                 miniAppInfoFetcher = MiniAppInfoFetcher(apiClient)
             )

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -110,7 +110,7 @@ abstract class MiniApp internal constructor() {
 
             instance = RealMiniApp(
                 apiClientRepository = apiClientRepository,
-                displayer = Displayer(),
+                displayer = Displayer(context),
                 miniAppDownloader = MiniAppDownloader(storage, apiClient, miniAppStatus),
                 miniAppInfoFetcher = MiniAppInfoFetcher(apiClient)
             )

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDisplay.kt
@@ -18,10 +18,10 @@ interface MiniAppDisplay : LifecycleObserver {
      * the parent's dimensions.
      *
      * This version of retrieval creates the mini app view which doesn't render some of the native
-     * elements of web tech. Using the updated API as recommended.
+     * elements of web tech. We recommend switching to the new API.
      */
     @Deprecated(message = "Please replace with getMiniAppView(Context)")
-    suspend fun getMiniAppView(): View?
+    suspend fun getMiniAppView(): View
 
     /**
      * Provides the view associated with the mini app to the caller for showing the mini app.
@@ -29,6 +29,7 @@ interface MiniAppDisplay : LifecycleObserver {
      * Should be the context of activity to ensure that all standard html components work properly.
      * @return [View] as mini app's view with [LayoutParams] set to match
      * the parent's dimensions.
+     * @throws MiniAppSdkException when a non-matching context is supplied
      */
     suspend fun getMiniAppView(activityContext: Context): View?
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDisplay.kt
@@ -16,18 +16,21 @@ interface MiniAppDisplay : LifecycleObserver {
      * Provides the view associated with the mini app to the caller for showing the mini app.
      * @return [View] as mini app's view with [LayoutParams] set to match
      * the parent's dimensions.
+     *
+     * This version of retrieval creates the mini app view which doesn't render some of the native
+     * elements of web tech. Using the updated API as recommended.
      */
     @Deprecated(message = "Please replace with getMiniAppView(Context)")
-    suspend fun getMiniAppView(): View
+    suspend fun getMiniAppView(): View?
 
     /**
      * Provides the view associated with the mini app to the caller for showing the mini app.
-     * @param providedContext is used by the view for initializing the internal services.
+     * @param activityContext is used by the view for initializing the internal services.
      * Should be the context of activity to ensure that all standard html components work properly.
      * @return [View] as mini app's view with [LayoutParams] set to match
      * the parent's dimensions.
      */
-    suspend fun getMiniAppView(providedContext: Context): View?
+    suspend fun getMiniAppView(activityContext: Context): View?
 
     /**
      * Upon invocation, destroys necessary view state and any services registered with.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDisplay.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.miniapp
 
+import android.content.Context
 import android.view.View
 import androidx.lifecycle.LifecycleObserver
 
@@ -13,10 +14,12 @@ interface MiniAppDisplay : LifecycleObserver {
 
     /**
      * Provides the view associated with the mini app to the caller for showing the mini app.
+     * @param activityContext is used by the view for initializing the internal services.
+     * The initialization could fail if an application context is forced, and null is returned.
      * @return [View] as mini app's view with [LayoutParams] set to match
      * the parent's dimensions.
      */
-    fun getMiniAppView(): View
+    fun getMiniAppView(activityContext: Context): View?
 
     /**
      * Upon invocation, destroys necessary view state and any services registered with.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDisplay.kt
@@ -14,12 +14,20 @@ interface MiniAppDisplay : LifecycleObserver {
 
     /**
      * Provides the view associated with the mini app to the caller for showing the mini app.
-     * @param activityContext is used by the view for initializing the internal services.
-     * The initialization could fail if an application context is forced, and null is returned.
      * @return [View] as mini app's view with [LayoutParams] set to match
      * the parent's dimensions.
      */
-    fun getMiniAppView(activityContext: Context): View?
+    @Deprecated(message = "Please replace with getMiniAppView(Context)")
+    suspend fun getMiniAppView(): View
+
+    /**
+     * Provides the view associated with the mini app to the caller for showing the mini app.
+     * @param providedContext is used by the view for initializing the internal services.
+     * Should be the context of activity to ensure that all standard html components work properly.
+     * @return [View] as mini app's view with [LayoutParams] set to match
+     * the parent's dimensions.
+     */
+    suspend fun getMiniAppView(providedContext: Context): View?
 
     /**
      * Upon invocation, destroys necessary view state and any services registered with.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
@@ -31,4 +31,4 @@ internal fun sdkExceptionForInvalidVersion() =
 
 @Suppress("FunctionMaxLength")
 internal fun sdkExceptionForNoActivityContext() =
-    MiniAppSdkException("Only accept context from Activity or ActivityCompat")
+    MiniAppSdkException("Only accept context of type Activity or ActivityCompat")

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
@@ -28,3 +28,6 @@ internal fun sdkExceptionForInvalidArguments(message: String = "") =
 
 internal fun sdkExceptionForInvalidVersion() =
     MiniAppSdkException("Invalid or unpublished MiniApp version")
+
+internal fun sdkExceptionForNoActivityContext() =
+    MiniAppSdkException("Only accept context from Activity or ActivityCompat")

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
@@ -29,5 +29,6 @@ internal fun sdkExceptionForInvalidArguments(message: String = "") =
 internal fun sdkExceptionForInvalidVersion() =
     MiniAppSdkException("Invalid or unpublished MiniApp version")
 
+@Suppress("FunctionMaxLength")
 internal fun sdkExceptionForNoActivityContext() =
     MiniAppSdkException("Only accept context from Activity or ActivityCompat")

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
@@ -1,18 +1,14 @@
 package com.rakuten.tech.mobile.miniapp.display
 
+import android.content.Context
 import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
-internal class Displayer {
+internal class Displayer(private val context: Context) {
 
-    suspend fun createMiniAppDisplay(
+    fun createMiniAppDisplay(
         basePath: String,
         appId: String,
         miniAppMessageBridge: MiniAppMessageBridge
-    ): MiniAppDisplay =
-        withContext(Dispatchers.Main) {
-            RealMiniAppDisplay(basePath, appId, miniAppMessageBridge)
-        }
+    ): MiniAppDisplay = RealMiniAppDisplay(context, basePath, appId, miniAppMessageBridge)
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
@@ -1,12 +1,11 @@
 package com.rakuten.tech.mobile.miniapp.display
 
-import android.content.Context
 import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-internal class Displayer(private val context: Context) {
+internal class Displayer {
 
     suspend fun createMiniAppDisplay(
         basePath: String,
@@ -14,8 +13,6 @@ internal class Displayer(private val context: Context) {
         miniAppMessageBridge: MiniAppMessageBridge
     ): MiniAppDisplay =
         withContext(Dispatchers.Main) {
-            context?.let {
-                RealMiniAppDisplay(context, basePath, appId, miniAppMessageBridge)
-            }
+            RealMiniAppDisplay(basePath, appId, miniAppMessageBridge)
         }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -1,0 +1,91 @@
+package com.rakuten.tech.mobile.miniapp.display
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.view.ViewGroup
+import android.webkit.WebView
+import android.widget.FrameLayout
+import androidx.annotation.VisibleForTesting
+import androidx.webkit.WebViewAssetLoader
+import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
+import java.io.File
+
+private const val SUB_DOMAIN_PATH = "miniapp"
+private const val MINI_APP_INTERFACE = "MiniAppAndroid"
+
+@SuppressLint("SetJavaScriptEnabled")
+internal class MiniAppWebView(
+    context: Context,
+    val basePath: String,
+    val appId: String,
+    miniAppMessageBridge: MiniAppMessageBridge
+) : WebView(context), WebViewListener {
+
+    private val miniAppDomain = "mscheme.$appId"
+    private val customScheme = "$miniAppDomain://"
+    private val customDomain = "https://$miniAppDomain/"
+
+    init {
+        layoutParams = FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
+        )
+
+        settings.javaScriptEnabled = true
+        addJavascriptInterface(miniAppMessageBridge, MINI_APP_INTERFACE)
+        miniAppMessageBridge.setWebViewListener(this)
+
+        settings.allowUniversalAccessFromFileURLs = true
+        settings.domStorageEnabled = true
+        settings.databaseEnabled = true
+        webViewClient =
+            MiniAppWebViewClient(context, getWebViewAssetLoader(), customDomain, customScheme)
+
+        loadUrl(getLoadUrl())
+    }
+
+    fun destroyView() {
+        stopLoading()
+        webViewClient = null
+        destroy()
+    }
+
+    override fun runSuccessCallback(callbackId: String, value: String) {
+        post {
+            evaluateJavascript(
+                "MiniAppBridge.execSuccessCallback(\"$callbackId\", \"$value\")"
+            ) {}
+        }
+    }
+
+    override fun runErrorCallback(callbackId: String, errorMessage: String) {
+        post {
+            evaluateJavascript(
+                "MiniAppBridge.execErrorCallback(\"$callbackId\", \"$errorMessage\")"
+            ) {}
+        }
+    }
+
+    private fun getWebViewAssetLoader() = WebViewAssetLoader.Builder()
+        .setDomain(miniAppDomain)
+        .addPathHandler(
+            "/$SUB_DOMAIN_PATH/", WebViewAssetLoader.InternalStoragePathHandler(
+                context,
+                File(basePath)
+            )
+        )
+        .addPathHandler(
+            "/", WebViewAssetLoader.InternalStoragePathHandler(
+                context,
+                File(basePath)
+            )
+        )
+        .build()
+
+    @VisibleForTesting
+    internal fun getLoadUrl() = "$customDomain$SUB_DOMAIN_PATH/index.html"
+}
+
+internal interface WebViewListener {
+    fun runSuccessCallback(callbackId: String, value: String)
+    fun runErrorCallback(callbackId: String, errorMessage: String)
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
@@ -1,97 +1,37 @@
 package com.rakuten.tech.mobile.miniapp.display
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.Context
 import android.view.View
-import android.view.ViewGroup
-import android.webkit.WebView
-import android.widget.FrameLayout
-import androidx.annotation.VisibleForTesting
+import androidx.core.app.ActivityCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.OnLifecycleEvent
-import androidx.webkit.WebViewAssetLoader
 import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
-import java.io.File
-
-private const val SUB_DOMAIN_PATH = "miniapp"
-private const val MINI_APP_INTERFACE = "MiniAppAndroid"
 
 @SuppressLint("SetJavaScriptEnabled")
 internal class RealMiniAppDisplay(
-    context: Context,
     val basePath: String,
     val appId: String,
-    miniAppMessageBridge: MiniAppMessageBridge
-) : MiniAppDisplay, WebView(context), WebViewListener {
+    val miniAppMessageBridge: MiniAppMessageBridge
+) : MiniAppDisplay {
 
-    private val miniAppDomain = "mscheme.$appId"
-    private val customScheme = "$miniAppDomain://"
-    private val customDomain = "https://$miniAppDomain/"
+    private var miniAppWebView: MiniAppWebView? = null
 
-    init {
-        layoutParams = FrameLayout.LayoutParams(
-            ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
-        )
-
-        settings.javaScriptEnabled = true
-        addJavascriptInterface(miniAppMessageBridge, MINI_APP_INTERFACE)
-        miniAppMessageBridge.setWebViewListener(this)
-
-        settings.allowUniversalAccessFromFileURLs = true
-        settings.domStorageEnabled = true
-        settings.databaseEnabled = true
-        webViewClient = MiniAppWebViewClient(context, getWebViewAssetLoader(), customDomain, customScheme)
-
-        loadUrl(getLoadUrl())
-    }
-
-    override fun getMiniAppView(): View = this
+    override fun getMiniAppView(activityContext: Context): View? =
+        if (activityContext is Activity || activityContext is ActivityCompat) {
+            (miniAppWebView ?: MiniAppWebView(
+                context = activityContext,
+                basePath = basePath,
+                appId = appId,
+                miniAppMessageBridge = miniAppMessageBridge
+            )).rootView
+        } else null
 
     @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
     override fun destroyView() {
-        stopLoading()
-        webViewClient = null
-        destroy()
+        miniAppWebView?.destroyView()
+        miniAppWebView = null
     }
-
-    override fun runSuccessCallback(callbackId: String, value: String) {
-        post {
-            evaluateJavascript(
-                "MiniAppBridge.execSuccessCallback(\"$callbackId\", \"$value\")"
-            ) {}
-        }
-    }
-
-    override fun runErrorCallback(callbackId: String, errorMessage: String) {
-        post {
-            evaluateJavascript(
-                "MiniAppBridge.execErrorCallback(\"$callbackId\", \"$errorMessage\")"
-            ) {}
-        }
-    }
-
-    private fun getWebViewAssetLoader() = WebViewAssetLoader.Builder()
-        .setDomain(miniAppDomain)
-        .addPathHandler(
-            "/$SUB_DOMAIN_PATH/", WebViewAssetLoader.InternalStoragePathHandler(
-                context,
-                File(basePath)
-            )
-        )
-        .addPathHandler(
-            "/", WebViewAssetLoader.InternalStoragePathHandler(
-                context,
-                File(basePath)
-            )
-        )
-        .build()
-
-    @VisibleForTesting
-    internal fun getLoadUrl() = "$customDomain$SUB_DOMAIN_PATH/index.html"
-}
-
-internal interface WebViewListener {
-    fun runSuccessCallback(callbackId: String, value: String)
-    fun runErrorCallback(callbackId: String, errorMessage: String)
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.OnLifecycleEvent
 import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
+import com.rakuten.tech.mobile.miniapp.sdkExceptionForNoActivityContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -49,7 +50,7 @@ internal class RealMiniAppDisplay(
                     )
                 }
             }
-        } else null
+        } else throw sdkExceptionForNoActivityContext()
 
     @VisibleForTesting
     internal fun isContextValid(activityContext: Context) =

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
@@ -1,37 +1,45 @@
 package com.rakuten.tech.mobile.miniapp.display
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.content.Context
 import android.view.View
-import androidx.core.app.ActivityCompat
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.OnLifecycleEvent
 import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 @SuppressLint("SetJavaScriptEnabled")
 internal class RealMiniAppDisplay(
+    val context: Context,
     val basePath: String,
     val appId: String,
     val miniAppMessageBridge: MiniAppMessageBridge
 ) : MiniAppDisplay {
 
-    private var miniAppWebView: MiniAppWebView? = null
+    @VisibleForTesting
+    internal var miniAppWebView: MiniAppWebView? = null
 
-    override fun getMiniAppView(activityContext: Context): View? =
-        if (activityContext is Activity || activityContext is ActivityCompat) {
-            (miniAppWebView ?: MiniAppWebView(
-                context = activityContext,
-                basePath = basePath,
-                appId = appId,
-                miniAppMessageBridge = miniAppMessageBridge
-            )).rootView
-        } else null
+    override suspend fun getMiniAppView(): View = provideMiniAppWebView(context)
+
+    override suspend fun getMiniAppView(providedContext: Context): View? =
+        provideMiniAppWebView(providedContext)
 
     @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
     override fun destroyView() {
         miniAppWebView?.destroyView()
         miniAppWebView = null
+    }
+
+    private suspend fun provideMiniAppWebView(providedContext: Context) =
+        withContext(Dispatchers.Main) {
+            (miniAppWebView ?: MiniAppWebView(
+                context = providedContext,
+                basePath = basePath,
+                appId = appId,
+                miniAppMessageBridge = miniAppMessageBridge
+            ))
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
@@ -35,17 +35,21 @@ internal class RealMiniAppDisplay(
         miniAppWebView = null
     }
 
-    private suspend fun provideMiniAppWebView(activityContext: Context) =
-        withContext(Dispatchers.Main) {
-            if (isContextValid(activityContext)) {
-                (miniAppWebView ?: MiniAppWebView(
-                    context = activityContext,
-                    basePath = basePath,
-                    appId = appId,
-                    miniAppMessageBridge = miniAppMessageBridge
-                ))
-            } else null
-        }
+    private suspend fun provideMiniAppWebView(activityContext: Context): View? =
+        if (isContextValid(activityContext)) {
+            if (miniAppWebView != null)
+                miniAppWebView
+            else {
+                withContext(Dispatchers.Main) {
+                    MiniAppWebView(
+                        context = activityContext,
+                        basePath = basePath,
+                        appId = appId,
+                        miniAppMessageBridge = miniAppMessageBridge
+                    )
+                }
+            }
+        } else null
 
     @VisibleForTesting
     internal fun isContextValid(activityContext: Context) =

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerTest.kt
@@ -8,7 +8,6 @@ import com.nhaarman.mockitokotlin2.mock
 import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
 import com.rakuten.tech.mobile.miniapp.TEST_MA_ID
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
-import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.shouldBeInstanceOf
 import org.junit.Before
 import org.junit.Test
@@ -26,20 +25,18 @@ class DisplayerTest {
     }
 
     @Test
-    fun `for a given base path createMiniAppDisplay returns an implementer of MiniAppDisplay`() =
-        runBlockingTest {
-            val obtainedDisplay = getMiniAppDisplay()
-            obtainedDisplay shouldBeInstanceOf RealMiniAppDisplay::class
-        }
+    fun `for a given base path createMiniAppDisplay returns an implementer of MiniAppDisplay`() {
+        val obtainedDisplay = getMiniAppDisplay()
+        obtainedDisplay shouldBeInstanceOf RealMiniAppDisplay::class
+    }
 
     @Test
-    fun `for a given base path createMiniAppDisplay returns an implementer of LifecycleObserver`() =
-        runBlockingTest {
-            val obtainedDisplay = getMiniAppDisplay()
-            obtainedDisplay shouldBeInstanceOf LifecycleObserver::class
-        }
+    fun `for a given base path createMiniAppDisplay returns an implementer of LifecycleObserver`() {
+        val obtainedDisplay = getMiniAppDisplay()
+        obtainedDisplay shouldBeInstanceOf LifecycleObserver::class
+    }
 
-    private suspend fun getMiniAppDisplay(): MiniAppDisplay =
+    private fun getMiniAppDisplay(): MiniAppDisplay =
         Displayer(context).createMiniAppDisplay(
             basePath = context.filesDir.path,
             appId = TEST_MA_ID,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewTest.kt
@@ -1,0 +1,156 @@
+package com.rakuten.tech.mobile.miniapp.display
+
+import android.content.Context
+import android.net.Uri
+import android.view.ViewGroup
+import android.webkit.WebResourceRequest
+import androidx.core.net.toUri
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.webkit.WebViewAssetLoader
+import com.nhaarman.mockitokotlin2.atLeastOnce
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.rakuten.tech.mobile.miniapp.TEST_MA_ID
+import com.rakuten.tech.mobile.miniapp.TEST_URL_HTTPS_1
+import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
+import org.amshove.kluent.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+class MiniAppWebviewTest {
+    private lateinit var context: Context
+    private lateinit var basePath: String
+    private lateinit var miniAppWebView: MiniAppWebView
+    private lateinit var webResourceRequest: WebResourceRequest
+    private val miniAppMessageBridge: MiniAppMessageBridge = mock()
+
+    @Before
+    fun setup() {
+        context = getApplicationContext()
+        basePath = context.filesDir.path
+        miniAppWebView = MiniAppWebView(
+            context,
+            basePath = basePath,
+            appId = TEST_MA_ID,
+            miniAppMessageBridge = miniAppMessageBridge
+        )
+        webResourceRequest = getWebResReq(miniAppWebView.getLoadUrl().toUri())
+    }
+
+    @Test
+    fun `for a given app id, creates corresponding view for the caller`() {
+        miniAppWebView.url shouldContain miniAppWebView.appId
+    }
+
+    @Test
+    fun `should have corrected load url format`() {
+        miniAppWebView.getLoadUrl() shouldEqual "https://mscheme.${miniAppWebView.appId}/miniapp/index.html"
+    }
+
+    @Test
+    fun `when MiniAppWebView is created then LayoutParams use MATCH_PARENT for dimensions`() {
+        miniAppWebView.layoutParams.width shouldEqualTo ViewGroup.LayoutParams.MATCH_PARENT
+        miniAppWebView.layoutParams.height shouldEqualTo ViewGroup.LayoutParams.MATCH_PARENT
+    }
+
+    @Test
+    fun `when MiniAppWebView is created then javascript should be enabled`() {
+        assertTrue { miniAppWebView.settings.javaScriptEnabled }
+    }
+
+    @Test
+    fun `when MiniAppWebView is created then allowUniversalAccessFromFileURLs should be enabled`() {
+        assertTrue { miniAppWebView.settings.allowUniversalAccessFromFileURLs }
+    }
+
+    @Test
+    fun `when MiniAppWebView is created then domStorageEnabled should be enabled`() {
+        miniAppWebView.settings.allowUniversalAccessFromFileURLs shouldBe true
+    }
+
+    @Test
+    fun `when MiniAppWebView is created then databaseEnabled should be enabled`() {
+        miniAppWebView.settings.allowUniversalAccessFromFileURLs shouldBe true
+    }
+
+    @Test
+    fun `when destroyView called then the MiniAppWebView should be disposed`() {
+        val displayer = Mockito.spy(miniAppWebView)
+        displayer.destroyView()
+
+        verify(displayer, times(1)).stopLoading()
+        displayer.webViewClient shouldBe null
+        verify(displayer, times(1)).destroy()
+    }
+
+    @Test
+    fun `for a WebViewClient, it should be MiniAppWebViewClient`() {
+        miniAppWebView.webViewClient shouldBeInstanceOf MiniAppWebViewClient::class
+    }
+
+    @Test
+    fun `each mini app should have different domain`() {
+        val miniAppWebViewForMiniapp1 = MiniAppWebView(
+            context, miniAppWebView.basePath, "app-id-1", miniAppMessageBridge)
+        val miniAppWebViewForMiniapp2 = MiniAppWebView(
+            context, miniAppWebView.basePath, "app-id-2", miniAppMessageBridge)
+        miniAppWebViewForMiniapp1.url shouldNotBeEqualTo miniAppWebViewForMiniapp2.url
+    }
+
+    @Test
+    fun `MiniAppMessageBridge should be connected with RealMiniAppDisplay`() {
+        verify(miniAppMessageBridge, atLeastOnce()).setWebViewListener(miniAppWebView)
+    }
+
+    @Test
+    fun `should intercept request with WebViewAssetLoader`() {
+        val webAssetLoader: WebViewAssetLoader =
+            Mockito.spy((miniAppWebView.webViewClient as MiniAppWebViewClient).loader)
+        val webViewClient = MiniAppWebViewClient(context, webAssetLoader,
+            "custom_domain", "custom_scheme")
+        val webResourceRequest = getWebResReq(TEST_URL_HTTPS_1.toUri())
+
+        webViewClient.shouldInterceptRequest(miniAppWebView, webResourceRequest)
+
+        verify(webAssetLoader, times(1))
+            .shouldInterceptRequest(webResourceRequest.url)
+    }
+
+    @Test
+    fun `should redirect to custom domain when only loading with custom scheme`() {
+        val webAssetLoader: WebViewAssetLoader = (miniAppWebView.webViewClient as MiniAppWebViewClient).loader
+        val customDomain = "https://mscheme.${miniAppWebView.appId}/"
+        val webViewClient = MiniAppWebViewClient(context, webAssetLoader,
+            customDomain, "mscheme.${miniAppWebView.appId}://")
+
+        val displayer = Mockito.spy(miniAppWebView)
+
+        webViewClient.onReceivedError(displayer, webResourceRequest, mock())
+        webViewClient.onReceivedError(displayer,
+            getWebResReq("mscheme.${miniAppWebView.appId}://".toUri()), mock())
+
+        verify(displayer, times(1)).loadUrl(customDomain)
+    }
+
+    private fun getWebResReq(uriReq: Uri): WebResourceRequest {
+        return object : WebResourceRequest {
+            override fun getUrl(): Uri = uriReq
+
+            override fun isRedirect(): Boolean = false
+
+            override fun getMethod(): String = "GET"
+
+            override fun getRequestHeaders(): MutableMap<String, String> = HashMap()
+
+            override fun hasGesture(): Boolean = false
+
+            override fun isForMainFrame(): Boolean = false
+        }
+    }
+}

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplayTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplayTest.kt
@@ -15,6 +15,7 @@ import org.amshove.kluent.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito
 
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
@@ -48,12 +49,19 @@ class RealMiniAppDisplayTest {
 
     @Test
     fun `should provide the exact context to MiniAppWebView`() = runBlockingTest {
-        val miniAppWebView = realDisplay.getMiniAppView() as MiniAppWebView
-        val miniAppWebView2 = realDisplay.getMiniAppView(context) as MiniAppWebView
+        val displayer = Mockito.spy(realDisplay)
+        val testContext = displayer.context
+        When calling displayer.isContextValid(testContext) itReturns true
+        val miniAppWebView = displayer.getMiniAppView(testContext) as MiniAppWebView
 
-        miniAppWebView.context shouldBe realDisplay.context
-        miniAppWebView2.context shouldBe context
+        miniAppWebView.context shouldBe testContext
     }
+
+    @Test
+    fun `getMiniAppView() should be null when the context provider is not activity context`() =
+        runBlockingTest {
+            realDisplay.getMiniAppView() shouldBe null
+        }
 
     @Test
     fun `for a given basePath, getMiniAppView should not return WebView to the caller`() =

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplayTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplayTest.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.miniapp.display
 
+import android.app.Activity
 import android.content.Context
 import android.webkit.WebView
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
@@ -58,10 +59,17 @@ class RealMiniAppDisplayTest {
     }
 
     @Test
-    fun `getMiniAppView() should be null when the context provider is not activity context`() =
+    fun `should return null when the context provider is not activity context`() =
         runBlockingTest {
             realDisplay.getMiniAppView() shouldBe null
         }
+
+    @Test
+    fun `should create MiniAppWebView when provide activity context`() = runBlockingTest {
+        val miniAppWebView: MiniAppWebView = mock()
+        realDisplay.miniAppWebView = miniAppWebView
+        realDisplay.getMiniAppView(Activity()) shouldBe miniAppWebView
+    }
 
     @Test
     fun `for a given basePath, getMiniAppView should not return WebView to the caller`() =

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplayTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplayTest.kt
@@ -55,15 +55,15 @@ class RealMiniAppDisplayTest {
         val testContext = displayer.context
         When calling displayer.isContextValid(testContext) itReturns true
         val miniAppWebView = displayer.getMiniAppView(testContext) as MiniAppWebView
+        val miniAppWebView2 = displayer.getMiniAppView() as MiniAppWebView
 
         miniAppWebView.context shouldBe testContext
+        miniAppWebView2.context shouldBe context
     }
 
     @Test(expected = MiniAppSdkException::class)
     fun `should throw exception when the context provider is not activity context`() =
-        runBlockingTest {
-            realDisplay.getMiniAppView() shouldBe null
-        }
+        runBlockingTest { realDisplay.getMiniAppView(context) }
 
     @Test
     fun `should create MiniAppWebView when provide activity context`() = runBlockingTest {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplayTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplayTest.kt
@@ -1,35 +1,27 @@
 package com.rakuten.tech.mobile.miniapp.display
 
 import android.content.Context
-import android.net.Uri
-import android.view.ViewGroup
-import android.webkit.WebResourceRequest
 import android.webkit.WebView
-import androidx.core.net.toUri
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.webkit.WebViewAssetLoader
-import com.nhaarman.mockitokotlin2.atLeastOnce
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.rakuten.tech.mobile.miniapp.TEST_MA_ID
-import com.rakuten.tech.mobile.miniapp.TEST_URL_HTTPS_1
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
-import kotlin.test.assertTrue
 
+@ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 class RealMiniAppDisplayTest {
     private lateinit var context: Context
     private lateinit var basePath: String
     private lateinit var realDisplay: RealMiniAppDisplay
-    private lateinit var webResourceRequest: WebResourceRequest
     private val miniAppMessageBridge: MiniAppMessageBridge = mock()
 
     @Before
@@ -42,121 +34,30 @@ class RealMiniAppDisplayTest {
             appId = TEST_MA_ID,
             miniAppMessageBridge = miniAppMessageBridge
         )
-        webResourceRequest = getWebResReq(realDisplay.getLoadUrl().toUri())
     }
 
     @Test
-    fun `for a given app id, RealMiniAppDisplay creates corresponding view for the caller`() =
-        runBlockingTest {
-            realDisplay.url shouldContain realDisplay.appId
-        }
+    fun `when destroyView be called then the miniAppWebView should be disposed`() = runBlockingTest {
+        val miniAppWebView: MiniAppWebView = mock()
+        realDisplay.miniAppWebView = miniAppWebView
+        realDisplay.destroyView()
+
+        verify(miniAppWebView, times(1)).destroyView()
+        realDisplay.miniAppWebView shouldBe null
+    }
+
+    @Test
+    fun `should provide the exact context to MiniAppWebView`() = runBlockingTest {
+        val miniAppWebView = realDisplay.getMiniAppView() as MiniAppWebView
+        val miniAppWebView2 = realDisplay.getMiniAppView(context) as MiniAppWebView
+
+        miniAppWebView.context shouldBe realDisplay.context
+        miniAppWebView2.context shouldBe context
+    }
 
     @Test
     fun `for a given basePath, getMiniAppView should not return WebView to the caller`() =
         runBlockingTest {
-            realDisplay.getMiniAppView() shouldNotHaveTheSameClassAs WebView::class
+            realDisplay.getMiniAppView(context) shouldNotHaveTheSameClassAs WebView::class
         }
-
-    @Test
-    fun `should have corrected load url format`() {
-        realDisplay.getLoadUrl() shouldEqual "https://mscheme.${realDisplay.appId}/miniapp/index.html"
-    }
-
-    @Test
-    fun `when MiniAppDisplay is created then LayoutParams use MATCH_PARENT for dimensions`() {
-        realDisplay.layoutParams.width shouldEqualTo ViewGroup.LayoutParams.MATCH_PARENT
-        realDisplay.layoutParams.height shouldEqualTo ViewGroup.LayoutParams.MATCH_PARENT
-    }
-
-    @Test
-    fun `when MiniAppDisplay is created then javascript should be enabled`() {
-        assertTrue { realDisplay.settings.javaScriptEnabled }
-    }
-
-    @Test
-    fun `when MiniAppDisplay is created then allowUniversalAccessFromFileURLs should be enabled`() {
-        assertTrue { realDisplay.settings.allowUniversalAccessFromFileURLs }
-    }
-
-    @Test
-    fun `when MiniAppDisplay is created then domStorageEnabled should be enabled`() {
-        realDisplay.settings.allowUniversalAccessFromFileURLs shouldBe true
-    }
-
-    @Test
-    fun `when MiniAppDisplay is created then databaseEnabled should be enabled`() {
-        realDisplay.settings.allowUniversalAccessFromFileURLs shouldBe true
-    }
-
-    @Test
-    fun `when destroyView called then the realDisplay should be disposed`() {
-        val displayer: RealMiniAppDisplay = Mockito.spy(realDisplay)
-        displayer.destroyView()
-
-        verify(displayer, times(1)).stopLoading()
-        displayer.webViewClient shouldBe null
-        verify(displayer, times(1)).destroy()
-    }
-
-    @Test
-    fun `for a WebViewClient, it should be MiniAppWebViewClient`() {
-        realDisplay.webViewClient shouldBeInstanceOf MiniAppWebViewClient::class
-    }
-
-    @Test
-    fun `each mini app should have different domain`() {
-        val realDisplayForMiniapp1 = RealMiniAppDisplay(context, realDisplay.basePath, "app-id-1", miniAppMessageBridge)
-        val realDisplayForMiniapp2 = RealMiniAppDisplay(context, realDisplay.basePath, "app-id-2", miniAppMessageBridge)
-        realDisplayForMiniapp1.url shouldNotBeEqualTo realDisplayForMiniapp2.url
-    }
-
-    @Test
-    fun `MiniAppMessageBridge should be connected with RealMiniAppDisplay`() {
-        verify(miniAppMessageBridge, atLeastOnce()).setWebViewListener(realDisplay)
-    }
-
-    @Test
-    fun `should intercept request with WebViewAssetLoader`() {
-        val webAssetLoader: WebViewAssetLoader = Mockito.spy((realDisplay.webViewClient as MiniAppWebViewClient).loader)
-        val webViewClient = MiniAppWebViewClient(context, webAssetLoader,
-            "custom_domain", "custom_scheme")
-        val webResourceRequest = getWebResReq(TEST_URL_HTTPS_1.toUri())
-
-        webViewClient.shouldInterceptRequest(realDisplay, webResourceRequest)
-
-        verify(webAssetLoader, times(1))
-            .shouldInterceptRequest(webResourceRequest.url)
-    }
-
-    @Test
-    fun `should redirect to custom domain when only loading with custom scheme`() {
-        val webAssetLoader: WebViewAssetLoader = (realDisplay.webViewClient as MiniAppWebViewClient).loader
-        val customDomain = "https://mscheme.${realDisplay.appId}/"
-        val webViewClient = MiniAppWebViewClient(context, webAssetLoader,
-            customDomain, "mscheme.${realDisplay.appId}://")
-
-        val displayer = Mockito.spy(realDisplay)
-
-        webViewClient.onReceivedError(displayer, webResourceRequest, mock())
-        webViewClient.onReceivedError(displayer,
-            getWebResReq("mscheme.${realDisplay.appId}://".toUri()), mock())
-
-        verify(displayer, times(1)).loadUrl(customDomain)
-    }
-
-    private fun getWebResReq(uriReq: Uri): WebResourceRequest {
-        return object : WebResourceRequest {
-            override fun getUrl(): Uri = uriReq
-
-            override fun isRedirect(): Boolean = false
-
-            override fun getMethod(): String = "GET"
-
-            override fun getRequestHeaders(): MutableMap<String, String> = HashMap()
-
-            override fun hasGesture(): Boolean = false
-
-            override fun isForMainFrame(): Boolean = false
-        }
-    }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplayTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplayTest.kt
@@ -8,6 +8,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
+import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.TEST_MA_ID
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -58,8 +59,8 @@ class RealMiniAppDisplayTest {
         miniAppWebView.context shouldBe testContext
     }
 
-    @Test
-    fun `should return null when the context provider is not activity context`() =
+    @Test(expected = MiniAppSdkException::class)
+    fun `should throw exception when the context provider is not activity context`() =
         runBlockingTest {
             realDisplay.getMiniAppView() shouldBe null
         }
@@ -74,6 +75,8 @@ class RealMiniAppDisplayTest {
     @Test
     fun `for a given basePath, getMiniAppView should not return WebView to the caller`() =
         runBlockingTest {
-            realDisplay.getMiniAppView(context) shouldNotHaveTheSameClassAs WebView::class
+            val displayer = Mockito.spy(realDisplay)
+            When calling displayer.isContextValid(context) itReturns true
+            displayer.getMiniAppView(context) shouldNotHaveTheSameClassAs WebView::class
         }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -15,7 +15,6 @@ import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
 import kotlinx.android.synthetic.main.mini_app_display_activity.*
-import kotlinx.coroutines.launch
 
 class MiniAppDisplayActivity : BaseActivity() {
 
@@ -71,18 +70,16 @@ class MiniAppDisplayActivity : BaseActivity() {
                 override fun getUniqueId() = AppSettings.instance.uniqueId
             }
 
-            launch {
-                if (appId.isEmpty())
-                    viewModel.obtainMiniAppDisplay(
-                        this@MiniAppDisplayActivity,
-                        intent.getParcelableExtra<MiniAppInfo>(miniAppTag)!!,
-                        miniAppMessageBridge)
-                else
-                    viewModel.obtainMiniAppDisplay(
-                        this@MiniAppDisplayActivity,
-                        appId,
-                        miniAppMessageBridge)
-            }
+            if (appId.isEmpty())
+                viewModel.obtainMiniAppDisplay(
+                    this@MiniAppDisplayActivity,
+                    intent.getParcelableExtra<MiniAppInfo>(miniAppTag)!!,
+                    miniAppMessageBridge)
+            else
+                viewModel.obtainMiniAppDisplay(
+                    this@MiniAppDisplayActivity,
+                    appId,
+                    miniAppMessageBridge)
         }
     }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -50,12 +50,12 @@ class MiniAppDisplayActivity : BaseActivity() {
             viewModel = ViewModelProvider.NewInstanceFactory()
                 .create(MiniAppDisplayViewModel::class.java).apply {
 
-                    setHostLifeCycle(lifecycle)
-                    miniAppView.observe(this@MiniAppDisplayActivity, Observer {
+                    miniAppDisplay.observe(this@MiniAppDisplayActivity, Observer {
                         if (ApplicationInfo.FLAG_DEBUGGABLE == 2)
                             WebView.setWebContentsDebuggingEnabled(true)
                         //action: display webview
-                        setContentView(it)
+                        lifecycle.addObserver(it)
+                        setContentView(it.getMiniAppView(this@MiniAppDisplayActivity))
                     })
 
                     errorData.observe(this@MiniAppDisplayActivity, Observer {
@@ -73,10 +73,10 @@ class MiniAppDisplayActivity : BaseActivity() {
 
             launch {
                 if (appId.isEmpty())
-                    viewModel.obtainMiniAppView(
+                    viewModel.obtainMiniAppDisplay(
                         intent.getParcelableExtra<MiniAppInfo>(miniAppTag)!!, miniAppMessageBridge)
                 else
-                    viewModel.obtainMiniAppView(appId, miniAppMessageBridge)
+                    viewModel.obtainMiniAppDisplay(appId, miniAppMessageBridge)
             }
         }
     }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -50,12 +50,12 @@ class MiniAppDisplayActivity : BaseActivity() {
             viewModel = ViewModelProvider.NewInstanceFactory()
                 .create(MiniAppDisplayViewModel::class.java).apply {
 
+                    setHostLifeCycle(lifecycle)
                     miniAppDisplay.observe(this@MiniAppDisplayActivity, Observer {
                         if (ApplicationInfo.FLAG_DEBUGGABLE == 2)
                             WebView.setWebContentsDebuggingEnabled(true)
                         //action: display webview
-                        lifecycle.addObserver(it)
-                        setContentView(it.getMiniAppView(this@MiniAppDisplayActivity))
+                        setContentView(it)
                     })
 
                     errorData.observe(this@MiniAppDisplayActivity, Observer {
@@ -74,9 +74,14 @@ class MiniAppDisplayActivity : BaseActivity() {
             launch {
                 if (appId.isEmpty())
                     viewModel.obtainMiniAppDisplay(
-                        intent.getParcelableExtra<MiniAppInfo>(miniAppTag)!!, miniAppMessageBridge)
+                        this@MiniAppDisplayActivity,
+                        intent.getParcelableExtra<MiniAppInfo>(miniAppTag)!!,
+                        miniAppMessageBridge)
                 else
-                    viewModel.obtainMiniAppDisplay(appId, miniAppMessageBridge)
+                    viewModel.obtainMiniAppDisplay(
+                        this@MiniAppDisplayActivity,
+                        appId,
+                        miniAppMessageBridge)
             }
         }
     }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
@@ -2,15 +2,14 @@ package com.rakuten.tech.mobile.testapp.ui.display
 
 import android.content.Context
 import android.view.View
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.*
 import com.rakuten.tech.mobile.miniapp.MiniApp
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class MiniAppDisplayViewModel constructor(
     private val miniapp: MiniApp
@@ -31,11 +30,11 @@ class MiniAppDisplayViewModel constructor(
     val isLoading: LiveData<Boolean>
         get() = _isLoading
 
-    suspend fun obtainMiniAppDisplay(
+    fun obtainMiniAppDisplay(
         context: Context,
         miniAppInfo: MiniAppInfo,
         miniAppMessageBridge: MiniAppMessageBridge
-    ) {
+    ) = viewModelScope.launch(Dispatchers.IO) {
         try {
             _isLoading.postValue(true)
             val miniAppDisplay = miniapp.create(miniAppInfo, miniAppMessageBridge)
@@ -49,18 +48,18 @@ class MiniAppDisplayViewModel constructor(
         }
     }
 
-    suspend fun obtainMiniAppDisplay(
+    fun obtainMiniAppDisplay(
         context: Context,
         appId: String,
-        miniAppMessageBridge: MiniAppMessageBridge) {
-            try {
-                obtainMiniAppDisplay(context, miniapp.fetchInfo(appId), miniAppMessageBridge)
-            } catch (e: MiniAppSdkException) {
-                e.printStackTrace()
-                _errorData.postValue(e.message)
-            } finally {
-                _isLoading.postValue(false)
-            }
+        miniAppMessageBridge: MiniAppMessageBridge) = viewModelScope.launch(Dispatchers.IO) {
+        try {
+            obtainMiniAppDisplay(context, miniapp.fetchInfo(appId), miniAppMessageBridge)
+        } catch (e: MiniAppSdkException) {
+            e.printStackTrace()
+            _errorData.postValue(e.message)
+        } finally {
+            _isLoading.postValue(false)
+        }
     }
 
     fun setHostLifeCycle(lifecycle: Lifecycle) {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
@@ -1,11 +1,12 @@
 package com.rakuten.tech.mobile.testapp.ui.display
 
-import android.view.View
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import com.rakuten.tech.mobile.miniapp.*
+import com.rakuten.tech.mobile.miniapp.MiniApp
+import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
+import com.rakuten.tech.mobile.miniapp.MiniAppInfo
+import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
 
@@ -15,26 +16,24 @@ class MiniAppDisplayViewModel constructor(
 
     constructor() : this(MiniApp.instance(AppSettings.instance.miniAppSettings))
 
-    private lateinit var miniAppDisplay: MiniAppDisplay
-    private lateinit var hostLifeCycle: Lifecycle
-
-    private val _miniAppView = MutableLiveData<View>()
+    private val _miniAppDisplay = MutableLiveData<MiniAppDisplay>()
     private val _errorData = MutableLiveData<String>()
     private val _isLoading = MutableLiveData<Boolean>()
 
-    val miniAppView: LiveData<View>
-        get() = _miniAppView
+    val miniAppDisplay: LiveData<MiniAppDisplay>
+        get() = _miniAppDisplay
     val errorData: LiveData<String>
         get() = _errorData
     val isLoading: LiveData<Boolean>
         get() = _isLoading
 
-    suspend fun obtainMiniAppView(miniAppInfo: MiniAppInfo, miniAppMessageBridge: MiniAppMessageBridge) {
+    suspend fun obtainMiniAppDisplay(
+        miniAppInfo: MiniAppInfo,
+        miniAppMessageBridge: MiniAppMessageBridge
+    ) {
         try {
             _isLoading.postValue(true)
-            miniAppDisplay = miniapp.create(miniAppInfo, miniAppMessageBridge)
-            hostLifeCycle?.addObserver(miniAppDisplay)
-            _miniAppView.postValue(miniAppDisplay.getMiniAppView())
+            _miniAppDisplay.postValue(miniapp.create(miniAppInfo, miniAppMessageBridge))
         } catch (e: MiniAppSdkException) {
             e.printStackTrace()
             _errorData.postValue(e.message)
@@ -43,9 +42,9 @@ class MiniAppDisplayViewModel constructor(
         }
     }
 
-    suspend fun obtainMiniAppView(appId: String, miniAppMessageBridge: MiniAppMessageBridge) {
+    suspend fun obtainMiniAppDisplay(appId: String, miniAppMessageBridge: MiniAppMessageBridge) {
         try {
-            obtainMiniAppView(miniapp.fetchInfo(appId), miniAppMessageBridge)
+            obtainMiniAppDisplay(miniapp.fetchInfo(appId), miniAppMessageBridge)
         } catch (e: MiniAppSdkException) {
             e.printStackTrace()
             _errorData.postValue(e.message)
@@ -54,7 +53,4 @@ class MiniAppDisplayViewModel constructor(
         }
     }
 
-    fun setHostLifeCycle(lifecycle: Lifecycle) {
-        this.hostLifeCycle = lifecycle
-    }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListFragment.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListFragment.kt
@@ -86,7 +86,7 @@ class MiniAppListFragment : BaseFragment(), MiniAppList {
     }
 
     private fun executeLoadingList() {
-        launch { viewModel.getMiniAppList() }
+        viewModel.getMiniAppList()
     }
 
     override fun onMiniAppItemClick(miniAppInfo: MiniAppInfo) {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListViewModel.kt
@@ -3,10 +3,13 @@ package com.rakuten.tech.mobile.testapp.ui.miniapplist
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.rakuten.tech.mobile.miniapp.MiniApp
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class MiniAppListViewModel constructor(
     private val miniapp: MiniApp
@@ -25,12 +28,12 @@ class MiniAppListViewModel constructor(
         get() = _errorData
 
     //for brevity
-    suspend fun getMiniAppList() {
+    fun getMiniAppList() = viewModelScope.launch(Dispatchers.IO) {
         try {
             val miniAppsList = miniapp.listMiniApp()
             _miniAppListData.postValue(miniAppsList)
         } catch (error: MiniAppSdkException) {
-            _errorData.postValue((error.message))
+            _errorData.postValue(error.message)
         }
     }
 }


### PR DESCRIPTION
# Description
Base commit for showing the activity's context injection into the mini-app display.

Note: CI would fail at this moment because of code refactoring and breaking of unit tests.

Updated: 
- Retain `ApplicationContext` in `Displayer` to maintain compatability, will omit it in the next release.
- `getMiniAppView()` is labeled as deprecated function.
- Update test cases.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
