### PR TITLE
fix: Update URL file parser to look for map-published-v2

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/UrlToFileInfoParser.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/UrlToFileInfoParser.kt
@@ -2,14 +2,14 @@ package com.rakuten.tech.mobile.miniapp.storage
 
 import java.io.File
 
-private const val KEY_MAP_PUB = "map-published"
+private const val KEY_MAP_PUB = "map-published-v2"
 private const val INDEX_PATH = 3
 
 internal class UrlToFileInfoParser {
 
     /**
      * Returns the path between versionId to file name e.g. for a given source,
-     * "https://host.os.net/map-published/min-872f9172-804f-44e2-addd-ed612170dac9/
+     * "https://host.os.net/map-published-v2/min-872f9172-804f-44e2-addd-ed612170dac9/
      * >>ver-6181004c-a6aa-4eda-b145-a5ff73fc4ad0/foo/bar/asset-manifest.json",
      * "/foo/bar/" will be returned.
      * Returns empty String when not found.
@@ -17,11 +17,11 @@ internal class UrlToFileInfoParser {
     fun getFilePath(fileUrl: String): String = fileUrl.split(File.separator).run {
         val versionIndex = indexOf(KEY_MAP_PUB)
         return when {
-            // If versionIndex = -1, map-published was not found, then this source is invalid.
+            // If versionIndex = -1, map-published-v2 was not found, then this source is invalid.
             versionIndex < 0 -> ""
             else -> {
                 var path = "/"
-                // The third string after "map-published" is the beginning of path.
+                // The third string after "map-published-v2" is the beginning of path.
                 subList(versionIndex + INDEX_PATH, lastIndex).forEach { path += "$it/" }
                 path
             }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
@@ -28,7 +28,7 @@ internal const val TEST_CALLBACK_VALUE = "test_callback_value"
 
 internal const val VALID_FILE_URL_PATH =
     "https://www.example.com/"
-        .plus("map-published/min-872f9172-804f-44e2-addd-ed612170dac9/")
+        .plus("map-published-v2/min-872f9172-804f-44e2-addd-ed612170dac9/")
         .plus("ver-6181004c-a6aa-4eda-b145-a5ff73fc4ad0/a/b/index.html")
 internal const val INVALID_FILE_URL_PATH = "https://78d85043-d04f-486a-8212-bf2601cb63a2/js"
 


### PR DESCRIPTION
# Description
Changes in the format of the URL returned in the manifest have broken our SDK because we depend on the `map-published` key in the URL. However, this key changed to `map-published-v2`.

Actually, it would be better to not depend on this key anymore. The reason it was depended upon is because we needed to know what path to save files into, however now that we have a ZIP file we no longer need that information. But this is just a quick fix for now to update the key.

## Links
MINI-1407

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
