### PR TITLE
Feature/build_version_display & update_get_latest_miniapp

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -41,6 +41,20 @@ abstract class MiniApp internal constructor() {
     ): MiniAppDisplay
 
     /**
+     * Creates a mini app.
+     * @param appId mini app id.
+     * The mini app is downloaded, saved and provides a [MiniAppDisplay] when successful
+     * @param miniAppMessageBridge the interface for communicating between host app & mini app
+     * @throws MiniAppSdkException when there is some issue during fetching,
+     * downloading or creating the view.
+     */
+    @Throws(MiniAppSdkException::class)
+    abstract suspend fun create(
+        appId: String,
+        miniAppMessageBridge: MiniAppMessageBridge
+    ): MiniAppDisplay
+
+    /**
      * @deprecated use {@link #create(MiniAppInfo, MiniAppMessageBridge)} instead.
      * Creates a mini app.
      * @param info metadata of a mini app.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -35,6 +35,7 @@ abstract class MiniApp internal constructor() {
      * downloading or creating the view.
      */
     @Throws(MiniAppSdkException::class)
+    @Deprecated(message = "Please replace with create(MiniAppId, MiniAppMessageBridge)")
     abstract suspend fun create(
         info: MiniAppInfo,
         miniAppMessageBridge: MiniAppMessageBridge
@@ -63,7 +64,7 @@ abstract class MiniApp internal constructor() {
      * downloading or creating the view.
      */
     @Throws(MiniAppSdkException::class)
-    @Deprecated(message = "Please replace with create(MiniAppInfo, MiniAppMessageBridge)")
+    @Deprecated(message = "Please replace with create(MiniAppId, MiniAppMessageBridge)")
     abstract suspend fun create(info: MiniAppInfo): MiniAppDisplay
 
     /**

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -36,8 +36,7 @@ internal class MiniAppDownloader(
                 val versionPath = storage.getMiniAppVersionPath(appId, versionId)
                 if (miniAppStatus.isVersionDownloaded(appId, versionId, versionPath))
                     return versionPath
-            } else
-                throw netError
+            }
         }
         // cannot load miniapp from server
         throw sdkExceptionForInternalServerError()

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -31,7 +31,7 @@ internal class MiniAppDownloader(
             }
         } catch (netError: MiniAppNetException) {
             // load local if possible when offline
-            val versionId = miniAppStatus.localVersion
+            val versionId = miniAppStatus.getDownloadedVersion(appId)
             if (versionId != null) {
                 val versionPath = storage.getMiniAppVersionPath(appId, versionId)
                 if (miniAppStatus.isVersionDownloaded(appId, versionId, versionPath))
@@ -68,7 +68,7 @@ internal class MiniAppDownloader(
                     storage.saveFile(file, baseSavePath, response.byteStream())
                 }
                 miniAppStatus.setVersionDownloaded(appId, versionId, true)
-                miniAppStatus.localVersion = versionId
+                miniAppStatus.saveDownloadedVersion(appId, versionId)
                 withContext(coroutineDispatcher) {
                     launch(Job()) { storage.removeOutdatedVersionApp(appId, versionId) }
                 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
@@ -26,9 +26,6 @@ internal fun sdkExceptionForInvalidArguments(message: String = "") =
         }}"
     )
 
-internal fun sdkExceptionForInvalidVersion() =
-    MiniAppSdkException("Invalid or unpublished MiniApp version")
-
 @Suppress("FunctionMaxLength")
 internal fun sdkExceptionForNoActivityContext() =
     MiniAppSdkException("Only accept context of type Activity or ActivityCompat")

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -20,29 +20,30 @@ internal class RealMiniApp(
         else -> miniAppInfoFetcher.getInfo(appId)
     }
 
-    override suspend fun create(
-        info: MiniAppInfo,
-        miniAppMessageBridge: MiniAppMessageBridge
-    ): MiniAppDisplay = executingCreate(info, miniAppMessageBridge)
-
     @Suppress("TooGenericExceptionThrown")
     override suspend fun create(info: MiniAppInfo): MiniAppDisplay =
-        executingCreate(info, object : MiniAppMessageBridge() {
+        executingCreate(info.id, object : MiniAppMessageBridge() {
             override fun getUniqueId(): String = throw Exception("MiniAppMessageBridge has not been implemented")
         })
 
-    private suspend fun executingCreate(
+    override suspend fun create(
         info: MiniAppInfo,
         miniAppMessageBridge: MiniAppMessageBridge
+    ): MiniAppDisplay = executingCreate(info.id, miniAppMessageBridge)
+
+    override suspend fun create(
+        appId: String,
+        miniAppMessageBridge: MiniAppMessageBridge
+    ): MiniAppDisplay = executingCreate(appId, miniAppMessageBridge)
+
+    private suspend fun executingCreate(
+        miniAppId: String,
+        miniAppMessageBridge: MiniAppMessageBridge
     ): MiniAppDisplay = when {
-        info.id.isBlank() || info.version.versionId.isBlank() ->
-            throw sdkExceptionForInvalidArguments()
+        miniAppId.isBlank() -> throw sdkExceptionForInvalidArguments()
         else -> {
-            val basePath = miniAppDownloader.getMiniApp(
-                appId = info.id,
-                versionId = info.version.versionId
-            )
-            displayer.createMiniAppDisplay(basePath, info.id, miniAppMessageBridge)
+            val basePath = miniAppDownloader.getMiniApp(miniAppId)
+            displayer.createMiniAppDisplay(basePath, miniAppId, miniAppMessageBridge)
         }
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
@@ -1,0 +1,28 @@
+package com.rakuten.tech.mobile.miniapp.display
+
+import android.content.Context
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import androidx.annotation.VisibleForTesting
+import java.io.BufferedReader
+
+internal class MiniAppWebChromeClient(context: Context) : WebChromeClient() {
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    @VisibleForTesting
+    internal val bridgeJs = try {
+        val inputStream = context.assets.open("bridge.js")
+        inputStream.bufferedReader().use(BufferedReader::readText)
+    } catch (e: Exception) {
+        null
+    }
+
+    override fun onReceivedTitle(webView: WebView, title: String?) {
+        doInjection(webView)
+        super.onReceivedTitle(webView, title)
+    }
+
+    @VisibleForTesting
+    internal fun doInjection(webView: WebView) {
+        webView.evaluateJavascript(bridgeJs) {}
+    }
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -37,8 +37,8 @@ internal class MiniAppWebView(
         settings.allowUniversalAccessFromFileURLs = true
         settings.domStorageEnabled = true
         settings.databaseEnabled = true
-        webViewClient =
-            MiniAppWebViewClient(context, getWebViewAssetLoader(), customDomain, customScheme)
+        webViewClient = MiniAppWebViewClient(getWebViewAssetLoader(), customDomain, customScheme)
+        webChromeClient = MiniAppWebChromeClient(context)
 
         loadUrl(getLoadUrl())
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
@@ -1,7 +1,5 @@
 package com.rakuten.tech.mobile.miniapp.display
 
-import android.content.Context
-import android.graphics.Bitmap
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
@@ -9,33 +7,17 @@ import android.webkit.WebViewClient
 import android.webkit.WebResourceError
 import androidx.annotation.VisibleForTesting
 import androidx.webkit.WebViewAssetLoader
-import java.io.BufferedReader
 
 internal class MiniAppWebViewClient(
-    context: Context,
     @VisibleForTesting internal val loader: WebViewAssetLoader,
     private val customDomain: String,
     private val customScheme: String
 ) : WebViewClient() {
 
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
-    @VisibleForTesting
-    internal val bridgeJs = try {
-        val inputStream = context.assets.open("bridge.js")
-        inputStream.bufferedReader().use(BufferedReader::readText)
-    } catch (e: Exception) {
-        null
-    }
-
     override fun shouldInterceptRequest(
         view: WebView,
         request: WebResourceRequest
     ): WebResourceResponse? = loader.shouldInterceptRequest(request.url)
-
-    override fun onPageStarted(webView: WebView, url: String?, favicon: Bitmap?) {
-        super.onPageStarted(webView, url, favicon)
-        webView.evaluateJavascript(bridgeJs) {}
-    }
 
     override fun onReceivedError(
         view: WebView,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStatus.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStatus.kt
@@ -5,16 +5,15 @@ import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
 import java.io.File
 
-private const val LOCAL_VERSION = "local_version"
-
 internal class MiniAppStatus(context: Context) {
     private val prefs: SharedPreferences = context.getSharedPreferences(
         "com.rakuten.tech.mobile.miniapp.storage", Context.MODE_PRIVATE
     )
 
-    var localVersion: String?
-        get() = prefs.getString(LOCAL_VERSION, null)
-        set(downloadedVersion) = prefs.edit().putString(LOCAL_VERSION, downloadedVersion).apply()
+    fun saveDownloadedVersion(appId: String, versionId: String) =
+        prefs.edit().putString(appId, versionId).apply()
+
+    fun getDownloadedVersion(appId: String): String? = prefs.getString(appId, null)
 
     fun setVersionDownloaded(appId: String, versionId: String, value: Boolean) =
         prefs.edit().putBoolean(appId + versionId, value).apply()

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStatus.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStatus.kt
@@ -5,8 +5,9 @@ import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
 import java.io.File
 
+private const val LOCAL_VERSION = "local_version"
+
 internal class MiniAppStatus(context: Context) {
-    private val LOCAL_VERSION = "local_version"
     private val prefs: SharedPreferences = context.getSharedPreferences(
         "com.rakuten.tech.mobile.miniapp.storage", Context.MODE_PRIVATE
     )

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStatus.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStatus.kt
@@ -6,9 +6,14 @@ import androidx.annotation.VisibleForTesting
 import java.io.File
 
 internal class MiniAppStatus(context: Context) {
+    private val LOCAL_VERSION = "local_version"
     private val prefs: SharedPreferences = context.getSharedPreferences(
         "com.rakuten.tech.mobile.miniapp.storage", Context.MODE_PRIVATE
     )
+
+    var localVersion: String?
+        get() = prefs.getString(LOCAL_VERSION, null)
+        set(downloadedVersion) = prefs.edit().putString(LOCAL_VERSION, downloadedVersion).apply()
 
     fun setVersionDownloaded(appId: String, versionId: String, value: Boolean) =
         prefs.edit().putBoolean(appId + versionId, value).apply()

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
@@ -181,7 +181,7 @@ class MiniAppDownloaderSpec {
                 TEST_ID_MINIAPP_VERSION,
                 TEST_BASE_PATH
             ) itReturns true
-            When calling miniAppStatus.localVersion itReturns TEST_ID_MINIAPP_VERSION
+            When calling miniAppStatus.getDownloadedVersion(TEST_ID_MINIAPP) itReturns TEST_ID_MINIAPP_VERSION
             When calling storage.getMiniAppVersionPath(
                 TEST_ID_MINIAPP,
                 TEST_ID_MINIAPP_VERSION

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
@@ -97,7 +97,7 @@ class MiniAppDownloaderSpec {
             setupValidManifestResponse(downloader, apiClient)
             setupLatestMiniAppInfoResponse(apiClient, TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
 
-            downloader.getMiniApp(TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
+            downloader.getMiniApp(TEST_ID_MINIAPP)
 
             verify(apiClient, times(1)).fetchFileList(
                 TEST_ID_MINIAPP,
@@ -122,7 +122,7 @@ class MiniAppDownloaderSpec {
             setupValidManifestResponse(downloader, apiClient)
             setupLatestMiniAppInfoResponse(apiClient, TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
 
-            downloader.getMiniApp(TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION) shouldBe TEST_BASE_PATH
+            downloader.getMiniApp(TEST_ID_MINIAPP) shouldBe TEST_BASE_PATH
         }
 
     @Test
@@ -139,7 +139,7 @@ class MiniAppDownloaderSpec {
             setupValidManifestResponse(downloader, apiClient)
             setupLatestMiniAppInfoResponse(apiClient, TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
 
-            downloader.getMiniApp(TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
+            downloader.getMiniApp(TEST_ID_MINIAPP)
 
             verify(storage, times(1)).removeOutdatedVersionApp(
                 TEST_ID_MINIAPP,
@@ -159,7 +159,7 @@ class MiniAppDownloaderSpec {
             setupValidManifestResponse(downloader, apiClient)
             setupLatestMiniAppInfoResponse(apiClient, TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
 
-            downloader.getMiniApp(TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
+            downloader.getMiniApp(TEST_ID_MINIAPP)
 
             verify(storage, times(1)).removeOutdatedVersionApp(
                 TEST_ID_MINIAPP,
@@ -181,13 +181,14 @@ class MiniAppDownloaderSpec {
                 TEST_ID_MINIAPP_VERSION,
                 TEST_BASE_PATH
             ) itReturns true
+            When calling miniAppStatus.localVersion itReturns TEST_ID_MINIAPP_VERSION
             When calling storage.getMiniAppVersionPath(
                 TEST_ID_MINIAPP,
                 TEST_ID_MINIAPP_VERSION
             ) itReturns TEST_BASE_PATH
             When calling apiClient.fetchInfo(TEST_ID_MINIAPP) doThrow MiniAppNetException(TEST_ERROR_MSG)
 
-            downloader.getMiniApp(TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION) shouldBe TEST_BASE_PATH
+            downloader.getMiniApp(TEST_ID_MINIAPP) shouldBe TEST_BASE_PATH
         }
 
     @Test(expected = MiniAppSdkException::class)
@@ -204,7 +205,7 @@ class MiniAppDownloaderSpec {
             ) itReturns TEST_BASE_PATH
             When calling apiClient.fetchInfo(TEST_ID_MINIAPP) doThrow MiniAppNetException(TEST_ERROR_MSG)
 
-            downloader.getMiniApp(TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
+            downloader.getMiniApp(TEST_ID_MINIAPP)
         }
 
     private suspend fun setupValidManifestResponse(

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
@@ -168,13 +168,6 @@ class MiniAppDownloaderSpec {
         }
     }
 
-    @Test(expected = MiniAppSdkException::class)
-    fun `should throw exception when the version of miniapp is not published`() =
-        runBlockingTest {
-            setupLatestMiniAppInfoResponse(apiClient, TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
-            downloader.getMiniApp(TEST_ID_MINIAPP, TEST_MA_VERSION_ID)
-        }
-
     @Test
     fun `MiniAppDownloader should implement UpdatableApiClient`() {
         downloader shouldBeInstanceOf UpdatableApiClient::class.java

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -48,19 +48,13 @@ class RealMiniAppSpec {
         realMiniApp.fetchInfo("")
     }
 
-    @Test(expected = MiniAppSdkException::class)
-    fun `should throw exception when version id is invalid`() = runBlockingTest {
-        val invalidMiniAppInfo = MiniAppInfo(TEST_MA_ID, "", "", Version("", ""))
-        realMiniApp.create(invalidMiniAppInfo, miniAppMessageBridge)
-    }
-
     @Test
     fun `should invoke from MiniAppDownloader and Displayer when calling create miniapp`() =
         runBlockingTest {
-            realMiniApp.create(miniAppInfo, miniAppMessageBridge)
+            realMiniApp.create(TEST_MA_ID, miniAppMessageBridge)
 
             val basePath: String = verify(miniAppDownloader, times(1))
-                .getMiniApp(TEST_MA_ID, TEST_MA_VERSION_ID)
+                .getMiniApp(TEST_MA_ID)
             verify(displayer, times(1)).createMiniAppDisplay(basePath, TEST_MA_ID, miniAppMessageBridge)
         }
 
@@ -68,8 +62,9 @@ class RealMiniAppSpec {
     fun `should still be able to download miniapp for deprecated method`() =
         runBlockingTest {
             realMiniApp.create(miniAppInfo)
+            realMiniApp.create(miniAppInfo, miniAppMessageBridge)
 
-            verify(miniAppDownloader, times(1)).getMiniApp(TEST_MA_ID, TEST_MA_VERSION_ID)
+            verify(miniAppDownloader, times(2)).getMiniApp(TEST_MA_ID)
         }
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewTest.kt
@@ -112,7 +112,7 @@ class MiniAppWebviewTest {
     fun `should intercept request with WebViewAssetLoader`() {
         val webAssetLoader: WebViewAssetLoader =
             Mockito.spy((miniAppWebView.webViewClient as MiniAppWebViewClient).loader)
-        val webViewClient = MiniAppWebViewClient(context, webAssetLoader,
+        val webViewClient = MiniAppWebViewClient(webAssetLoader,
             "custom_domain", "custom_scheme")
         val webResourceRequest = getWebResReq(TEST_URL_HTTPS_1.toUri())
 
@@ -126,8 +126,8 @@ class MiniAppWebviewTest {
     fun `should redirect to custom domain when only loading with custom scheme`() {
         val webAssetLoader: WebViewAssetLoader = (miniAppWebView.webViewClient as MiniAppWebViewClient).loader
         val customDomain = "https://mscheme.${miniAppWebView.appId}/"
-        val webViewClient = MiniAppWebViewClient(context, webAssetLoader,
-            customDomain, "mscheme.${miniAppWebView.appId}://")
+        val webViewClient = MiniAppWebViewClient(webAssetLoader, customDomain,
+            "mscheme.${miniAppWebView.appId}://")
 
         val displayer = Mockito.spy(miniAppWebView)
 
@@ -136,6 +136,25 @@ class MiniAppWebviewTest {
             getWebResReq("mscheme.${miniAppWebView.appId}://".toUri()), mock())
 
         verify(displayer, times(1)).loadUrl(customDomain)
+    }
+
+    @Test
+    fun `for a WebChromeClient, it should be MiniAppWebChromeClient`() {
+        miniAppWebView.webChromeClient shouldBeInstanceOf MiniAppWebChromeClient::class
+    }
+
+    @Test
+    fun `should do js injection when there is a change in the document title`() {
+        val webChromeClient = Mockito.spy(miniAppWebView.webChromeClient as MiniAppWebChromeClient)
+        webChromeClient.onReceivedTitle(miniAppWebView, "web_title")
+
+        verify(webChromeClient, times(1)).doInjection(miniAppWebView)
+    }
+
+    @Test
+    fun `bridge js should be null when js asset is inaccessible`() {
+        val webClient = MiniAppWebChromeClient(mock())
+        webClient.bridgeJs shouldBe null
     }
 
     private fun getWebResReq(uriReq: Uri): WebResourceRequest {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStatusTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStatusTest.kt
@@ -37,7 +37,8 @@ class MiniAppStatusTest {
 
     @Test
     fun `localVersion should be saved in storage`() {
-        miniAppStatus.localVersion = TEST_ID_MINIAPP_VERSION
-        MiniAppStatus(ApplicationProvider.getApplicationContext()).localVersion shouldBe TEST_ID_MINIAPP_VERSION
+        miniAppStatus.saveDownloadedVersion(TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
+        MiniAppStatus(ApplicationProvider.getApplicationContext()).getDownloadedVersion(
+            TEST_ID_MINIAPP) shouldBe TEST_ID_MINIAPP_VERSION
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStatusTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStatusTest.kt
@@ -34,4 +34,10 @@ class MiniAppStatusTest {
         miniAppStatus.isVersionDownloaded(
             TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION, context.filesDir.path) shouldBe true
     }
+
+    @Test
+    fun `localVersion should be saved in storage`() {
+        miniAppStatus.localVersion = TEST_ID_MINIAPP_VERSION
+        MiniAppStatus(ApplicationProvider.getApplicationContext()).localVersion shouldBe TEST_ID_MINIAPP_VERSION
+    }
 }

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -46,7 +46,7 @@ android {
             subscriptionKey: property("HOST_APP_PROD_SUBSCRIPTION_KEY") ?: "test-subs-key"
     ]
 
-    def buildVersion = new Date().format('yyMMddHHmm')
+    def buildVersion = System.getenv("CIRCLE_BUILD_NUM") ?: new Date().format('yyMMddHHmm')
 
     buildTypes {
         debug {

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -45,11 +45,15 @@ android {
             appId          : property("HOST_APP_PROD_ID") ?: "test-host-app-id",
             subscriptionKey: property("HOST_APP_PROD_SUBSCRIPTION_KEY") ?: "test-subs-key"
     ]
+
+    def buildVersion = new Date().format('yyMMddHHmm')
+
     buildTypes {
         debug {
             applicationIdSuffix '.debug'
             versionNameSuffix '-DEBUG'
             resValue "string", "app_name", "$appName DEBUG"
+            resValue "string", "build_version", buildVersion
             debuggable true
             minifyEnabled false
 
@@ -57,6 +61,7 @@ android {
         }
         release {
             resValue "string", "app_name", appName
+            resValue "string", "build_version", buildVersion
             debuggable true
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
@@ -66,7 +71,7 @@ android {
         staging {
             initWith release
             applicationIdSuffix '.staging'
-            versionNameSuffix '-STG'
+            versionNameSuffix "-STG-build-$buildVersion"
             resValue "string", "app_name", "$appName STG"
             matchingFallbacks = ['release', 'debug']
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -73,7 +73,7 @@ class MiniAppDisplayActivity : BaseActivity() {
             if (appId.isEmpty())
                 viewModel.obtainMiniAppDisplay(
                     this@MiniAppDisplayActivity,
-                    intent.getParcelableExtra<MiniAppInfo>(miniAppTag)!!,
+                    intent.getParcelableExtra<MiniAppInfo>(miniAppTag)!!.id,
                     miniAppMessageBridge)
             else
                 viewModel.obtainMiniAppDisplay(

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.view.View
 import androidx.lifecycle.*
 import com.rakuten.tech.mobile.miniapp.MiniApp
-import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
@@ -32,28 +31,13 @@ class MiniAppDisplayViewModel constructor(
 
     fun obtainMiniAppDisplay(
         context: Context,
-        miniAppInfo: MiniAppInfo,
-        miniAppMessageBridge: MiniAppMessageBridge
-    ) = viewModelScope.launch(Dispatchers.IO) {
-        try {
-            _isLoading.postValue(true)
-            val miniAppDisplay = miniapp.create(miniAppInfo, miniAppMessageBridge)
-            hostLifeCycle?.addObserver(miniAppDisplay)
-            _miniAppDisplay.postValue(miniAppDisplay.getMiniAppView(context))
-        } catch (e: MiniAppSdkException) {
-            e.printStackTrace()
-            _errorData.postValue(e.message)
-        } finally {
-            _isLoading.postValue(false)
-        }
-    }
-
-    fun obtainMiniAppDisplay(
-        context: Context,
         appId: String,
         miniAppMessageBridge: MiniAppMessageBridge) = viewModelScope.launch(Dispatchers.IO) {
         try {
-            obtainMiniAppDisplay(context, miniapp.fetchInfo(appId), miniAppMessageBridge)
+            _isLoading.postValue(true)
+            val miniAppDisplay = miniapp.create(appId, miniAppMessageBridge)
+            hostLifeCycle?.addObserver(miniAppDisplay)
+            _miniAppDisplay.postValue(miniAppDisplay.getMiniAppView(context))
         } catch (e: MiniAppSdkException) {
             e.printStackTrace()
             _errorData.postValue(e.message)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuBaseActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuBaseActivity.kt
@@ -70,7 +70,8 @@ abstract class SettingsMenuBaseActivity : BaseActivity() {
         subscriptionKey: EditText
     ) {
         val dialog = AlertDialog.Builder(this)
-            .setTitle(R.string.lb_app_settings)
+            .setTitle("${resources.getString(R.string.lb_app_settings)} - Build " +
+                    resources.getString(R.string.build_version))
             .setView(settingsDialog)
             .setPositiveButton(R.string.action_save, null)
             .setNegativeButton(android.R.string.cancel, null)


### PR DESCRIPTION
# Description
- Display build information in the setting menu. The build version is generated in `build.gradle` of testapp. There will the appending in apk build Version name`-build-$buildVersion`.

- From discussion & agreement, update sdk as loading miniapp with latest version. `IsLatestVersion()` is omitted.

## Links
[MINI-921](https://jira.rakuten-it.com/jira/browse/MINI-921)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
