### PR TITLE
refactor: update create MiniApp.create

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -30,12 +30,13 @@ abstract class MiniApp internal constructor() {
      * Creates a mini app.
      * @param info metadata of a mini app.
      * The mini app is downloaded, saved and provides a [MiniAppDisplay] when successful
-     * @param miniAppMessageBridge the inferface for exchanging data between mobile hostapp & miniapp
+     * @param miniAppMessageBridge the interface for communicating between host app & mini app
      * @throws MiniAppSdkException when there is some issue during fetching,
      * downloading or creating the view.
      */
     @Throws(MiniAppSdkException::class)
     abstract suspend fun create(
+        context: Context,
         info: MiniAppInfo,
         miniAppMessageBridge: MiniAppMessageBridge
     ): MiniAppDisplay

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.miniapp
 
+import android.content.Context
 import androidx.annotation.VisibleForTesting
 import com.rakuten.tech.mobile.miniapp.api.ApiClient
 import com.rakuten.tech.mobile.miniapp.api.ApiClientRepository
@@ -21,17 +22,19 @@ internal class RealMiniApp(
     }
 
     override suspend fun create(
+        context: Context,
         info: MiniAppInfo,
         miniAppMessageBridge: MiniAppMessageBridge
-    ): MiniAppDisplay = executingCreate(info, miniAppMessageBridge)
+    ): MiniAppDisplay = executingCreate(context, info, miniAppMessageBridge)
 
     @Suppress("TooGenericExceptionThrown")
     override suspend fun create(info: MiniAppInfo): MiniAppDisplay =
