### PR TITLE
fix: create intermediate directory when unzip

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/FileWriter.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/FileWriter.kt
@@ -23,6 +23,7 @@ internal fun ZipInputStream.decompress(zipPath: String) = use { input ->
 
     while (input.nextEntry.also { entry = it } != null) {
         val newFile = File(outputFilePath.parentFile, entry!!.name)
+        newFile.parentFile?.mkdirs()
         if (entry!!.isDirectory)
             newFile.mkdir()
         else


### PR DESCRIPTION
# Description
- When doing decompression, it's mandatory to create the intermediate directory container of the zip entry.
`JS-SDK-Sample` zip and other zips which have the same issue will load successfully from this fix. 
- This fix will also allow android sdk to extract the hidden folder.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
