### PR TITLE
Feature: testing endpoint

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -100,7 +100,6 @@ abstract class MiniApp internal constructor() {
         internal fun init(
             context: Context,
             baseUrl: String,
-            testUrl: String?,
             isTestMode: Boolean,
             rasAppId: String,
             subscriptionKey: String,
@@ -108,17 +107,17 @@ abstract class MiniApp internal constructor() {
         ) {
             defaultConfig = MiniAppSdkConfig(
                 baseUrl = baseUrl,
-                testUrl = testUrl,
-                isTestMode = isTestMode,
                 rasAppId = rasAppId,
                 subscriptionKey = subscriptionKey,
-                hostAppVersionId = hostAppVersionId
+                hostAppVersionId = hostAppVersionId,
+                isTestMode = isTestMode
             )
             val apiClient = ApiClient(
-                baseUrl = defaultConfig.providedUrl!!,
-                rasAppId = defaultConfig.rasAppId,
-                subscriptionKey = defaultConfig.subscriptionKey,
-                hostAppVersionId = defaultConfig.hostAppVersionId
+                baseUrl = baseUrl,
+                rasAppId = rasAppId,
+                subscriptionKey = subscriptionKey,
+                hostAppVersionId = hostAppVersionId,
+                isTestMode = isTestMode
             )
             val apiClientRepository = ApiClientRepository().apply {
                 registerApiClient(defaultConfig.key, apiClient)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -96,11 +96,11 @@ abstract class MiniApp internal constructor() {
         fun instance(settings: MiniAppSdkConfig = defaultConfig): MiniApp =
             instance.apply { updateConfiguration(settings) }
 
-        @Suppress("LongMethod")
+        @Suppress("LongMethod", "LongParameterList")
         internal fun init(
             context: Context,
             baseUrl: String,
-            testUrl: String,
+            testUrl: String?,
             isTestMode: Boolean,
             rasAppId: String,
             subscriptionKey: String,
@@ -114,7 +114,12 @@ abstract class MiniApp internal constructor() {
                 subscriptionKey = subscriptionKey,
                 hostAppVersionId = hostAppVersionId
             )
-            val apiClient = createApiClient(defaultConfig)
+            val apiClient = ApiClient(
+                baseUrl = defaultConfig.providedUrl!!,
+                rasAppId = defaultConfig.rasAppId,
+                subscriptionKey = defaultConfig.subscriptionKey,
+                hostAppVersionId = defaultConfig.hostAppVersionId
+            )
             val apiClientRepository = ApiClientRepository().apply {
                 registerApiClient(defaultConfig.key, apiClient)
             }
@@ -129,12 +134,5 @@ abstract class MiniApp internal constructor() {
                 miniAppInfoFetcher = MiniAppInfoFetcher(apiClient)
             )
         }
-
-        internal fun createApiClient(newConfig: MiniAppSdkConfig) = ApiClient(
-            baseUrl = newConfig.providedUrl,
-            rasAppId = newConfig.rasAppId,
-            subscriptionKey = newConfig.subscriptionKey,
-            hostAppVersionId = newConfig.hostAppVersionId
-        )
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -100,22 +100,21 @@ abstract class MiniApp internal constructor() {
         internal fun init(
             context: Context,
             baseUrl: String,
+            testUrl: String,
+            isTestMode: Boolean,
             rasAppId: String,
             subscriptionKey: String,
             hostAppVersionId: String
         ) {
             defaultConfig = MiniAppSdkConfig(
                 baseUrl = baseUrl,
+                testUrl = testUrl,
+                isTestMode = isTestMode,
                 rasAppId = rasAppId,
                 subscriptionKey = subscriptionKey,
                 hostAppVersionId = hostAppVersionId
             )
-            val apiClient = ApiClient(
-                baseUrl = baseUrl,
-                rasAppId = rasAppId,
-                subscriptionKey = subscriptionKey,
-                hostAppVersionId = hostAppVersionId
-            )
+            val apiClient = createApiClient(defaultConfig)
             val apiClientRepository = ApiClientRepository().apply {
                 registerApiClient(defaultConfig.key, apiClient)
             }
@@ -130,5 +129,12 @@ abstract class MiniApp internal constructor() {
                 miniAppInfoFetcher = MiniAppInfoFetcher(apiClient)
             )
         }
+
+        internal fun createApiClient(newConfig: MiniAppSdkConfig) = ApiClient(
+            baseUrl = newConfig.providedUrl,
+            rasAppId = newConfig.rasAppId,
+            subscriptionKey = newConfig.subscriptionKey,
+            hostAppVersionId = newConfig.hostAppVersionId
+        )
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -11,13 +11,13 @@ package com.rakuten.tech.mobile.miniapp
  */
 data class MiniAppSdkConfig(
     private var baseUrl: String,
-    private var testUrl: String,
+    private var testUrl: String?,
     var isTestMode: Boolean,
     var rasAppId: String,
     var subscriptionKey: String,
     var hostAppVersionId: String
 ) {
-    internal val providedUrl = if (isTestMode) testUrl else baseUrl
+    internal val providedUrl: String? = if (isTestMode) testUrl else baseUrl
     internal val key = "$providedUrl-$rasAppId-$subscriptionKey-$hostAppVersionId"
 
     init {
@@ -34,4 +34,4 @@ data class MiniAppSdkConfig(
     }
 }
 
-private fun isBaseUrlValid(url: String) = url.startsWith("https://")
+private fun isBaseUrlValid(url: String?) = url != null && url.startsWith("https://")

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -2,23 +2,28 @@ package com.rakuten.tech.mobile.miniapp
 
 /**
  * This represents the configuration settings for the Mini App SDK.
- * @property baseUrl Base URL used for retrieving a Mini App.
+ * @property baseUrl Url endpoint for the published mini apps.
+ * @property testUrl Url endpoint for the testing mini apps.
+ * @property isTestMode Whether the sdk is running in Testing mode.
  * @property rasAppId App ID for the Platform API.
  * @property subscriptionKey Subscription Key for the Platform API.
  * @property hostAppVersionId Version of the host app, used to determine feature compatibility for Mini App.
  */
 data class MiniAppSdkConfig(
-    var baseUrl: String,
+    private var baseUrl: String,
+    private var testUrl: String,
+    var isTestMode: Boolean,
     var rasAppId: String,
     var subscriptionKey: String,
     var hostAppVersionId: String
 ) {
-    internal val key = "$baseUrl-$rasAppId-$subscriptionKey-$hostAppVersionId"
+    internal val providedUrl = if (isTestMode) testUrl else baseUrl
+    internal val key = "$providedUrl-$rasAppId-$subscriptionKey-$hostAppVersionId"
 
     init {
         when {
-            !isBaseUrlValid(baseUrl) ->
-                throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid baseUrl")
+            !isBaseUrlValid(providedUrl) ->
+                throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid url endpoint")
             rasAppId.isBlank() ->
                 throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid rasAppId")
             subscriptionKey.isBlank() ->

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -10,12 +10,12 @@ package com.rakuten.tech.mobile.miniapp
  * @property hostAppVersionId Version of the host app, used to determine feature compatibility for Mini App.
  */
 data class MiniAppSdkConfig(
-    private var baseUrl: String,
-    private var testUrl: String?,
-    var isTestMode: Boolean,
-    var rasAppId: String,
-    var subscriptionKey: String,
-    var hostAppVersionId: String
+    private val baseUrl: String,
+    private val testUrl: String?,
+    val isTestMode: Boolean,
+    val rasAppId: String,
+    val subscriptionKey: String,
+    val hostAppVersionId: String
 ) {
     internal val providedUrl: String? = if (isTestMode) testUrl else baseUrl
     internal val key = "$providedUrl-$rasAppId-$subscriptionKey-$hostAppVersionId"

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -2,28 +2,25 @@ package com.rakuten.tech.mobile.miniapp
 
 /**
  * This represents the configuration settings for the Mini App SDK.
- * @property baseUrl Url endpoint for the published mini apps.
- * @property testUrl Url endpoint for the testing mini apps.
+ * @property baseUrl Base URL used for retrieving a Mini App.
  * @property isTestMode Whether the sdk is running in Testing mode.
  * @property rasAppId App ID for the Platform API.
  * @property subscriptionKey Subscription Key for the Platform API.
  * @property hostAppVersionId Version of the host app, used to determine feature compatibility for Mini App.
  */
 data class MiniAppSdkConfig(
-    private val baseUrl: String,
-    private val testUrl: String?,
-    val isTestMode: Boolean,
+    val baseUrl: String,
     val rasAppId: String,
     val subscriptionKey: String,
-    val hostAppVersionId: String
+    val hostAppVersionId: String,
+    val isTestMode: Boolean
 ) {
-    internal val providedUrl: String? = if (isTestMode) testUrl else baseUrl
-    internal val key = "$providedUrl-$rasAppId-$subscriptionKey-$hostAppVersionId"
+    internal val key = "$baseUrl-$isTestMode-$rasAppId-$subscriptionKey-$hostAppVersionId"
 
     init {
         when {
-            !isBaseUrlValid(providedUrl) ->
-                throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid url endpoint")
+            !isBaseUrlValid(baseUrl) ->
+                throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid baseUrl")
             rasAppId.isBlank() ->
                 throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid rasAppId")
             subscriptionKey.isBlank() ->
@@ -34,4 +31,4 @@ data class MiniAppSdkConfig(
     }
 }
 
-private fun isBaseUrlValid(url: String?) = url != null && url.startsWith("https://")
+private fun isBaseUrlValid(url: String) = url.startsWith("https://")

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -22,10 +22,22 @@ class MiniappSdkInitializer : ContentProvider() {
     interface App {
 
         /**
-         * Base Url for the mini app backend.
+         * Url endpoint for the published mini apps.
          **/
         @MetaData(key = "com.rakuten.tech.mobile.miniapp.BaseUrl")
         fun baseUrl(): String
+
+        /**
+         * Url endpoint for the testing mini apps.
+         **/
+        @MetaData(key = "com.rakuten.tech.mobile.miniapp.TestUrl")
+        fun testUrl(): String
+
+        /**
+         * Whether the sdk is running in Testing mode.
+         **/
+        @MetaData(key = "com.rakuten.tech.mobile.miniapp.IsTestMode")
+        fun isTestMode(): Boolean
 
         /**
          * Host app version for the mini app backend.
@@ -53,6 +65,8 @@ class MiniappSdkInitializer : ContentProvider() {
         MiniApp.init(
             context = context,
             baseUrl = manifestConfig.baseUrl(),
+            testUrl = manifestConfig.testUrl(),
+            isTestMode = manifestConfig.isTestMode(),
             rasAppId = manifestConfig.rasAppId(),
             subscriptionKey = manifestConfig.subscriptionKey(),
             hostAppVersionId = manifestConfig.hostAppVersion()

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -22,16 +22,10 @@ class MiniappSdkInitializer : ContentProvider() {
     interface App {
 
         /**
-         * Url endpoint for the published mini apps.
+         * Base URL used for retrieving a Mini App.
          **/
         @MetaData(key = "com.rakuten.tech.mobile.miniapp.BaseUrl")
         fun baseUrl(): String
-
-        /**
-         * Url endpoint for the testing mini apps.
-         **/
-        @MetaData(key = "com.rakuten.tech.mobile.miniapp.TestUrl")
-        fun testUrl(): String
 
         /**
          * Whether the sdk is running in Testing mode.
@@ -65,11 +59,10 @@ class MiniappSdkInitializer : ContentProvider() {
         MiniApp.init(
             context = context,
             baseUrl = manifestConfig.baseUrl(),
-            testUrl = manifestConfig.testUrl(),
-            isTestMode = manifestConfig.isTestMode(),
             rasAppId = manifestConfig.rasAppId(),
             subscriptionKey = manifestConfig.subscriptionKey(),
-            hostAppVersionId = manifestConfig.hostAppVersion()
+            hostAppVersionId = manifestConfig.hostAppVersion(),
+            isTestMode = manifestConfig.isTestMode()
         )
 
         return true

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -1,7 +1,5 @@
 package com.rakuten.tech.mobile.miniapp
 
-import androidx.annotation.VisibleForTesting
-import com.rakuten.tech.mobile.miniapp.api.ApiClient
 import com.rakuten.tech.mobile.miniapp.api.ApiClientRepository
 import com.rakuten.tech.mobile.miniapp.display.Displayer
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
@@ -59,13 +57,4 @@ internal class RealMiniApp(
             miniAppInfoFetcher.updateApiClient(it)
         }
     }
-
-    @VisibleForTesting
-    internal fun createApiClient(newConfig: MiniAppSdkConfig) =
-        ApiClient(
-            baseUrl = newConfig.baseUrl,
-            rasAppId = newConfig.rasAppId,
-            subscriptionKey = newConfig.subscriptionKey,
-            hostAppVersionId = newConfig.hostAppVersionId
-        )
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -62,9 +62,10 @@ internal class RealMiniApp(
 
     @VisibleForTesting
     internal fun createApiClient(newConfig: MiniAppSdkConfig) = ApiClient(
-        baseUrl = newConfig.providedUrl!!,
+        baseUrl = newConfig.baseUrl,
         rasAppId = newConfig.rasAppId,
         subscriptionKey = newConfig.subscriptionKey,
-        hostAppVersionId = newConfig.hostAppVersionId
+        hostAppVersionId = newConfig.hostAppVersionId,
+        isTestMode = newConfig.isTestMode
     )
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -1,5 +1,7 @@
 package com.rakuten.tech.mobile.miniapp
 
+import androidx.annotation.VisibleForTesting
+import com.rakuten.tech.mobile.miniapp.api.ApiClient
 import com.rakuten.tech.mobile.miniapp.api.ApiClientRepository
 import com.rakuten.tech.mobile.miniapp.display.Displayer
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
@@ -57,4 +59,12 @@ internal class RealMiniApp(
             miniAppInfoFetcher.updateApiClient(it)
         }
     }
+
+    @VisibleForTesting
+    internal fun createApiClient(newConfig: MiniAppSdkConfig) = ApiClient(
+        baseUrl = newConfig.providedUrl!!,
+        rasAppId = newConfig.rasAppId,
+        subscriptionKey = newConfig.subscriptionKey,
+        hostAppVersionId = newConfig.hostAppVersionId
+    )
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -18,6 +18,7 @@ import java.net.UnknownHostException
 
 internal class ApiClient @VisibleForTesting constructor(
     retrofit: Retrofit,
+    private val isTestMode: Boolean,
     private val hostAppVersionId: String,
     private val hostAppId: String,
     private val appInfoApi: AppInfoApi = retrofit.create(AppInfoApi::class.java),
@@ -30,26 +31,37 @@ internal class ApiClient @VisibleForTesting constructor(
         baseUrl: String,
         rasAppId: String,
         subscriptionKey: String,
-        hostAppVersionId: String
+        hostAppVersionId: String,
+        isTestMode: Boolean = false
     ) : this(
         retrofit = createRetrofitClient(
             baseUrl = baseUrl,
             rasAppId = rasAppId,
             subscriptionKey = subscriptionKey
         ),
+        isTestMode = isTestMode,
         hostAppVersionId = hostAppVersionId,
         hostAppId = rasAppId
     )
 
+    private val testPath = if (isTestMode) "test" else ""
+
     @Throws(MiniAppSdkException::class)
     suspend fun list(): List<MiniAppInfo> {
-        val request = appInfoApi.list(hostAppId, hostAppVersionId)
+        val request = appInfoApi.list(
+            hostAppId = hostAppId,
+            hostAppVersionId = hostAppVersionId,
+            testPath = testPath)
         return requestExecutor.executeRequest(request)
     }
 
     @Throws(MiniAppSdkException::class)
     suspend fun fetchInfo(appId: String): MiniAppInfo {
-        val request = appInfoApi.fetchInfo(hostAppId, hostAppVersionId, appId)
+        val request = appInfoApi.fetchInfo(
+            hostAppId = hostAppId,
+            hostAppVersionId = hostAppVersionId,
+            miniAppId = appId,
+            testPath = testPath)
         val info = requestExecutor.executeRequest(request)
 
         if (info.isNotEmpty()) {
@@ -64,7 +76,8 @@ internal class ApiClient @VisibleForTesting constructor(
             hostAppId = hostAppId,
             miniAppId = miniAppId,
             versionId = versionId,
-            hostAppVersionId = hostAppVersionId
+            hostAppVersionId = hostAppVersionId,
+            testPath = testPath
         )
         return requestExecutor.executeRequest(request)
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/AppInfoApi.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/AppInfoApi.kt
@@ -8,16 +8,17 @@ import retrofit2.http.Query
 
 internal interface AppInfoApi {
 
-    @GET("host/{hostappId}/miniapps")
+    @GET("host/{hostappId}/miniapps/{testPath}")
     fun list(
         @Path("hostappId") hostAppId: String,
+        @Path("testPath") testPath: String = "",
         @Query("hostVersion") hostAppVersionId: String
     ): Call<List<MiniAppInfo>>
 
-    @GET("host/{hostappId}/miniapps")
+    @GET("host/{hostappId}/miniapps/{testPath}")
     fun fetchInfo(
-        // for readability, maintainability & avoiding `null` default init for optional query param
         @Path("hostappId") hostAppId: String,
+        @Path("testPath") testPath: String = "",
         @Query("hostVersion") hostAppVersionId: String,
         @Query("miniAppId") miniAppId: String
     ): Call<List<MiniAppInfo>>

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ManifestApi.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ManifestApi.kt
@@ -7,11 +7,13 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 
 internal interface ManifestApi {
-    @GET("host/{hostappId}/miniapp/{miniappId}/version/{versionId}/manifest")
+    // double slash is okay
+    @GET("host/{hostappId}/miniapp/{miniappId}/version/{versionId}/{testPath}/manifest")
     fun fetchFileListFromManifest(
         @Path("hostappId") hostAppId: String,
         @Path("miniappId") miniAppId: String,
         @Path("versionId") versionId: String,
+        @Path("testPath") testPath: String = "",
         @Query("hostVersion") hostAppVersionId: String
     ): Call<ManifestEntity>
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfigSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfigSpec.kt
@@ -1,36 +1,31 @@
 package com.rakuten.tech.mobile.miniapp
 
+import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldEqual
 import org.junit.Test
 
 class MiniAppSdkConfigSpec {
 
     @Test
-    fun `should initialize successfully for valid properties`() {
-        MiniAppSdkConfig(
-            baseUrl = TEST_URL_HTTPS_1,
-            rasAppId = TEST_HA_ID_APP,
-            subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
-            hostAppVersionId = TEST_HA_ID_VERSION
-        )
-    }
-
-    @Test
     fun `the key pattern should match the defined scheme`() {
         val config = MiniAppSdkConfig(
-            baseUrl = TEST_URL_HTTPS_1,
+            baseUrl = TEST_URL_HTTPS_2,
+            testUrl = TEST_URL_HTTPS_2,
+            isTestMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION
         )
         config.key shouldEqual
-                "${config.baseUrl}-${config.rasAppId}-${config.subscriptionKey}-${config.hostAppVersionId}"
+                "${config.providedUrl}-${config.rasAppId}-${config.subscriptionKey}-${config.hostAppVersionId}"
     }
 
     @Test(expected = MiniAppSdkException::class)
     fun `should throw exception when api url is not https`() {
         MiniAppSdkConfig(
             baseUrl = "http://www.example.com/1",
+            testUrl = TEST_URL_HTTPS_2,
+            isTestMode = false,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION
@@ -40,7 +35,9 @@ class MiniAppSdkConfigSpec {
     @Test(expected = MiniAppSdkException::class)
     fun `should throw exception when api url is blank`() {
         MiniAppSdkConfig(
-            baseUrl = " ",
+            baseUrl = TEST_URL_HTTPS_2,
+            testUrl = " ",
+            isTestMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION
@@ -50,7 +47,9 @@ class MiniAppSdkConfigSpec {
     @Test(expected = MiniAppSdkException::class)
     fun `should throw exception when rasAppId is blank`() {
         MiniAppSdkConfig(
-            baseUrl = TEST_URL_HTTPS_1,
+            baseUrl = TEST_URL_HTTPS_2,
+            testUrl = TEST_URL_HTTPS_2,
+            isTestMode = true,
             rasAppId = " ",
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION
@@ -60,7 +59,9 @@ class MiniAppSdkConfigSpec {
     @Test(expected = MiniAppSdkException::class)
     fun `should throw exception when subscriptionKey is blank`() {
         MiniAppSdkConfig(
-            baseUrl = TEST_URL_HTTPS_1,
+            baseUrl = TEST_URL_HTTPS_2,
+            testUrl = TEST_URL_HTTPS_2,
+            isTestMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = " ",
             hostAppVersionId = TEST_HA_ID_VERSION
@@ -70,10 +71,33 @@ class MiniAppSdkConfigSpec {
     @Test(expected = MiniAppSdkException::class)
     fun `should throw exception when hostAppVersionId is blank`() {
         MiniAppSdkConfig(
-            baseUrl = TEST_URL_HTTPS_1,
+            baseUrl = TEST_URL_HTTPS_2,
+            testUrl = TEST_URL_HTTPS_2,
+            isTestMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = " "
         )
+    }
+
+    @Test
+    fun `should providing correct url type`() {
+        MiniAppSdkConfig(
+            baseUrl = TEST_URL_HTTPS_2,
+            testUrl = "$TEST_URL_HTTPS_2/test/",
+            isTestMode = false,
+            rasAppId = TEST_HA_ID_APP,
+            subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
+            hostAppVersionId = TEST_HA_ID_VERSION
+        ).providedUrl shouldBe TEST_URL_HTTPS_2
+
+        MiniAppSdkConfig(
+            baseUrl = TEST_URL_HTTPS_2,
+            testUrl = "$TEST_URL_HTTPS_2/test/",
+            isTestMode = true,
+            rasAppId = TEST_HA_ID_APP,
+            subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
+            hostAppVersionId = TEST_HA_ID_VERSION
+        ).providedUrl shouldBe "$TEST_URL_HTTPS_2/test/"
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfigSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfigSpec.kt
@@ -45,6 +45,18 @@ class MiniAppSdkConfigSpec {
     }
 
     @Test(expected = MiniAppSdkException::class)
+    fun `should throw exception when test api is null in test mode`() {
+        MiniAppSdkConfig(
+            baseUrl = TEST_URL_HTTPS_2,
+            testUrl = null,
+            isTestMode = true,
+            rasAppId = TEST_HA_ID_APP,
+            subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
+            hostAppVersionId = TEST_HA_ID_VERSION
+        )
+    }
+
+    @Test(expected = MiniAppSdkException::class)
     fun `should throw exception when rasAppId is blank`() {
         MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
@@ -80,16 +92,19 @@ class MiniAppSdkConfigSpec {
         )
     }
 
+    @Suppress("LongMethod")
     @Test
     fun `should providing correct url type`() {
-        MiniAppSdkConfig(
+        val config = MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
             testUrl = "$TEST_URL_HTTPS_2/test/",
             isTestMode = false,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION
-        ).providedUrl shouldBe TEST_URL_HTTPS_2
+        )
+        config.isTestMode shouldBe false
+        config.providedUrl shouldBe TEST_URL_HTTPS_2
 
         MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfigSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfigSpec.kt
@@ -95,7 +95,7 @@ class MiniAppSdkConfigSpec {
     @Suppress("LongMethod")
     @Test
     fun `should providing correct url type`() {
-        val config = MiniAppSdkConfig(
+        val regularConfig = MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
             testUrl = "$TEST_URL_HTTPS_2/test/",
             isTestMode = false,
@@ -103,16 +103,18 @@ class MiniAppSdkConfigSpec {
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION
         )
-        config.isTestMode shouldBe false
-        config.providedUrl shouldBe TEST_URL_HTTPS_2
+        regularConfig.isTestMode shouldBe false
+        regularConfig.providedUrl shouldBe TEST_URL_HTTPS_2
 
-        MiniAppSdkConfig(
+        val testConfig = MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
             testUrl = "$TEST_URL_HTTPS_2/test/",
             isTestMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION
-        ).providedUrl shouldBe "$TEST_URL_HTTPS_2/test/"
+        )
+        testConfig.isTestMode shouldBe true
+        testConfig.providedUrl shouldBe "$TEST_URL_HTTPS_2/test/"
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfigSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfigSpec.kt
@@ -1,6 +1,5 @@
 package com.rakuten.tech.mobile.miniapp
 
-import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldEqual
 import org.junit.Test
 
@@ -10,21 +9,19 @@ class MiniAppSdkConfigSpec {
     fun `the key pattern should match the defined scheme`() {
         val config = MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
-            testUrl = TEST_URL_HTTPS_2,
             isTestMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION
         )
-        config.key shouldEqual
-                "${config.providedUrl}-${config.rasAppId}-${config.subscriptionKey}-${config.hostAppVersionId}"
+        config.key shouldEqual "${config.baseUrl}-${config.isTestMode}" +
+                "-${config.rasAppId}-${config.subscriptionKey}-${config.hostAppVersionId}"
     }
 
     @Test(expected = MiniAppSdkException::class)
     fun `should throw exception when api url is not https`() {
         MiniAppSdkConfig(
             baseUrl = "http://www.example.com/1",
-            testUrl = TEST_URL_HTTPS_2,
             isTestMode = false,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
@@ -35,20 +32,7 @@ class MiniAppSdkConfigSpec {
     @Test(expected = MiniAppSdkException::class)
     fun `should throw exception when api url is blank`() {
         MiniAppSdkConfig(
-            baseUrl = TEST_URL_HTTPS_2,
-            testUrl = " ",
-            isTestMode = true,
-            rasAppId = TEST_HA_ID_APP,
-            subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
-            hostAppVersionId = TEST_HA_ID_VERSION
-        )
-    }
-
-    @Test(expected = MiniAppSdkException::class)
-    fun `should throw exception when test api is null in test mode`() {
-        MiniAppSdkConfig(
-            baseUrl = TEST_URL_HTTPS_2,
-            testUrl = null,
+            baseUrl = " ",
             isTestMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
@@ -60,7 +44,6 @@ class MiniAppSdkConfigSpec {
     fun `should throw exception when rasAppId is blank`() {
         MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
-            testUrl = TEST_URL_HTTPS_2,
             isTestMode = true,
             rasAppId = " ",
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
@@ -72,7 +55,6 @@ class MiniAppSdkConfigSpec {
     fun `should throw exception when subscriptionKey is blank`() {
         MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
-            testUrl = TEST_URL_HTTPS_2,
             isTestMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = " ",
@@ -84,37 +66,10 @@ class MiniAppSdkConfigSpec {
     fun `should throw exception when hostAppVersionId is blank`() {
         MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
-            testUrl = TEST_URL_HTTPS_2,
             isTestMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = " "
         )
-    }
-
-    @Suppress("LongMethod")
-    @Test
-    fun `should providing correct url type`() {
-        val regularConfig = MiniAppSdkConfig(
-            baseUrl = TEST_URL_HTTPS_2,
-            testUrl = "$TEST_URL_HTTPS_2/test/",
-            isTestMode = false,
-            rasAppId = TEST_HA_ID_APP,
-            subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
-            hostAppVersionId = TEST_HA_ID_VERSION
-        )
-        regularConfig.isTestMode shouldBe false
-        regularConfig.providedUrl shouldBe TEST_URL_HTTPS_2
-
-        val testConfig = MiniAppSdkConfig(
-            baseUrl = TEST_URL_HTTPS_2,
-            testUrl = "$TEST_URL_HTTPS_2/test/",
-            isTestMode = true,
-            rasAppId = TEST_HA_ID_APP,
-            subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
-            hostAppVersionId = TEST_HA_ID_VERSION
-        )
-        testConfig.isTestMode shouldBe true
-        testConfig.providedUrl shouldBe "$TEST_URL_HTTPS_2/test/"
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSpec.kt
@@ -30,8 +30,7 @@ class MiniAppSpec {
         AppInfo.instance = mock()
         MiniApp.init(
             context = getApplicationContext(),
-            baseUrl = TEST_URL_HTTPS_1,
-            testUrl = TEST_URL_HTTPS_2,
+            baseUrl = TEST_URL_HTTPS_2,
             isTestMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSpec.kt
@@ -30,7 +30,9 @@ class MiniAppSpec {
         AppInfo.instance = mock()
         MiniApp.init(
             context = getApplicationContext(),
-            baseUrl = TEST_URL_HTTPS_2,
+            baseUrl = TEST_URL_HTTPS_1,
+            testUrl = TEST_URL_HTTPS_2,
+            isTestMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializerSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializerSpec.kt
@@ -33,6 +33,7 @@ class MiniappSdkInitializerSpec {
 
         When calling sdkInitializer.context itReturns context
         When calling sdkInitializer.createAppManifestConfig(context) itReturns appManifestConfig
+        When calling appManifestConfig.isTestMode() itReturns false
         When calling appManifestConfig.baseUrl() itReturns TEST_URL_HTTPS_2
         When calling appManifestConfig.rasAppId() itReturns TEST_HA_ID_APP
         When calling appManifestConfig.subscriptionKey() itReturns TEST_HA_SUBSCRIPTION_KEY

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -98,6 +98,8 @@ class RealMiniAppSpec {
         val miniApp = Mockito.spy(realMiniApp)
         val miniAppSdkConfig = MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
+            testUrl = TEST_URL_HTTPS_2,
+            isTestMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -98,7 +98,6 @@ class RealMiniAppSpec {
         val miniApp = Mockito.spy(realMiniApp)
         val miniAppSdkConfig = MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
-            testUrl = TEST_URL_HTTPS_2,
             isTestMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
@@ -34,7 +34,7 @@ open class ApiClientSpec {
     fun `should fetch the list of mini apps`() = runBlockingTest {
         val mockCall: Call<List<MiniAppInfo>> = mock()
 
-        When calling mockAppInfoApi.list(any(), any()) itReturns mockCall
+        When calling mockAppInfoApi.list(any(), any(), any()) itReturns mockCall
         When calling mockRequestExecutor.executeRequest(mockCall) itReturns listOf(miniAppInfo)
 
         val apiClient = createApiClient(appInfoApi = mockAppInfoApi)
@@ -48,7 +48,7 @@ open class ApiClientSpec {
         val mockCall: Call<ManifestEntity> = mock()
         When calling
                 mockManifestApi
-                    .fetchFileListFromManifest(any(), any(), any(), any()) itReturns mockCall
+                    .fetchFileListFromManifest(any(), any(), any(), any(), any()) itReturns mockCall
         When calling
                 mockRequestExecutor
                     .executeRequest(mockCall) itReturns ManifestEntity(fileList)
@@ -82,7 +82,7 @@ open class ApiClientSpec {
     fun `should fetch meta data for a mini app for a given appId`() = runBlockingTest {
         val mockCall: Call<List<MiniAppInfo>> = mock()
 
-        When calling mockAppInfoApi.fetchInfo(any(), any(), any()) itReturns mockCall
+        When calling mockAppInfoApi.fetchInfo(any(), any(), any(), any()) itReturns mockCall
         When calling mockRequestExecutor.executeRequest(mockCall) itReturns listOf(miniAppInfo)
 
         val apiClient = createApiClient(appInfoApi = mockAppInfoApi)
@@ -95,7 +95,7 @@ open class ApiClientSpec {
         val secondItem = miniAppInfo.copy()
         val resultList = listOf(miniAppInfo, secondItem)
 
-        When calling mockAppInfoApi.fetchInfo(any(), any(), any()) itReturns mockCall
+        When calling mockAppInfoApi.fetchInfo(any(), any(), any(), any()) itReturns mockCall
         When calling mockRequestExecutor.executeRequest(mockCall) itReturns resultList
 
         val apiClient = createApiClient(appInfoApi = mockAppInfoApi)
@@ -106,11 +106,10 @@ open class ApiClientSpec {
     fun `fetchInfo should throw MiniAppSdkException when the API returns zero items`() = runBlockingTest {
         val mockCall: Call<List<MiniAppInfo>> = mock()
 
-        When calling mockAppInfoApi.fetchInfo(any(), any(), any()) itReturns mockCall
+        When calling mockAppInfoApi.fetchInfo(any(), any(), any(), any()) itReturns mockCall
         When calling mockRequestExecutor.executeRequest(mockCall) itReturns emptyList()
 
         val apiClient = createApiClient(appInfoApi = mockAppInfoApi)
-
         apiClient.fetchInfo("test-app-id")
     }
 
@@ -127,7 +126,7 @@ open class ApiClientSpec {
         When calling mockRetrofitClient.create(ManifestApi::class.java) itReturns mockManifestApi
         When calling mockRetrofitClient.create(DownloadApi::class.java) itReturns mockDownloadApi
 
-        ApiClient(mockRetrofitClient, TEST_HA_ID_APP, TEST_HA_ID_VERSION).downloadFile(TEST_URL_FILE)
+        ApiClient(mockRetrofitClient, false, TEST_HA_ID_APP, TEST_HA_ID_VERSION).downloadFile(TEST_URL_FILE)
     }
 
     @Test
@@ -160,6 +159,7 @@ open class ApiClientSpec {
         downloadApi: DownloadApi = mockDownloadApi
     ) = ApiClient(
         retrofit = retrofit,
+        isTestMode = false,
         hostAppId = hostAppId,
         hostAppVersionId = hostAppVersionId,
         requestExecutor = requestExecutor,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/AppInfoApiSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/AppInfoApiSpec.kt
@@ -53,14 +53,21 @@ class AppInfoApiRequestSpec : AppInfoApiSpec() {
     fun `should fetch mini apps using the 'miniapps' endpoint`() {
         executeListingCallByRetrofit()
         val requestUrl = mockServer.takeRequest().requestUrl!!
-        requestUrl.encodedPath shouldEndWith "miniapps"
+
+        requestUrl.encodedPath shouldEndWith "miniapps/"
         requestUrl.encodedQuery.toString() shouldContain "hostVersion=$TEST_HA_ID_VERSION"
     }
 
     @Test
-    fun `should fetch mini apps for the provided host app version`() {
-        executeListingCallByRetrofit()
-        mockServer.takeRequest().path!! shouldContain "test_version"
+    fun `should fetch mini apps for the provided host app version in test mode`() {
+        mockServer.enqueue(createResponse())
+        retrofit.create(AppInfoApi::class.java)
+            .list(hostAppId = TEST_HA_ID_APP, hostAppVersionId = TEST_HA_ID_VERSION, testPath = "test")
+            .execute()
+        val request = mockServer.takeRequest()
+
+        request.requestUrl!!.encodedPath shouldEndWith "miniapps/test"
+        request.path!! shouldContain "test_version"
     }
 
     private fun executeListingCallByRetrofit() {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiSpec.kt
@@ -57,6 +57,20 @@ class ManifestApiRequestSpec : ManifestApiSpec() {
                 "miniapp/$TEST_ID_MINIAPP/version/$TEST_ID_MINIAPP_VERSION/"
     }
 
+    @Test
+    fun `should have test endpoint when in test mode`() {
+        mockServer.enqueue(createResponse())
+        retrofit.create(ManifestApi::class.java)
+            .fetchFileListFromManifest(
+                hostAppId = TEST_HA_ID_APP,
+                miniAppId = TEST_ID_MINIAPP,
+                versionId = TEST_ID_MINIAPP_VERSION,
+                hostAppVersionId = TEST_HA_ID_VERSION,
+                testPath = "test"
+            ).execute()
+        mockServer.takeRequest().path!! shouldContain "test"
+    }
+
     private fun executeManifestCallByRetrofit() {
         mockServer.enqueue(createResponse())
         retrofit.create(ManifestApi::class.java)
@@ -78,10 +92,10 @@ class ManifestApiResponseSpec : ManifestApiSpec() {
         mockServer.enqueue(createResponse())
         manifestEntity = retrofit.create(ManifestApi::class.java)
             .fetchFileListFromManifest(
-                TEST_HA_ID_APP,
-                TEST_ID_MINIAPP,
-                TEST_ID_MINIAPP_VERSION,
-                TEST_HA_ID_VERSION
+                hostAppId = TEST_HA_ID_APP,
+                miniAppId = TEST_ID_MINIAPP,
+                versionId = TEST_ID_MINIAPP_VERSION,
+                hostAppVersionId = TEST_HA_ID_VERSION
             )
             .execute().body()!!
     }

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -35,7 +35,6 @@ android {
     def appName = "Mini App Sample"
     def stagingManifestPlaceholders = [
             baseUrl        : property("MINIAPP_SERVER_BASE_URL") ?: "https://www.example.com/",
-            testUrl        : property("MINIAPP_SERVER_TEST_URL") ?: "https://www.example.com/",
             isTestMode     : property("IS_TEST_MODE") ?: false,
             hostAppVersion : property("HOST_APP_VERSION") ?: "test-host-app-version",
             appId          : property("HOST_APP_ID") ?: "test-host-app-id",
@@ -43,7 +42,6 @@ android {
     ]
     def prodManifestPlaceholders = [
             baseUrl         : property("MINIAPP_PROD_SERVER_BASE_URL") ?: "https://www.example.com/",
-            testUrl         : property("MINIAPP_PROD_SERVER_TEST_URL") ?: "https://www.example.com/",
             isTestMode      : property("PROD_IS_TEST_MODE") ?: false,
             hostAppVersion  : property("HOST_APP_PROD_VERSION") ?: "test-host-app-version",
             appId           : property("HOST_APP_PROD_ID") ?: "test-host-app-id",

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -43,7 +43,7 @@ android {
     ]
     def prodManifestPlaceholders = [
             baseUrl         : property("MINIAPP_PROD_SERVER_BASE_URL") ?: "https://www.example.com/",
-            testUrl         : property("MINIAPP_SERVER_TEST_URL") ?: "https://www.example.com/",
+            testUrl         : property("MINIAPP_PROD_SERVER_TEST_URL") ?: "https://www.example.com/",
             isTestMode      : property("PROD_IS_TEST_MODE") ?: false,
             hostAppVersion  : property("HOST_APP_PROD_VERSION") ?: "test-host-app-version",
             appId           : property("HOST_APP_PROD_ID") ?: "test-host-app-id",

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -36,7 +36,7 @@ android {
     def stagingManifestPlaceholders = [
             baseUrl        : property("MINIAPP_SERVER_BASE_URL") ?: "https://www.example.com/",
             testUrl        : property("MINIAPP_SERVER_TEST_URL") ?: "https://www.example.com/",
-            isTestMode     : true,
+            isTestMode     : property("IS_TEST_MODE") ?: false,
             hostAppVersion : property("HOST_APP_VERSION") ?: "test-host-app-version",
             appId          : property("HOST_APP_ID") ?: "test-host-app-id",
             subscriptionKey: property("HOST_APP_SUBSCRIPTION_KEY") ?: "test-subs-key"
@@ -44,7 +44,7 @@ android {
     def prodManifestPlaceholders = [
             baseUrl         : property("MINIAPP_PROD_SERVER_BASE_URL") ?: "https://www.example.com/",
             testUrl         : property("MINIAPP_SERVER_TEST_URL") ?: "https://www.example.com/",
-            isTestMode      : false,
+            isTestMode      : property("PROD_IS_TEST_MODE") ?: false,
             hostAppVersion  : property("HOST_APP_PROD_VERSION") ?: "test-host-app-version",
             appId           : property("HOST_APP_PROD_ID") ?: "test-host-app-id",
             subscriptionKey : property("HOST_APP_PROD_SUBSCRIPTION_KEY") ?: "test-subs-key"

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -35,15 +35,19 @@ android {
     def appName = "Mini App Sample"
     def stagingManifestPlaceholders = [
             baseUrl        : property("MINIAPP_SERVER_BASE_URL") ?: "https://www.example.com/",
+            testUrl        : property("MINIAPP_SERVER_TEST_URL") ?: "https://www.example.com/",
+            isTestMode     : true,
             hostAppVersion : property("HOST_APP_VERSION") ?: "test-host-app-version",
             appId          : property("HOST_APP_ID") ?: "test-host-app-id",
             subscriptionKey: property("HOST_APP_SUBSCRIPTION_KEY") ?: "test-subs-key"
     ]
     def prodManifestPlaceholders = [
-            baseUrl        : property("MINIAPP_PROD_SERVER_BASE_URL") ?: "https://www.example.com/",
-            hostAppVersion : property("HOST_APP_PROD_VERSION") ?: "test-host-app-version",
-            appId          : property("HOST_APP_PROD_ID") ?: "test-host-app-id",
-            subscriptionKey: property("HOST_APP_PROD_SUBSCRIPTION_KEY") ?: "test-subs-key"
+            baseUrl         : property("MINIAPP_PROD_SERVER_BASE_URL") ?: "https://www.example.com/",
+            testUrl         : property("MINIAPP_SERVER_TEST_URL") ?: "https://www.example.com/",
+            isTestMode      : false,
+            hostAppVersion  : property("HOST_APP_PROD_VERSION") ?: "test-host-app-version",
+            appId           : property("HOST_APP_PROD_ID") ?: "test-host-app-id",
+            subscriptionKey : property("HOST_APP_PROD_SUBSCRIPTION_KEY") ?: "test-subs-key"
     ]
 
     def buildVersion = System.getenv("CIRCLE_BUILD_NUM") ?: new Date().format('yyMMddHHmm')

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -30,6 +30,12 @@
             android:name="com.rakuten.tech.mobile.miniapp.BaseUrl"
             android:value="${baseUrl}" />
         <meta-data
+            android:name="com.rakuten.tech.mobile.miniapp.TestUrl"
+            android:value="${testUrl}" />
+        <meta-data
+            android:name="com.rakuten.tech.mobile.miniapp.IsTestMode"
+            android:value="${isTestMode}" />
+        <meta-data
             android:name="com.rakuten.tech.mobile.miniapp.HostAppVersion"
             android:value="${hostAppVersion}" />
         <meta-data

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -30,9 +30,6 @@
             android:name="com.rakuten.tech.mobile.miniapp.BaseUrl"
             android:value="${baseUrl}" />
         <meta-data
-            android:name="com.rakuten.tech.mobile.miniapp.TestUrl"
-            android:value="${testUrl}" />
-        <meta-data
             android:name="com.rakuten.tech.mobile.miniapp.IsTestMode"
             android:value="${isTestMode}" />
         <meta-data

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/MiniAppListStore.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/MiniAppListStore.kt
@@ -5,9 +5,10 @@ import android.content.SharedPreferences
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
+import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
 import java.lang.IllegalStateException
 
-class MiniAppListStore(context: Context) {
+class MiniAppListStore private constructor(context: Context) {
 
     companion object {
         lateinit var instance: MiniAppListStore
@@ -22,7 +23,7 @@ class MiniAppListStore(context: Context) {
         Context.MODE_PRIVATE
     )
     private val gson = Gson()
-    private val MINI_APP_LIST = "mini_app_list"
+    private val MINI_APP_LIST = "mini_app_list" + "_is_test_${AppSettings.instance.isTestMode}"
 
     fun saveMiniAppList(list: List<MiniAppInfo>): Boolean = when {
         list.isEmpty() -> false
@@ -33,7 +34,7 @@ class MiniAppListStore(context: Context) {
     }
 
     fun getMiniAppList(): List<MiniAppInfo> = try {
-        gson.fromJson<List<MiniAppInfo>>(
+        gson.fromJson(
             prefs.getString(MINI_APP_LIST, ""),
             object : TypeToken<List<MiniAppInfo>>() {}.type
         )

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListActivity.kt
@@ -16,7 +16,7 @@ class MiniAppListActivity : SettingsMenuBaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.mini_app_list_activity)
-        if (AppSettings.instance.isSettingSaved()) {
+        if (AppSettings.instance.isSettingSaved) {
             layoutTut.visibility = View.GONE
             supportFragmentManager.beginTransaction()
                 .replace(R.id.container, MiniAppListFragment.newInstance())

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListFragment.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListFragment.kt
@@ -31,7 +31,6 @@ class MiniAppListFragment : BaseFragment(), MiniAppList {
     private lateinit var viewModel: MiniAppListViewModel
     private lateinit var binding: MiniAppListFragmentBinding
     private lateinit var miniAppListAdapter: MiniAppListAdapter
-    private var miniapps = listOf<MiniAppInfo>()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -45,7 +44,7 @@ class MiniAppListFragment : BaseFragment(), MiniAppList {
         )
         binding.fragment = this
         binding.rvMiniAppList.layoutManager = LinearLayoutManager(this.context)
-        miniAppListAdapter = MiniAppListAdapter(miniapps, this)
+        miniAppListAdapter = MiniAppListAdapter(ArrayList(), this)
         binding.rvMiniAppList.adapter = miniAppListAdapter
         return binding.root
     }
@@ -81,8 +80,7 @@ class MiniAppListFragment : BaseFragment(), MiniAppList {
     }
 
     private fun displayMiniAppList(list: List<MiniAppInfo>) {
-        miniAppListAdapter.miniapps = list
-        miniAppListAdapter.notifyDataSetChanged()
+        miniAppListAdapter.addListWithSection(list)
     }
 
     private fun executeLoadingList() {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -31,6 +31,10 @@ class AppSettings private constructor(context: Context) {
         }
         set(subscriptionKey) { cache.subscriptionKey = subscriptionKey }
 
+    var isSettingSaved: Boolean
+        get() = cache.isSettingSaved
+        set(isSettingSaved) { cache.isSettingSaved = isSettingSaved }
+
     val baseUrl = manifestConfig.baseUrl()
     val testUrl = manifestConfig.testUrl()
 
@@ -44,8 +48,6 @@ class AppSettings private constructor(context: Context) {
         subscriptionKey = subscriptionKey,
         hostAppVersionId = hostAppVersionId
     )
-
-    fun isSettingSaved() = cache.appId != null
 
     companion object {
         lateinit var instance: AppSettings
@@ -83,10 +85,15 @@ private class Settings(context: Context) {
         get() = prefs.getString(UNIQUE_ID, null)
         set(uuid) = prefs.edit().putString(UNIQUE_ID, uuid).apply()
 
+    var isSettingSaved: Boolean
+        get() = prefs.getBoolean(IS_SETTING_SAVED, false)
+        set(isSettingSaved) = prefs.edit().putBoolean(IS_SETTING_SAVED, isSettingSaved).apply()
+
     companion object {
         private const val IS_TEST_MODE = "is_test_mode"
         private const val APP_ID = "app_id"
         private const val SUBSCRIPTION_KEY = "subscription_key"
         private const val UNIQUE_ID = "unique_id"
+        private const val IS_SETTING_SAVED = "is_setting_saved"
     }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -11,6 +11,10 @@ class AppSettings private constructor(context: Context) {
     private val manifestConfig = AppManifestConfig(context)
     private val cache = Settings(context)
 
+    var isTestMode: Boolean
+        get() = cache.isTestMode ?: manifestConfig.isTestMode()
+        set(isTestMode) { cache.isTestMode = isTestMode }
+
     var appId: String
         get() = cache.appId ?: manifestConfig.rasAppId()
         set(appId) { cache.appId = appId }
@@ -28,11 +32,14 @@ class AppSettings private constructor(context: Context) {
         set(subscriptionKey) { cache.subscriptionKey = subscriptionKey }
 
     val baseUrl = manifestConfig.baseUrl()
+    val testUrl = manifestConfig.testUrl()
 
     val hostAppVersionId = manifestConfig.hostAppVersion()
 
     val miniAppSettings: MiniAppSdkConfig get() = MiniAppSdkConfig(
         baseUrl = baseUrl,
+        testUrl = testUrl,
+        isTestMode = isTestMode,
         rasAppId = appId,
         subscriptionKey = subscriptionKey,
         hostAppVersionId = hostAppVersionId
@@ -56,6 +63,14 @@ private class Settings(context: Context) {
         Context.MODE_PRIVATE
     )
 
+    var isTestMode: Boolean?
+        get() =
+            if (prefs.contains(IS_TEST_MODE))
+                prefs.getBoolean(IS_TEST_MODE, false)
+            else
+                null
+        set(isTestMode) = prefs.edit().putBoolean(IS_TEST_MODE, isTestMode!!).apply()
+
     var appId: String?
         get() = prefs.getString(APP_ID, null)
         set(appId) = prefs.edit().putString(APP_ID, appId).apply()
@@ -69,6 +84,7 @@ private class Settings(context: Context) {
         set(uuid) = prefs.edit().putString(UNIQUE_ID, uuid).apply()
 
     companion object {
+        private const val IS_TEST_MODE = "is_test_mode"
         private const val APP_ID = "app_id"
         private const val SUBSCRIPTION_KEY = "subscription_key"
         private const val UNIQUE_ID = "unique_id"

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -36,17 +36,15 @@ class AppSettings private constructor(context: Context) {
         set(isSettingSaved) { cache.isSettingSaved = isSettingSaved }
 
     val baseUrl = manifestConfig.baseUrl()
-    val testUrl = manifestConfig.testUrl()
 
     val hostAppVersionId = manifestConfig.hostAppVersion()
 
     val miniAppSettings: MiniAppSdkConfig get() = MiniAppSdkConfig(
         baseUrl = baseUrl,
-        testUrl = testUrl,
-        isTestMode = isTestMode,
         rasAppId = appId,
         subscriptionKey = subscriptionKey,
-        hostAppVersionId = hostAppVersionId
+        hostAppVersionId = hostAppVersionId,
+        isTestMode = isTestMode
     )
 
     companion object {

--- a/testapp/src/main/res/layout/app_settings_dialog.xml
+++ b/testapp/src/main/res/layout/app_settings_dialog.xml
@@ -33,6 +33,14 @@
         android:inputType="text" />
     </com.google.android.material.textfield.TextInputLayout>
 
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/switchTest"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/tiny_2dp"
+        android:layout_marginTop="@dimen/tiny_2dp"
+        android:text="@string/lb_test_mode"/>
+
     <ProgressBar
         android:id="@+id/pb"
         style="?android:attr/progressBarStyle"

--- a/testapp/src/main/res/layout/item_list_miniapp.xml
+++ b/testapp/src/main/res/layout/item_list_miniapp.xml
@@ -15,8 +15,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?selectableItemBackground"
-        android:paddingTop="2dp"
-        android:paddingBottom="2dp"
+        android:paddingTop="@dimen/small_8"
+        android:paddingBottom="@dimen/small_8"
         android:paddingStart="@dimen/small_8"
         android:paddingEnd="@dimen/small_8"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -40,44 +40,12 @@
             android:layout_alignParentStart="true"
             android:layout_marginStart="@dimen/small_8"
             android:paddingStart="@dimen/small_8"
-            android:paddingTop="@dimen/small_8"
             android:paddingEnd="@dimen/small_8"
             android:paddingBottom="@dimen/small_8"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toEndOf="@+id/iv_app_icon"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent">
-
-            <TextView
-                android:id="@+id/tv_app_name"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:textColor="@android:color/black"
-                android:textSize="@dimen/text_medium_14"
-                android:text="@{miniapp.displayName}"
-                android:singleLine="true"
-                android:ellipsize="end"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:text="Name of the Mini App" />
-
-            <TextView
-                android:id="@+id/tv_description"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/small_8"
-                android:alpha="0.6"
-                android:gravity="start"
-                android:textColor="@android:color/black"
-                android:textSize="@dimen/text_medium_14"
-                android:visibility="gone"
-                android:singleLine="true"
-                android:ellipsize="end"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/tv_app_name"
-                tools:text="Description of the Mini App" />
 
             <TextView
                 android:id="@+id/tv_lb_version"
@@ -90,7 +58,7 @@
                 android:textSize="@dimen/text_medium_14"
                 android:text="@{@string/lb_version + `: `}"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/tv_description"
+                app:layout_constraintTop_toTopOf="parent"
                 tools:text="Version: " />
 
             <TextView
@@ -106,8 +74,8 @@
                 android:ellipsize="marquee"
                 android:marqueeRepeatLimit="marquee_forever"
                 app:layout_constraintStart_toEndOf="@id/tv_lb_version"
-                app:layout_constraintTop_toBottomOf="@+id/tv_description"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
                 tools:text="9ab14a68-e8f9-4216-a6df-2c3b06f3c7f7" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/testapp/src/main/res/layout/item_section_miniapp.xml
+++ b/testapp/src/main/res/layout/item_section_miniapp.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <data>
+        <import type="android.text.TextUtils"/>
+        <variable
+            name="miniapp"
+            type="com.rakuten.tech.mobile.miniapp.MiniAppInfo" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        xmlns:tools="http://schemas.android.com/tools"
+        xmlns:app="http://schemas.android.com/apk/res-auto">
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/color_bg_default_icon"
+            app:layout_constraintTop_toTopOf="parent"/>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/color_bg_default_icon"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+        <TextView
+            android:id="@+id/tv_app_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:text="@{miniapp.displayName}"
+            android:textColor="@android:color/black"
+            android:textSize="@dimen/text_large_16"
+            android:padding="@dimen/medium_16"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Name of the Mini App" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+    </layout>

--- a/testapp/src/main/res/values/dimens.xml
+++ b/testapp/src/main/res/values/dimens.xml
@@ -6,6 +6,8 @@
     <dimen name="fab_margin">16dp</dimen>
     <dimen name="appbar_padding_top">8dp</dimen>
 
+    <dimen name="tiny_2dp">2dp</dimen>
+    <dimen name="small_5">5dp</dimen>
     <dimen name="small_8">8dp</dimen>
     <dimen name="small_12">12dp</dimen>
     <dimen name="medium_16">16dp</dimen>

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -2,12 +2,16 @@
     <string name="lb_version">Version</string>
     <string name="lb_description">Description</string>
     <string name="lb_app_id">App ID</string>
+    <string name="lb_app_settings">App Settings</string>
+    <string name="lb_test_mode">Test Mode</string>
+
     <string name="action_display">Display</string>
-    <string name="error_empty">Required</string>
-    <string name="error_invalid_input">Invalid Input</string>
     <string name="action_go_input">Display Miniapp From ID</string>
     <string name="action_display_list">Display Miniapp From List</string>
-    <string name="lb_app_settings">App Settings</string>
     <string name="action_save">Save</string>
+
+    <string name="error_empty">Required</string>
+    <string name="error_invalid_input">Invalid Input</string>
+
     <string name="tut_setting">This is the first time you launch the MiniApp Demo application on this device. You need to provide your own Host App ID and Subscription Key from &lt;font color="#BF0000">&lt;b>Rakuten&lt;/b>&lt;/font> &lt;b>App Studio&lt;/b></string>
 </resources>


### PR DESCRIPTION
# Description
1/ Switching to test endpoint to see miniapp versions in Testing environment by adding Path on url:
MiniApp api: `.../test`
Manifest api: `.../test/manifest`

The data responses from server side are expected the same as they are now.

Update for the manifest configuration:
`IsTestMode`: Decide to run original api or testing one.

When this PR gets approved, require an update config on CI for this value:

- Staging
`IS_TEST_MODE`: true

- Production
`PROD_IS_TEST_MODE`: should be false. Production does not need testing miniapps.

2/ Update UI sample app
- Add toggle button to switch to Testing on Setting dialog.
- Display miniapp list as Section list. The section is miniapp name, items are miniapp versions & icons.

## Links
[MINI-235](https://jira.rakuten-it.com/jira/browse/MINI-235)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
