### PR TITLE
fix: stop display error page

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
@@ -25,9 +25,19 @@ internal class MiniAppWebViewClient(
         error: WebResourceError
     ) {
         if (request.url != null && request.url.toString().startsWith(customScheme)) {
-            view.loadUrl(request.url.toString().replace(customScheme, customDomain))
+            loadWithCustomDomain(view, request.url.toString().replace(customScheme, customDomain))
             return
         }
         super.onReceivedError(view, request, error)
+    }
+
+    @Suppress("MagicNumber")
+    @VisibleForTesting
+    internal fun loadWithCustomDomain(view: WebView, requestUrl: String) {
+        view.stopLoading()
+        view.postDelayed(
+            { view.loadUrl(requestUrl) },
+            100
+        )
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewTest.kt
@@ -126,8 +126,8 @@ class MiniAppWebviewTest {
     fun `should redirect to custom domain when only loading with custom scheme`() {
         val webAssetLoader: WebViewAssetLoader = (miniAppWebView.webViewClient as MiniAppWebViewClient).loader
         val customDomain = "https://mscheme.${miniAppWebView.appId}/"
-        val webViewClient = MiniAppWebViewClient(webAssetLoader, customDomain,
-            "mscheme.${miniAppWebView.appId}://")
+        val webViewClient = Mockito.spy(MiniAppWebViewClient(webAssetLoader, customDomain,
+            "mscheme.${miniAppWebView.appId}://"))
 
         val displayer = Mockito.spy(miniAppWebView)
 
@@ -135,7 +135,7 @@ class MiniAppWebviewTest {
         webViewClient.onReceivedError(displayer,
             getWebResReq("mscheme.${miniAppWebView.appId}://".toUri()), mock())
 
-        verify(displayer, times(1)).loadUrl(customDomain)
+        verify(webViewClient, times(1)).loadWithCustomDomain(displayer, customDomain)
     }
 
     @Test

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -54,6 +54,7 @@ android {
             versionNameSuffix '-DEBUG'
             resValue "string", "app_name", "$appName DEBUG"
             resValue "string", "build_version", buildVersion
+            resValue "string", "miniapp_sdk_version", project.version
             debuggable true
             minifyEnabled false
 
@@ -62,6 +63,7 @@ android {
         release {
             resValue "string", "app_name", appName
             resValue "string", "build_version", buildVersion
+            resValue "string", "miniapp_sdk_version", project.version
             debuggable true
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuBaseActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuBaseActivity.kt
@@ -71,6 +71,7 @@ abstract class SettingsMenuBaseActivity : BaseActivity() {
     ) {
         val dialog = AlertDialog.Builder(this)
             .setTitle("${resources.getString(R.string.lb_app_settings)} - Build " +
+                    resources.getString(R.string.miniapp_sdk_version) + " - " +
                     resources.getString(R.string.build_version))
             .setView(settingsDialog)
             .setPositiveButton(R.string.action_save, null)


### PR DESCRIPTION
# Description
- Fix custom scheme error redirection.
We had implemented the redirection with custom domain before by replacing custom scheme with http on `OnReceivedError`. However, in some webview versions, the behavior of displaying error is still there even the new redirection has been called. The solution is to stop display webview then wait after a while then finally calling redirection with http.

- Display sdk version sample app as a requirement from updated ticket.

## Links
[MINI-1118](https://jira.rakuten-it.com/jira/browse/MINI-1118)
[MINI-921](https://jira.rakuten-it.com/jira/browse/MINI-921)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
