### PR TITLE
Refactor to a template for build info string in settings

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
@@ -29,10 +29,6 @@ class SettingsMenuActivity : BaseActivity() {
     private lateinit var settings: AppSettings
     private lateinit var settingsProgressDialog: SettingsProgressDialog
 
-    companion object {
-        private const val buildInfoTemplate = "Build %s - %s"
-    }
-
     private var saveViewEnabled by Delegates.observable(true) { _, old, new ->
         if (new != old) {
             invalidateOptionsMenu()
@@ -108,11 +104,9 @@ class SettingsMenuActivity : BaseActivity() {
     }
 
     private fun createBuildInfo(): String {
-        return String.format(
-            buildInfoTemplate,
-            getString(R.string.miniapp_sdk_version),
-            getString(R.string.build_version)
-        )
+        val sdkVersion = getString(R.string.miniapp_sdk_version)
+        val buildVersion = getString(R.string.build_version)
+        return "Build $sdkVersion - $buildVersion"
     }
 
     internal fun validateInputIDs() {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
@@ -29,6 +29,10 @@ class SettingsMenuActivity : BaseActivity() {
     private lateinit var settings: AppSettings
     private lateinit var settingsProgressDialog: SettingsProgressDialog
 
+    companion object {
+        private const val buildInfoTemplate = "Build %s - %s"
+    }
+
     private var saveViewEnabled by Delegates.observable(true) { _, old, new ->
         if (new != old) {
             invalidateOptionsMenu()
@@ -92,7 +96,7 @@ class SettingsMenuActivity : BaseActivity() {
     }
 
     private fun renderAppSettingsScreen() {
-        textInfo.text = createSettingsInfo()
+        textInfo.text = createBuildInfo()
         editAppId.setText(settings.appId)
         editSubscriptionKey.setText(settings.subscriptionKey)
         switchTestMode.isChecked = settings.isTestMode
@@ -103,9 +107,12 @@ class SettingsMenuActivity : BaseActivity() {
         validateInputIDs()
     }
 
-    private fun createSettingsInfo(): String {
-        return "Build " + getString(R.string.miniapp_sdk_version) + " - " +
-                getString(R.string.build_version)
+    private fun createBuildInfo(): String {
+        return String.format(
+            buildInfoTemplate,
+            getString(R.string.miniapp_sdk_version),
+            getString(R.string.build_version)
+        )
     }
 
     internal fun validateInputIDs() {


### PR DESCRIPTION
# Description
To refactor the build info string by template in sample app settings screen.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
