### PR TITLE
hotfix: undo version plugin change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ buildscript {
 plugins {
     id 'io.gitlab.arturbosch.detekt' version '1.1.1'
     id 'net.ltgt.errorprone' version '0.7'
-    id 'pl.allegro.tech.build.axion-release' version '1.12.0'
+    id 'pl.allegro.tech.build.axion-release' version '1.10.2'
 }
 
 allprojects {
@@ -73,10 +73,6 @@ allprojects {
             prefix = 'v'
             versionSeparator = ''
             versionIncrementer 'incrementMinor'
-        }
-        nextVersion {
-            suffix = '.*'
-            separator = '-'
         }
     }
 


### PR DESCRIPTION
# Description
The SCM plugin is not able to read the tagged version

# Checklist
- [ ] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data before every commit, including API endpoints and keys
- [ ] I ran `./gradlew check` without errors