-        executingCreate(info, object : MiniAppMessageBridge() {
+        executingCreate(null, info, object : MiniAppMessageBridge() {
             override fun getUniqueId(): String = throw Exception("MiniAppMessageBridge has not been implemented")
         })
 
     private suspend fun executingCreate(
+        context: Context?,
         info: MiniAppInfo,
         miniAppMessageBridge: MiniAppMessageBridge
     ): MiniAppDisplay = when {
@@ -42,7 +45,7 @@ internal class RealMiniApp(
                 appId = info.id,
                 versionId = info.version.versionId
             )
-            displayer.createMiniAppDisplay(basePath, info.id, miniAppMessageBridge)
+            displayer.createMiniAppDisplay(context, basePath, info.id, miniAppMessageBridge)
         }
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
@@ -9,11 +9,13 @@ import kotlinx.coroutines.withContext
 internal class Displayer(private val context: Context) {
 
     suspend fun createMiniAppDisplay(
+        baseContext: Context?,
         basePath: String,
         appId: String,
         miniAppMessageBridge: MiniAppMessageBridge
     ): MiniAppDisplay =
         withContext(Dispatchers.Main) {
+            val context = baseContext ?: this@Displayer.context
             context?.let {
                 RealMiniAppDisplay(context, basePath, appId, miniAppMessageBridge)
             }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -1,5 +1,8 @@
 package com.rakuten.tech.mobile.miniapp
 
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
@@ -15,11 +18,14 @@ import org.amshove.kluent.calling
 import org.amshove.kluent.itReturns
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.Mockito
 
+@RunWith(AndroidJUnit4::class)
 @ExperimentalCoroutinesApi
 class RealMiniAppSpec {
 
+    private lateinit var context: Context
     private var apiClient: ApiClient = mock()
     private val apiClientRepository: ApiClientRepository = mock()
     private val displayer: Displayer = mock()
@@ -33,6 +39,7 @@ class RealMiniAppSpec {
 
     @Before
     fun setup() {
+        context = ApplicationProvider.getApplicationContext()
         When calling apiClientRepository.getApiClientFor(miniAppSdkConfig.key) itReturns apiClient
     }
 
@@ -51,17 +58,18 @@ class RealMiniAppSpec {
     @Test(expected = MiniAppSdkException::class)
     fun `should throw exception when version id is invalid`() = runBlockingTest {
         val invalidMiniAppInfo = MiniAppInfo(TEST_MA_ID, "", "", Version("", ""))
-        realMiniApp.create(invalidMiniAppInfo, miniAppMessageBridge)
+        realMiniApp.create(context, invalidMiniAppInfo, miniAppMessageBridge)
     }
 
     @Test
     fun `should invoke from MiniAppDownloader and Displayer when calling create miniapp`() =
         runBlockingTest {
-            realMiniApp.create(miniAppInfo, miniAppMessageBridge)
+            realMiniApp.create(context, miniAppInfo, miniAppMessageBridge)
 
             val basePath: String = verify(miniAppDownloader, times(1))
                 .getMiniApp(TEST_MA_ID, TEST_MA_VERSION_ID)
-            verify(displayer, times(1)).createMiniAppDisplay(basePath, TEST_MA_ID, miniAppMessageBridge)
+            verify(displayer, times(1)).createMiniAppDisplay(
+                context, basePath, TEST_MA_ID, miniAppMessageBridge)
         }
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerTest.kt
@@ -41,6 +41,7 @@ class DisplayerTest {
 
     private suspend fun getMiniAppDisplay(): MiniAppDisplay =
         Displayer(context).createMiniAppDisplay(
+            baseContext = null,
             basePath = context.filesDir.path,
             appId = TEST_MA_ID,
             miniAppMessageBridge = miniAppMessageBridge

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -74,9 +74,14 @@ class MiniAppDisplayActivity : BaseActivity() {
             launch {
                 if (appId.isEmpty())
                     viewModel.obtainMiniAppView(
-                        intent.getParcelableExtra<MiniAppInfo>(miniAppTag)!!, miniAppMessageBridge)
+                        this@MiniAppDisplayActivity,
+                        intent.getParcelableExtra<MiniAppInfo>(miniAppTag)!!,
+                        miniAppMessageBridge)
                 else
-                    viewModel.obtainMiniAppView(appId, miniAppMessageBridge)
+                    viewModel.obtainMiniAppView(
+                        this@MiniAppDisplayActivity,
+                        appId,
+                        miniAppMessageBridge)
             }
         }
     }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.testapp.ui.display
 
+import android.content.Context
 import android.view.View
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LiveData
@@ -29,10 +30,13 @@ class MiniAppDisplayViewModel constructor(
     val isLoading: LiveData<Boolean>
         get() = _isLoading
 
-    suspend fun obtainMiniAppView(miniAppInfo: MiniAppInfo, miniAppMessageBridge: MiniAppMessageBridge) {
+    suspend fun obtainMiniAppView(
+        context: Context,
+        miniAppInfo: MiniAppInfo,
+        miniAppMessageBridge: MiniAppMessageBridge) {
         try {
             _isLoading.postValue(true)
-            miniAppDisplay = miniapp.create(miniAppInfo, miniAppMessageBridge)
+            miniAppDisplay = miniapp.create(context, miniAppInfo, miniAppMessageBridge)
             hostLifeCycle?.addObserver(miniAppDisplay)
             _miniAppView.postValue(miniAppDisplay.getMiniAppView())
         } catch (e: MiniAppSdkException) {
@@ -43,9 +47,12 @@ class MiniAppDisplayViewModel constructor(
         }
     }
 
-    suspend fun obtainMiniAppView(appId: String, miniAppMessageBridge: MiniAppMessageBridge) {
+    suspend fun obtainMiniAppView(
+        context: Context,
+        appId: String,
+        miniAppMessageBridge: MiniAppMessageBridge) {
         try {
-            obtainMiniAppView(miniapp.fetchInfo(appId), miniAppMessageBridge)
+            obtainMiniAppView(context, miniapp.fetchInfo(appId), miniAppMessageBridge)
         } catch (e: MiniAppSdkException) {
             e.printStackTrace()
             _errorData.postValue(e.message)


### PR DESCRIPTION
# Description
Load webview with the provided context or using the default as `ApplicationContext` by updating `MiniApp.create` method.

## Links
[MINI-1020](https://jira.rakuten-it.com/jira/browse/MINI-1020)
Another PR by updating`MiniAppDisplay.getMiniAppView`:
- https://github.com/rakutentech/android-miniapp/pull/89
- https://github.com/rakutentech/android-miniapp/pull/90

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
