### PR TITLE
Use shared Orbs in CircleCI config 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,19 @@
 version: 2.1
 
 orbs:
-  android-sdk: rakutentech/android-sdk@0.1.0
+  android-sdk: rakutentech/android-sdk@0.2.0
   app-center: rakutentech/app-center@0.1.0
 
 commands:
-  updateSubmodule: set -e
-    git submodule update --init
-    cp miniapp/src/main/assets/js-miniapp/js-miniapp-bridge/export/android/bridge.js miniapp/src/main/assets
-    rm -r miniapp/src/main/assets/js-miniapp
-    (cd miniapp/src/main/assets && mkdir -p js-miniapp/js-miniapp-bridge/export/android)
-    mv miniapp/src/main/assets/bridge.js miniapp/src/main/assets/js-miniapp/js-miniapp-bridge/export/android/
+  update-submodules:
+    steps:
+      - run: |
+          set -e
+          git submodule update --init
+          cp miniapp/src/main/assets/js-miniapp/js-miniapp-bridge/export/android/bridge.js miniapp/src/main/assets
+          rm -r miniapp/src/main/assets/js-miniapp
+          (cd miniapp/src/main/assets && mkdir -p js-miniapp/js-miniapp-bridge/export/android)
+          mv miniapp/src/main/assets/bridge.js miniapp/src/main/assets/js-miniapp/js-miniapp-bridge/export/android/
 
 workflows:
   version: 2.1
@@ -32,7 +35,7 @@ workflows:
                   base64 -d \<<< "$RELEASE_KEYSTORE_BASE64" > ./testapp/release-keystore.jks
                 fi
           after-prepare-steps:
-            - updateSubmodule
+            - update-submodules
           filters:
             tags:
               only: /^v.*/
@@ -63,7 +66,7 @@ workflows:
           requires:
             - release-verification
           after-prepare-steps:
-            - updateSubmodule
+            - update-submodules
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,198 +1,83 @@
-version: 2
+version: 2.1
 
-gradle_cache_key: &gradle_cache_key gradle-{{ checksum "build.gradle" }}-{{ checksum "miniapp/build.gradle" }}
-maven_cache_key: &maven_cache_key maven-{{ checksum "miniapp/src/test/AndroidManifest.xml" }}
+orbs:
+  android-sdk: rakutentech/android-sdk@0.1.0
+  app-center: rakutentech/app-center@0.1.0
 
