### PR TITLE
fix: no invalid field warning in settings screen

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -68,3 +68,7 @@ The footer should contain any information about **Breaking Changes** and is also
 reference GitHub issues that this commit **Closes**.
 
 **Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines. The rest of the commit message is then used for this.
+
+## Changelog Guidelines
+All changes will be documented [in this file](https://github.com/rakutentech/android-miniapp/blob/master/CHANGELOG.md) by ordering chronologically for each version with following format.
+

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -68,7 +68,3 @@ The footer should contain any information about **Breaking Changes** and is also
 reference GitHub issues that this commit **Closes**.
 
 **Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines. The rest of the commit message is then used for this.
-
-## Changelog Guidelines
-All changes will be documented [in this file](https://github.com/rakutentech/android-miniapp/blob/master/CHANGELOG.md) by ordering chronologically for each version with following format.
-

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/UUIDHelper.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/UUIDHelper.kt
@@ -9,6 +9,3 @@ fun String.isInvalidUuid(): Boolean = try {
 } catch (e: IllegalArgumentException) {
     true
 }
-
-fun String.includeHyphen(): String =
-    replace("(.{8})(.{4})(.{4})(.{4})(.+)".toRegex(), "$1-$2-$3-$4-$5")

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/UUIDHelper.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/UUIDHelper.kt
@@ -1,10 +1,14 @@
 package com.rakuten.tech.mobile.testapp.helper
 
+import java.lang.IllegalArgumentException
 import java.util.UUID
 
 fun String.isInvalidUuid(): Boolean = try {
     UUID.fromString(this)
     false
-} catch (e: Exception) {
+} catch (e: IllegalArgumentException) {
     true
 }
+
+fun String.includeHyphen(): String =
+    replace("(.{8})(.{4})(.{4})(.{4})(.+)".toRegex(), "$1-$2-$3-$4-$5")

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/UUIDHelper.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/UUIDHelper.kt
@@ -1,7 +1,6 @@
 package com.rakuten.tech.mobile.testapp.helper
 
-import java.lang.Exception
-import java.util.*
+import java.util.UUID
 
 fun String.isInvalidUuid(): Boolean = try {
     UUID.fromString(this)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
@@ -40,7 +40,7 @@ class SettingsMenuActivity : BaseActivity() {
         override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
 
         override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-            enableSaveView()
+            validateInputView()
         }
     }
 
@@ -99,7 +99,7 @@ class SettingsMenuActivity : BaseActivity() {
         editAppId.addTextChangedListener(settingsTextWatcher)
         editSubscriptionKey.addTextChangedListener(settingsTextWatcher)
 
-        enableSaveView()
+        validateInputView()
     }
 
     private fun createSettingsInfo(): String {
@@ -107,9 +107,19 @@ class SettingsMenuActivity : BaseActivity() {
                 getString(R.string.build_version)
     }
 
-    private fun enableSaveView() {
-        saveViewEnabled =
-            !(editAppId.text.toString().isInvalidUuid() || editSubscriptionKey.text.isNullOrEmpty())
+    private fun validateInputView() {
+        val isAppIdInvalid = editAppId.text.toString().isInvalidUuid() || editAppId.text.isNullOrEmpty()
+        val isSubKeyInvalid = editSubscriptionKey.text.toString().isInvalidUuid() || editSubscriptionKey.text.isNullOrEmpty()
+
+        saveViewEnabled = !(isAppIdInvalid || isSubKeyInvalid)
+
+        if (isAppIdInvalid) {
+            editAppId.error = "invalid input"
+        }
+
+        if (isSubKeyInvalid) {
+            editSubscriptionKey.error = "invalid input"
+        }
     }
 
     private fun updateSettings(appId: String, subscriptionKey: String, isTestMode: Boolean) {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
@@ -7,12 +7,14 @@ import android.view.Gravity
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.Toast
+import androidx.appcompat.widget.AppCompatEditText
 import androidx.appcompat.widget.Toolbar
 import com.rakuten.tech.mobile.miniapp.MiniApp
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.testapp.AppScreen.MINI_APP_INPUT_ACTIVITY
 import com.rakuten.tech.mobile.testapp.AppScreen.MINI_APP_LIST_ACTIVITY
+import com.rakuten.tech.mobile.testapp.helper.includeHyphen
 import com.rakuten.tech.mobile.testapp.helper.isInvalidUuid
 import com.rakuten.tech.mobile.testapp.launchActivity
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
@@ -40,7 +42,7 @@ class SettingsMenuActivity : BaseActivity() {
         override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
 
         override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-            validateInputView()
+            validateInputIDs()
         }
     }
 
@@ -99,7 +101,7 @@ class SettingsMenuActivity : BaseActivity() {
         editAppId.addTextChangedListener(settingsTextWatcher)
         editSubscriptionKey.addTextChangedListener(settingsTextWatcher)
 
-        validateInputView()
+        validateInputIDs()
     }
 
     private fun createSettingsInfo(): String {
@@ -107,19 +109,24 @@ class SettingsMenuActivity : BaseActivity() {
                 getString(R.string.build_version)
     }
 
-    private fun validateInputView() {
-        val isAppIdInvalid = editAppId.text.toString().isInvalidUuid() || editAppId.text.isNullOrEmpty()
-        val isSubKeyInvalid = editSubscriptionKey.text.toString().isInvalidUuid() || editSubscriptionKey.text.isNullOrEmpty()
+    internal fun validateInputIDs() {
+        val isAppIdInvalid = editAppId.text.toString().isInvalidUuid()
+        val isSubsKeyInvalid = editSubscriptionKey.text.toString().includeHyphen().isInvalidUuid()
 
-        saveViewEnabled = !(isAppIdInvalid || isSubKeyInvalid)
+        saveViewEnabled = !(isInputEmpty(editAppId) || isInputEmpty(editSubscriptionKey)
+                || isAppIdInvalid || isSubsKeyInvalid)
 
-        if (isAppIdInvalid) {
-            editAppId.error = "invalid input"
+        if (isInputEmpty(editAppId) || isAppIdInvalid) {
+            editAppId.error = getString(R.string.error_invalid_input)
         }
 
-        if (isSubKeyInvalid) {
-            editSubscriptionKey.error = "invalid input"
+        if (isInputEmpty(editSubscriptionKey) || isSubsKeyInvalid) {
+            editSubscriptionKey.error = getString(R.string.error_invalid_input)
         }
+    }
+
+    private fun isInputEmpty(input: AppCompatEditText): Boolean {
+        return input.text.toString().isEmpty() || input.text.toString().isBlank()
     }
 
     private fun updateSettings(appId: String, subscriptionKey: String, isTestMode: Boolean) {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
@@ -113,8 +113,10 @@ class SettingsMenuActivity : BaseActivity() {
         val isAppIdInvalid = editAppId.text.toString().isInvalidUuid()
         val isSubsKeyInvalid = editSubscriptionKey.text.toString().includeHyphen().isInvalidUuid()
 
-        saveViewEnabled = !(isInputEmpty(editAppId) || isInputEmpty(editSubscriptionKey)
-                || isAppIdInvalid || isSubsKeyInvalid)
+        saveViewEnabled = !(isInputEmpty(editAppId)
+                || isInputEmpty(editSubscriptionKey)
+                || isAppIdInvalid
+                || isSubsKeyInvalid)
 
         if (isInputEmpty(editAppId) || isAppIdInvalid) {
             editAppId.error = getString(R.string.error_invalid_input)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
@@ -14,7 +14,6 @@ import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.testapp.AppScreen.MINI_APP_INPUT_ACTIVITY
 import com.rakuten.tech.mobile.testapp.AppScreen.MINI_APP_LIST_ACTIVITY
-import com.rakuten.tech.mobile.testapp.helper.includeHyphen
 import com.rakuten.tech.mobile.testapp.helper.isInvalidUuid
 import com.rakuten.tech.mobile.testapp.launchActivity
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
@@ -111,18 +110,16 @@ class SettingsMenuActivity : BaseActivity() {
 
     internal fun validateInputIDs() {
         val isAppIdInvalid = editAppId.text.toString().isInvalidUuid()
-        val isSubsKeyInvalid = editSubscriptionKey.text.toString().includeHyphen().isInvalidUuid()
 
         saveViewEnabled = !(isInputEmpty(editAppId)
                 || isInputEmpty(editSubscriptionKey)
-                || isAppIdInvalid
-                || isSubsKeyInvalid)
+                || isAppIdInvalid)
 
         if (isInputEmpty(editAppId) || isAppIdInvalid) {
             editAppId.error = getString(R.string.error_invalid_input)
         }
 
-        if (isInputEmpty(editSubscriptionKey) || isSubsKeyInvalid) {
+        if (isInputEmpty(editSubscriptionKey)) {
             editSubscriptionKey.error = getString(R.string.error_invalid_input)
         }
     }
@@ -155,7 +152,7 @@ class SettingsMenuActivity : BaseActivity() {
                     settingsProgressDialog.cancel()
                     val toast =
                         Toast.makeText(this@SettingsMenuActivity, error.message, Toast.LENGTH_LONG)
-                    toast.setGravity(Gravity.BOTTOM, 0, 0)
+                    toast.setGravity(Gravity.BOTTOM, 0, 100)
                     toast.show()
                 }
             }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
@@ -155,7 +155,7 @@ class SettingsMenuActivity : BaseActivity() {
                     settingsProgressDialog.cancel()
                     val toast =
                         Toast.makeText(this@SettingsMenuActivity, error.message, Toast.LENGTH_LONG)
-                    toast.setGravity(Gravity.TOP, 0, 0)
+                    toast.setGravity(Gravity.BOTTOM, 0, 0)
                     toast.show()
                 }
             }

--- a/testapp/src/main/res/color/text_enable_state.xml
+++ b/testapp/src/main/res/color/text_enable_state.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-  <item android:color="#CCFFFFFF" android:state_enabled="false" />
+  <item android:color="#8AFFFFFF" android:state_enabled="false" />
   <item android:color="#FFFFFF" />
 </selector>


### PR DESCRIPTION
# Description
 A warning should appear while there are invalid inputs like the following cases:
- App host id is not UUID
- empty / blank characters 

For the UI, this PR aims to use `setError(CharSequence error)` from [TextView](https://developer.android.com/reference/android/widget/TextView).

## Links
- [MINI-1271](https://jira.rakuten-it.com/jira/browse/MINI-1271)

## Screenshots
<img width="326" alt="Screen Shot 2020-07-27 at 12 36 45" src="https://user-images.githubusercontent.com/66930373/88501248-dda1be00-d005-11ea-9953-3a74ececf98c.png">

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
