### PR TITLE
feature: close miniapp

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/base/BaseActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/base/BaseActivity.kt
@@ -15,6 +15,13 @@ abstract class BaseActivity: AppCompatActivity(), CoroutineScope {
 
     val raceExecutor = RaceExecutor()
 
+    protected fun showBackIcon() {
+        supportActionBar?.let {
+            it.setDisplayHomeAsUpEnabled(true)
+            it.setDisplayShowHomeEnabled(true)
+        }
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         job.cancel()

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.os.Bundle
+import android.view.MenuItem
 import android.view.View
 import android.webkit.WebView
 import android.widget.Toast
@@ -45,8 +46,18 @@ class MiniAppDisplayActivity : BaseActivity() {
 
     private lateinit var viewModel: MiniAppDisplayViewModel
 
+    override fun onOptionsItemSelected(item: MenuItem): Boolean = when (item.itemId) {
+        android.R.id.home -> {
+            finish()
+            true
+        }
+        else -> super.onOptionsItemSelected(item)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        showBackIcon()
+
         if (intent.hasExtra(miniAppTag) || intent.hasExtra(appIdTag)) {
             appId = intent.getStringExtra(appIdTag) ?: ""
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
@@ -87,8 +87,7 @@ class SettingsMenuActivity : BaseActivity() {
     private fun initializeActionBar() {
         val toolBar = findViewById<Toolbar>(R.id.toolbar)
         setSupportActionBar(toolBar)
-        supportActionBar?.setDisplayHomeAsUpEnabled(true)
-        supportActionBar?.setDisplayShowHomeEnabled(true)
+        showBackIcon()
     }
 
     private fun renderAppSettingsScreen() {


### PR DESCRIPTION
# Description
Sample app:
We had implemented the back navigation on webview, now we have the close button to quit miniapp.

## Links
[MINI-1097](https://jira.rakuten-it.com/jira/browse/MINI-1097)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
