### PR TITLE
build: Fix version incrementer for snapshot versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ buildscript {
 plugins {
     id 'io.gitlab.arturbosch.detekt' version '1.1.1'
     id 'net.ltgt.errorprone' version '0.7'
-    id 'pl.allegro.tech.build.axion-release' version '1.10.2'
+    id 'pl.allegro.tech.build.axion-release' version '1.12.0'
 }
 
 allprojects {
@@ -73,6 +73,10 @@ allprojects {
             prefix = 'v'
             versionSeparator = ''
             versionIncrementer 'incrementMinor'
+        }
+        nextVersion {
+            suffix = '.*'
+            separator = '-'
         }
     }
 


### PR DESCRIPTION
# Description
Sometimes the snapshot version was not being set correctly for tags like 'v1.2.0-alpha2' when there was already an 'alpha' release. Set the snapshot suffix to match anything after the '-' in the tag. Also updated the axion plugin to the latest version

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
