### PR TITLE
refactor: file path parse

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorage.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorage.kt
@@ -26,9 +26,8 @@ internal class MiniAppStorage(
         inputStream: InputStream
     ) {
         try {
-            val filePath = getFilePath(source)
             val fileName = getFileName(source)
-            fileWriter.unzip(inputStream, getAbsoluteWritePath(basePath, filePath, fileName))
+            fileWriter.unzip(inputStream, getAbsoluteWritePath(basePath, fileName))
         } catch (error: Exception) {
             // This should not happen unless BE sends in a differently "constructed" URL
             // which differs in logic as that of LocalUrlParser
@@ -39,12 +38,8 @@ internal class MiniAppStorage(
     @VisibleForTesting
     fun getAbsoluteWritePath(
         basePath: String,
-        filePath: String,
         fileName: String
-    ) = "$basePath$filePath$fileName"
-
-    @VisibleForTesting
-    fun getFilePath(file: String) = urlToFileInfoParser.getFilePath(file)
+    ) = "$basePath/$fileName"
 
     @VisibleForTesting
     fun getFileName(file: String) = urlToFileInfoParser.getFileName(file)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/UrlToFileInfoParser.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/UrlToFileInfoParser.kt
@@ -2,31 +2,7 @@ package com.rakuten.tech.mobile.miniapp.storage
 
 import java.io.File
 
-private const val KEY_MAP_PUB = "map-published-v2"
-private const val INDEX_PATH = 3
-
 internal class UrlToFileInfoParser {
-
-    /**
-     * Returns the path between versionId to file name e.g. for a given source,
-     * "https://host.os.net/map-published-v2/min-872f9172-804f-44e2-addd-ed612170dac9/
-     * >>ver-6181004c-a6aa-4eda-b145-a5ff73fc4ad0/foo/bar/asset-manifest.json",
-     * "/foo/bar/" will be returned.
-     * Returns empty String when not found.
-     */
-    fun getFilePath(fileUrl: String): String = fileUrl.split(File.separator).run {
-        val versionIndex = indexOf(KEY_MAP_PUB)
-        return when {
-            // If versionIndex = -1, map-published-v2 was not found, then this source is invalid.
-            versionIndex < 0 -> ""
-            else -> {
-                var path = "/"
-                // The third string after "map-published-v2" is the beginning of path.
-                subList(versionIndex + INDEX_PATH, lastIndex).forEach { path += "$it/" }
-                path
-            }
-        }
-    }
 
     /**
      * Returns the last element of the split string. Returns empty String when not found.

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageTest.kt
@@ -73,6 +73,18 @@ class MiniAppStorageTest {
     }
 
     @Test
+    fun `should extract file with FileWriter`() = runBlockingTest {
+        val file = tempFolder.newFile()
+        When calling miniAppStorage.getFileName(file.path) itReturns file.name
+        val inputStream: InputStream = mock()
+        miniAppStorage.saveFile(file.path, file.path, inputStream)
+
+        verify(fileWriter, times(1))
+            .unzip(inputStream, miniAppStorage.getAbsoluteWritePath(
+                file.path, miniAppStorage.getFileName(file.path)))
+    }
+
+    @Test
     fun `should unzip file without exception`() = runBlockingTest {
         val file = tempFolder.newFile()
         val filePath = file.path

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageTest.kt
@@ -37,7 +37,7 @@ class MiniAppStorageTest {
 
     @Test
     fun `for a given set of base path & file path, formed parent path is returned`() {
-        assertTrue { miniAppStorage.getAbsoluteWritePath("a","c") == "a/c" }
+        assertTrue { miniAppStorage.getAbsoluteWritePath("a", "c") == "a/c" }
     }
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageTest.kt
@@ -37,15 +37,7 @@ class MiniAppStorageTest {
 
     @Test
     fun `for a given set of base path & file path, formed parent path is returned`() {
-        assertTrue { miniAppStorage.getAbsoluteWritePath("a", "b", "c") == "abc" }
-    }
-
-    @Test
-    fun `for a given url file path is returned via LocalUrlParser`() {
-        val localUrlParser = getMockedLocalUrlParser()
-        val miniAppStorage = MiniAppStorage(mock(), mock(), localUrlParser)
-        miniAppStorage.getFilePath(TEST_URL_FILE)
-        verify(localUrlParser, times(1)).getFilePath(TEST_URL_FILE)
+        assertTrue { miniAppStorage.getAbsoluteWritePath("a","c") == "a/c" }
     }
 
     @Test
@@ -78,19 +70,6 @@ class MiniAppStorageTest {
         oldFile1.exists() shouldBe false
         oldFile2.exists() shouldBe false
         latestPackage.exists() shouldBe true
-    }
-
-    @Test
-    fun `should extract file with FileWriter`() = runBlockingTest {
-        val file = tempFolder.newFile()
-        When calling miniAppStorage.getFilePath(file.path) itReturns file.path
-        When calling miniAppStorage.getFileName(file.path) itReturns file.name
-        val inputStream: InputStream = mock()
-        miniAppStorage.saveFile(file.path, file.path, inputStream)
-
-        verify(fileWriter, times(1))
-            .unzip(inputStream, miniAppStorage.getAbsoluteWritePath(
-                file.path, miniAppStorage.getFilePath(file.path), miniAppStorage.getFileName(file.path)))
     }
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/UrlToFileInfoParserTest.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/UrlToFileInfoParserTest.kt
@@ -10,16 +10,6 @@ class UrlToFileInfoParserTest {
     private var urlParser = UrlToFileInfoParser()
 
     @Test
-    fun shouldGetFilePathWithValidUrl() {
-        urlParser.getFilePath(VALID_FILE_URL_PATH) shouldEqual "/a/b/"
-    }
-
-    @Test
-    fun shouldGetEmptyFilePathWithInvalidUrl() {
-        urlParser.getFilePath(INVALID_FILE_URL_PATH) shouldEqual ""
-    }
-
-    @Test
     fun shouldGetFileNameWithValidUrl() {
         urlParser.getFileName(VALID_FILE_URL_PATH) shouldEqual "index.html"
     }


### PR DESCRIPTION
# Description
Remove the dependency on the URL structure. No more need for getting file path.

## Links
[MINI-1408](https://jira.rakuten-it.com/jira/browse/MINI-1408)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
