### PR TITLE
Fix to load miniapps after save settings

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListActivity.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.testapp.ui.miniapplist
 
+import android.app.Activity
 import android.app.SearchManager
 import android.content.Intent
 import android.os.Build
@@ -20,6 +21,10 @@ class MiniAppListActivity : MenuBaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.mini_app_list_activity)
+        launchMiniApps()
+    }
+
+    private fun launchMiniApps() {
         if (AppSettings.instance.isSettingSaved) {
             layoutTut.visibility = View.GONE
             supportFragmentManager.beginTransaction()
@@ -38,8 +43,7 @@ class MiniAppListActivity : MenuBaseActivity() {
     override fun navigateToScreen(): Boolean {
         val intent = Intent(this, SettingsMenuActivity::class.java)
         intent.putExtra(MENU_SCREEN_NAME, MINI_APP_LIST_ACTIVITY)
-        startActivity(intent)
-        finish()
+        startActivityForResult(intent, 0)
         return true
     }
 
@@ -57,6 +61,16 @@ class MiniAppListActivity : MenuBaseActivity() {
                 if (fragment?.isAdded ?: return) {
                     fragment.startSearch(query)
                 }
+            }
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        when (resultCode) {
+            Activity.RESULT_CANCELED -> {
+                launchMiniApps()
             }
         }
     }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListActivity.kt
@@ -39,6 +39,7 @@ class MiniAppListActivity : MenuBaseActivity() {
         val intent = Intent(this, SettingsMenuActivity::class.java)
         intent.putExtra(MENU_SCREEN_NAME, MINI_APP_LIST_ACTIVITY)
         startActivity(intent)
+        finish()
         return true
     }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
@@ -1,5 +1,7 @@
 package com.rakuten.tech.mobile.testapp.ui.settings
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -162,7 +164,12 @@ class SettingsMenuActivity : BaseActivity() {
     private fun navigateToPreviousScreen() {
         when (intent.extras?.getString(MENU_SCREEN_NAME)) {
             MINI_APP_LIST_ACTIVITY -> {
-                raceExecutor.run { launchActivity<MiniAppListActivity>() }
+                val intent = Intent(this, MiniAppListActivity::class.java).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                setResult(Activity.RESULT_CANCELED, intent)
+                startActivity(intent)
+                finish()
             }
             MINI_APP_INPUT_ACTIVITY -> {
                 raceExecutor.run { launchActivity<MiniAppInputActivity>() }


### PR DESCRIPTION
# Description
Miniapps are not loading after saving the settings. Sample app has to relaunch to see the miniapps. This PR will fix the issue. 

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
