### PR TITLE
docs: Fix some issues in the user guide

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
@@ -1,17 +1,23 @@
 package com.rakuten.tech.mobile.miniapp
 
+import android.os.NetworkOnMainThreadException
+
 /**
  * A custom exception class which treats the purpose of providing
  * error information to the consumer app in an unified way.
  */
-open class MiniAppSdkException(message: String) : Exception(message) {
+open class MiniAppSdkException(message: String, cause: Throwable?) : Exception(message, cause) {
 
-    constructor(e: Exception) : this("Found some problem, ${e.message}")
+    constructor(e: Exception) : this(exceptionMessage(e), e)
+
+    constructor(message: String) : this(message, null)
 }
 
-internal class MiniAppNetException(message: String) : MiniAppSdkException(message) {
+internal class MiniAppNetException(message: String, cause: Throwable?) : MiniAppSdkException(message, cause) {
 
-    constructor(e: Exception) : this("Found some problem, ${e.message}")
+    constructor(e: Exception) : this("Found some problem, ${e.message}", e)
+
+    constructor(message: String) : this(message, null)
 }
 
 @Suppress("FunctionMaxLength")
@@ -29,3 +35,9 @@ internal fun sdkExceptionForInvalidArguments(message: String = "") =
 @Suppress("FunctionMaxLength")
 internal fun sdkExceptionForNoActivityContext() =
     MiniAppSdkException("Only accept context of type Activity or ActivityCompat")
+
+private fun exceptionMessage(exception: Exception) = when (exception) {
+    is NetworkOnMainThreadException -> "Network requests must not be performed on the main thread. "
+        .plus("Use Dispatchers.IO or Dispatchers.Default for MiniApp suspending functions.")
+    else -> "Found some problem, ${exception.message}"
+}


### PR DESCRIPTION
# Description
The MiniApp#create function was still using the old method (which has now been removed). Also removed the note about AppCompat because this was relevant to Android 22 and below only (we now support 23+).


# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
