### PR TITLE
ci: Fix error with setting release keystore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,14 +28,13 @@ workflows:
           maven-cache-key: maven-{{ checksum "miniapp/src/test/AndroidManifest.xml" }}
           sdk-path: miniapp
           sample-app-path: testapp
-          pre-steps:
+          after-prepare-steps:
+            - update-submodules
             # Retrieve Base64 Keystore from Env variable and save to testapp project
             - run: |
                 if [[ "$RELEASE_KEYSTORE_BASE64" != "" ]]; then
                   base64 -d \<<< "$RELEASE_KEYSTORE_BASE64" > ./testapp/release-keystore.jks
                 fi
-          after-prepare-steps:
-            - update-submodules
           filters:
             tags:
               only: /^v.*/


### PR DESCRIPTION
# Description
It needs to be set after the project has been checkout out, so I've moved this step to the after-prepare-steps section

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