-jobs:
-  build:
-    docker:
-      - image: circleci/android@sha256:45eb47efaf498cdbf01b16e6a294ef20a4979f6acd6aaf75913707190806bb4c
-    working_directory: ~/code
-    environment:
-      JVM_OPTS: "-Xmx3200m"
-    steps:
-      - checkout
-      # ToDo Find a solution to upgrade git version of Debian to use sparse-checkout.
-      - run:
-          name: Update submodule
-          command: |
-            set -e
-            git submodule update --init
-            cp miniapp/src/main/assets/js-miniapp/js-miniapp-bridge/export/android/bridge.js miniapp/src/main/assets
-            rm -r miniapp/src/main/assets/js-miniapp
-            (cd miniapp/src/main/assets && mkdir -p js-miniapp/js-miniapp-bridge/export/android)
-            mv miniapp/src/main/assets/bridge.js miniapp/src/main/assets/js-miniapp/js-miniapp-bridge/export/android/
-        # Retrieve Base64 Keystore from Env variable and save to testapp project
-      - run: |
-          if [[ $RELEASE_KEYSTORE_BASE64 != "" ]]; then
-            base64 -d <<< $RELEASE_KEYSTORE_BASE64 > ./testapp/release-keystore.jks
-          fi
-      - restore_cache:
-          key: *gradle_cache_key
-      - run:
-          name: Download Dependencies
-          command: ./gradlew androidDependencies
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: *gradle_cache_key
-      - restore_cache:
-          ## Robolectric uses maven to download sources, so we must use a different cache for maven
-          key: *maven_cache_key
-      - run:
-          name: Run Tests
-          command: ./gradlew check
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: *maven_cache_key
-      - run:
-          name: Assemble AAR
-          command: ./gradlew assemble
-      - run:
-          name: Current Version
-          command: ./gradlew currentVersion
-      - run:
-          name: Upload Code Coverage
-          command: bash <(curl -s https://codecov.io/bash)
-      - store_artifacts:
-          path: miniapp/build/reports
-          destination: reports/
-      - store_test_results:
-          path: miniapp/build/test-results
-      - store_artifacts:
-          path: miniapp/build/outputs/aar
-          destination: aar/
-      - persist_to_workspace:
-          root: testapp/build/outputs
-          paths:
-            - apk/
-      - persist_to_workspace:
-          root: ~/code
-          paths:
-            - miniapp/build/
-
-  publish-sdk:
-    docker:
-      - image: circleci/android@sha256:45eb47efaf498cdbf01b16e6a294ef20a4979f6acd6aaf75913707190806bb4c
-    working_directory: ~/code
-    environment:
-      JVM_OPTS: "-Xmx3200m"
-    steps:
-      - checkout
-      - run:
-          name: Update submodule
-          command: |
-            set -e
-            git submodule update --init
-            cp miniapp/src/main/assets/js-miniapp/js-miniapp-bridge/export/android/bridge.js miniapp/src/main/assets
-            rm -r miniapp/src/main/assets/js-miniapp
-            (cd miniapp/src/main/assets && mkdir -p js-miniapp/js-miniapp-bridge/export/android)
-            mv miniapp/src/main/assets/bridge.js miniapp/src/main/assets/js-miniapp/js-miniapp-bridge/export/android/
-      - attach_workspace:
-          at: ./
-      - run:
-          name: Current Version
-          command: ./gradlew cV
-      - run:
-          name: Publish Artifacts
-          command: ./gradlew publish
-      - run:
-          name: Publish Documentation
-          command: |
-            set -e
-            ./gradlew generatePublishableDocs
-            if [[ ! $CIRCLE_TAG == *"-"* ]]; then
-              git checkout gh-pages
-              cp -R miniapp/build/publishableDocs/docs/. ./docs
-              cp -R miniapp/build/publishableDocs/_versions/. ./_versions
-              git add docs _versions
-              git config user.name "CI Publisher"
-              git config user.email "dev-opensource@mail.rakuten.com"
-              git commit -m "Publish documentation for $CIRCLE_TAG"
-              git push origin gh-pages
-            else
-              echo "Documentation not published for snapshot version"
-            fi
-
-  deploy-test-app-stg:
-    docker:
-      - image: circleci/node
-    working_directory: ~/code
-    steps:
-      - attach_workspace:
-          at: ./
-      - run:
-          name: Install App Center CLI
-          command: npm init --yes && npm install appcenter-cli
-      - run:
-          name: Upload APK to App Center
-          command: >
-            npx appcenter distribute release
-            --group Testers
-            --file apk/staging/testapp-staging.apk
-            --app $APP_CENTER_APP_NAME
-            --release-notes $CIRCLE_BUILD_URL
-            --token $APP_CENTER_TOKEN
-            --quiet
-
-  deploy-test-app-prod:
-    docker:
-      - image: circleci/node
-    working_directory: ~/code
-    steps:
-      - attach_workspace:
-          at: ./
-      - run:
-          name: Install App Center CLI
-          command: npm init --yes && npm install appcenter-cli
-      - run:
-          name: Upload APK to App Center
-          command: >
-            npx appcenter distribute release
-            --group Production
-            --file apk/release/testapp-release.apk
-            --app $APP_CENTER_APP_NAME
-            --release-notes "Production build for Android SDK $CIRCLE_TAG"
-            --token $APP_CENTER_TOKEN
-            --quiet
+commands:
+  updateSubmodule: set -e
+    git submodule update --init
+    cp miniapp/src/main/assets/js-miniapp/js-miniapp-bridge/export/android/bridge.js miniapp/src/main/assets
+    rm -r miniapp/src/main/assets/js-miniapp
+    (cd miniapp/src/main/assets && mkdir -p js-miniapp/js-miniapp-bridge/export/android)
+    mv miniapp/src/main/assets/bridge.js miniapp/src/main/assets/js-miniapp/js-miniapp-bridge/export/android/
 
 workflows:
-  version: 2
+  version: 2.1
   build-and-release:
     jobs:
-      - build:
+      - android-sdk/build:
+          gradle-cache-key: >-
+            gradle-
+            {{ checksum "build.gradle" }}
+            {{ checksum "miniapp/build.gradle" }}
+            {{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+          maven-cache-key: maven-{{ checksum "miniapp/src/test/AndroidManifest.xml" }}
+          sdk-path: miniapp
+          sample-app-path: testapp
+          pre-steps:
+            # Retrieve Base64 Keystore from Env variable and save to testapp project
+            - run: |
+                if [[ "$RELEASE_KEYSTORE_BASE64" != "" ]]; then
+                  base64 -d \<<< "$RELEASE_KEYSTORE_BASE64" > ./testapp/release-keystore.jks
+                fi
+          after-prepare-steps:
+            - updateSubmodule
           filters:
             tags:
               only: /^v.*/
             branches:
               only: /.*/
-      - deploy-test-app-stg:
+      - app-center/publish:
+          name: deploy-test-app-stg
+          group: Testers
+          file: apk/staging/testapp-staging.apk
+          app: $APP_CENTER_APP_NAME
+          token: $APP_CENTER_TOKEN
+          notes: $CIRCLE_BUILD_URL
           requires:
-            - build
+            - android-sdk/build
           filters:
             branches:
               only: master
       - release-verification:
           type: approval
           requires:
-            - build
+            - android-sdk/build
           filters:
             tags:
               only: /^v.*/
             branches:
               ignore: /.*/
-      - publish-sdk:
+      - android-sdk/publish:
           requires:
             - release-verification
+          after-prepare-steps:
+            - updateSubmodule
           filters:
             tags:
               only: /^v.*/
             branches:
               ignore: /.*/
-      - deploy-test-app-prod:
+      - app-center/publish:
+          name: deploy-test-app-prod
+          group: Production
+          file: apk/release/testapp-release.apk
+          app: $APP_CENTER_APP_NAME
+          token: $APP_CENTER_TOKEN
+          notes: Production build for Android SDK $CIRCLE_TAG
           requires:
-            - publish-sdk
+            - android-sdk/publish
           filters:
             tags:
               only: /^v.*/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Next, you must define a few settings used by the Sample App. These can be define
 MINIAPP_SERVER_BASE_URL=https://www.example.com/
 HOST_APP_ID=test-host-app-id
 HOST_APP_SUBSCRIPTION_KEY=test-subs-key
-HOST_APP_UA_INFO=MiniAppDemoApp/1.0.0
+HOST_APP_UA_INFO=MiniAppDemoApp/1.0.0-SNAPSHOT
 HOST_APP_VERSION=test-host-app-version
 ```
 
@@ -51,6 +51,7 @@ Next, you must define the prod settings for the Sample App as either environment
 MINIAPP_PROD_SERVER_BASE_URL=https://www.example.com/
 HOST_APP_PROD_ID=test-host-app-id
 HOST_APP_PROD_SUBSCRIPTION_KEY=test-subs-key
+HOST_APP_PROD_UA_INFO=MiniAppDemoApp/1.0.0
 HOST_APP_PROD_VERSION=test-host-app-version
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Download](https://api.bintray.com/packages/ssed-oss-jcenter/ssed-mobile-libs/android-miniapp/images/download.svg)](https://bintray.com/ssed-oss-jcenter/ssed-mobile-libs/android-miniapp/_latestVersion)
 [![CircleCI](https://circleci.com/gh/rakutentech/android-miniapp.svg?style=svg)](https://circleci.com/gh/rakutentech/android-miniapp)
 [![codecov](https://codecov.io/gh/rakutentech/android-miniapp/branch/master/graph/badge.svg)](https://codecov.io/gh/rakutentech/android-miniapp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
@@ -5,7 +6,7 @@
 # MiniApp SDK for Android
 
 Provides a set of tools and capabilities to show mini app in Android Applications. The SDK offers features like fetching, caching and displaying of mini app. 
-For instructions on implementing in an android application, see the [User Guide](miniapp/USERGUIDE.md).
+For instructions on implementing in an android application, see the [User Guide](https://rakutentech.github.io/android-miniapp/).
 
 ## How to build
 
@@ -13,16 +14,87 @@ This repository uses submodules for some configuration, so they must be initiali
 
 Note: sparse-checkout is optional. Required Git v2.25 or up.
 ```bash
-$ git submodule init
-$ git submodule update
+$ git submodule update --init
 $ (cd miniapp/src/main/assets/js-miniapp && git sparse-checkout set js-miniapp-bridge/export/android)
 $ ./gradlew assemble
 ```
 
-## How to test the Sample app
+Next, you must define a few settings used by the Sample App. These can be defined either as environment variables or Gradle properties (in your `~/.gradle/gradle.properties` file).
 
-We are still working on this, please watch this space for future updates.
+```
+MINIAPP_SERVER_BASE_URL=https://www.example.com/
+HOST_APP_ID=test-host-app-id
+HOST_APP_SUBSCRIPTION_KEY=test-subs-key
+HOST_APP_UA_INFO=MiniAppDemoApp/1.0.0
+HOST_APP_VERSION=test-host-app-version
+```
+
+Finally, you can build the project via Gradle:
+
+```bash
+$ ./gradlew assembleDebug
+```
+
+### How to Build the Production Sample App
+
+First you will need to create the keystore file at `testapp/release-keystore.jks`. Next you must define environment variables for the keystore settings.
+
+```
+MINIAPP_RELEASE_KEY_ALIAS=my_alias
+MINIAPP_RELEASE_KEY_PASSWORD=my_password
+MINIAPP_KEYSTORE_PASSWORD=my_keystore_password
+```
+
+Next, you must define the prod settings for the Sample App as either environment variables are Gradle Properties.
+
+```
+MINIAPP_PROD_SERVER_BASE_URL=https://www.example.com/
+HOST_APP_PROD_ID=test-host-app-id
+HOST_APP_PROD_SUBSCRIPTION_KEY=test-subs-key
+HOST_APP_PROD_VERSION=test-host-app-version
+```
+
+Finally, you can build the release config for the Sample App.
+
+```bash
+$ ./gradlew assembleRelease
+```
+
+## How to Test the Sample App
+
+We currently don't provide an API for public use, so you must provide your own API.
+
+## Continuous Integration and Deployment
+
+[CircleCI](https://circleci.com/gh/rakutentech/android-miniapp) is used for building and testing the project for every pull request. It is also used for publishing the SDK and the Sample App. 
+
+We use jobs from two CircleCI Orbs (see the [android-buildconfig](https://github.com/rakutentech/android-buildconfig/tree/master/circleci) repo): [android-sdk Orb](https://github.com/rakutentech/android-buildconfig/blob/master/circleci/android-sdk/README.md) and [app-center Orb](https://github.com/rakutentech/android-buildconfig/blob/master/circleci/app-center/README.md). See the Readme for those Orbs for more information on what the jobs do.
+
+### Merge to Master
+
+The following describes the steps CircleCI performs when a branch is merged to master.
+
+1. We trigger CircleCI by merging a branch to master.
+2. CI builds the SDK and Sample App, run tests, linting, etc.
+3. CI publishes staging build of Sample App to App Center "Testers" group.
+
+### Release
+
+The following describes the steps CircleCI performs to release a new version of the SDK.
+
+1. We trigger CircleCI by pushing a git tag to this repo which is in the format `vX.X.X`.
+2. CI builds SDK and Sample App, run tests, linting, etc.
+3. CI pauses the workflow for verification from user.
+4. After approval, CI publishes the SDK to [Bintray](https://bintray.com/ssed-oss-jcenter/ssed-mobile-libs/android-miniapp).
+5. CI publishes generated documentation to [Github Pages site](https://rakutentech.github.io/android-miniapp/).
+6. CI publishes production build of Sample App to App Center's "Production" group.
+
+*Note:* It's also possible to publish a snapshot version of the SDK by using a `-` in the version name, such as `v1.0.0-alpha` (and the generated version name will be `1.0.0-SNAPSHOT`). In this case, the snapshot will be published to the [JFrog OSS Snapshot repository](https://oss.jfrog.org/) and the documentation publishing will be skipped.
 
 ## Contributing
 
-We are still working on this, please watch this space for future updates.
+See our [Contribution Guide](.github/CONTRIBUTING.md).
+
+## Changelog
+
+See the [Changelog](CHANGELOG.md).

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
-        classpath "digital.wup:android-maven-publish:3.6.3"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:${dokka_version}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
@@ -50,6 +49,7 @@ plugins {
     id 'io.gitlab.arturbosch.detekt' version '1.1.1'
     id 'net.ltgt.errorprone' version '0.7'
     id 'pl.allegro.tech.build.axion-release' version '1.10.2'
+    id 'org.ajoberstar.git-publish' version '2.1.3'
 }
 
 allprojects {

--- a/miniapp/build.gradle
+++ b/miniapp/build.gradle
@@ -95,15 +95,21 @@ dokka {
 }
 
 apply from: '../config/publish/android.gradle'
-publishing {
-    publications {
-        MiniApp(MavenPublication, androidArtifact())
+afterEvaluate {
+    publishing {
+        publications {
+            MiniApp(MavenPublication, androidArtifact())
+        }
     }
 }
-
 def isSnapshot = project.version.contains('-')
 if (isSnapshot) {
     apply from: '../config/publish/artifactory.gradle'
 } else {
     apply from: '../config/publish/bintray.gradle'
 }
+
+project.ext.docPublishing = [
+        repoUri: 'git@github.com:rakutentech/android-miniapp.git'
+]
+apply from: '../config/publish/documentation/gh-pages.gradle'

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -44,7 +44,7 @@ android {
     def prodManifestPlaceholders = [
             baseUrl                 : property("MINIAPP_PROD_SERVER_BASE_URL") ?: "https://www.example.com/",
             isTestMode              : property("PROD_IS_TEST_MODE") ?: false,
-            hostAppUserAgentInfo    : property("HOST_APP_UA_INFO") ?: "MiniApp Demo App/$project.version",
+            hostAppUserAgentInfo    : property("HOST_APP_PROD_UA_INFO") ?: "MiniApp Demo App/$project.version",
             hostAppVersion          : property("HOST_APP_PROD_VERSION") ?: "test-host-app-version",
             appId                   : property("HOST_APP_PROD_ID") ?: "test-host-app-id",
             subscriptionKey         : property("HOST_APP_PROD_SUBSCRIPTION_KEY") ?: "test-subs-key"

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -19,7 +19,7 @@ android {
     if (keystoreFile.exists()) {
         signingConfigs {
             release {
-                keyAlias 'miniapp'
+                keyAlias "$System.env.MINIAPP_RELEASE_KEY_ALIAS"
                 keyPassword "$System.env.MINIAPP_RELEASE_KEY_PASSWORD"
 
                 storeFile keystoreFile


### PR DESCRIPTION
# Description
Updated the CircleCI config to use our shared [CircleCI Orbs](https://github.com/rakutentech/android-buildconfig/blob/master/circleci/README.md).

Also updated the `config` submodule to the latest version and applied the config for publishing to github pages.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
