### PR TITLE
Add user-guide for custom permissions 

### DIFF
--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -137,17 +137,12 @@ val miniAppMessageBridge = object: MiniAppMessageBridge() {
     }
 
     override fun requestCustomPermissions(
-        permissions: List<Pair<MiniAppCustomPermissionType, String>>,
-        callback: (grantResult: String) -> Unit
+        permissionsWithDescription: List<Pair<MiniAppCustomPermissionType, String>>,
+        callback: (context: Context, permissionResult: MiniAppCustomPermission) -> Unit
     ) {
         // Implementation details to request custom permissions
         // .. .. ..
-
-        // sending json response to miniapp
-        val permissionResults: List<Pair<MiniAppCustomPermissionType, String>>
-        // .. .. ..
-        val result = MiniAppCustomPermissionManager(miniapp).createJsonResponse(miniAppId, permissionResults)
-        callback.invoke(result)
+        callback.invoke(context, permissionResult)
     }
 }
 ```

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -135,6 +135,20 @@ val miniAppMessageBridge = object: MiniAppMessageBridge() {
 
         callback.invoke(true)
     }
+
+    override fun requestCustomPermissions(
+        permissions: List<Pair<MiniAppCustomPermissionType, String>>,
+        callback: (grantResult: String) -> Unit
+    ) {
+        // Implementation details to request custom permissions
+        // .. .. ..
+
+        // sending json response to miniapp
+        val permissionResults: List<Pair<MiniAppCustomPermissionType, String>>
+        // .. .. ..
+        val result = MiniAppCustomPermissionManager(miniapp).createJsonResponse(miniAppId, permissionResults)
+        callback.invoke(result)
+    }
 }
 ```
 
@@ -223,6 +237,23 @@ miniAppNavigator = object : MiniAppNavigator {
         // Load external url with own webview.
     }
 }
+```
+
+### #4 Custom Permissions
+MiniApp Android SDK supports list of Custom Permissions ( ```MiniAppCustomPermissionType```) and these can be stored and retrieved using the following public interfaces.
+#### Retrieving the Mini App Custom Permissions using MiniAppID
+Custom permissions and its status can be retrieved using the following interface. ```getCustomPermissions``` will return ```MiniAppCustomPermission``` that contains the meta-info such as ```Pair``` of 
+name and grant result of the custom permissions per miniAppId.
+```kotlin
+val permissions = miniapp.getCustomPermissions(miniAppId)
+```
+#### Store the Mini App Custom Permissions
+Custom permissions for a mini app is cached by the SDK and you can use the following interface to store and retrieve it when you need.
+```kotlin
+var permissionPairs = listOf<Pair<MiniAppCustomPermissionType, MiniAppCustomPermissionResult>>()
+// .. .. ..
+val permissionsToSet = MiniAppCustomPermission(miniAppId, permissionPairs)
+miniapp.setCustomPermissions(permissionsToSet)
 ```
 
 - Create mini app display

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -138,11 +138,12 @@ val miniAppMessageBridge = object: MiniAppMessageBridge() {
 
     override fun requestCustomPermissions(
         permissionsWithDescription: List<Pair<MiniAppCustomPermissionType, String>>,
-        callback: (context: Context, permissionResult: MiniAppCustomPermission) -> Unit
+        callback: (List<Pair<MiniAppCustomPermissionType, MiniAppCustomPermissionResult>>) -> Unit
     ) {
         // Implementation details to request custom permissions
         // .. .. ..
-        callback.invoke(context, permissionResult)
+        // pass a list of Pair of MiniAppCustomPermissionType and MiniAppCustomPermissionResult in callback 
+        callback.invoke(listOf()) 
     }
 }
 ```

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -239,23 +239,6 @@ miniAppNavigator = object : MiniAppNavigator {
 }
 ```
 
-### #4 Custom Permissions
-MiniApp Android SDK supports list of Custom Permissions ( ```MiniAppCustomPermissionType```) and these can be stored and retrieved using the following public interfaces.
-#### Retrieving the Mini App Custom Permissions using MiniAppID
-Custom permissions and its status can be retrieved using the following interface. ```getCustomPermissions``` will return ```MiniAppCustomPermission``` that contains the meta-info such as ```Pair``` of 
-name and grant result of the custom permissions per miniAppId.
-```kotlin
-val permissions = miniapp.getCustomPermissions(miniAppId)
-```
-#### Store the Mini App Custom Permissions
-Custom permissions for a mini app is cached by the SDK and you can use the following interface to store and retrieve it when you need.
-```kotlin
-var permissionPairs = listOf<Pair<MiniAppCustomPermissionType, MiniAppCustomPermissionResult>>()
-// .. .. ..
-val permissionsToSet = MiniAppCustomPermission(miniAppId, permissionPairs)
-miniapp.setCustomPermissions(permissionsToSet)
-```
-
 - Create mini app display
 Using `MiniApp.instance().create("MINI_APP_ID", miniAppMessageBridge, miniAppNavigator)`.
 
@@ -306,6 +289,23 @@ Using `miniAppExternalUrlLoader.shouldClose(url)` which returns `Boolean` to che
 mini app scheme and should close external webview.
 
 Using `#ExternalResultHandler.emitResult(String)` to transmit the url string to mini app view.
+
+### #4 Custom Permissions
+MiniApp Android SDK supports list of Custom Permissions (`MiniAppCustomPermissionType`) and these can be stored and retrieved using the following public interfaces.
+#### Retrieving the Mini App Custom Permissions using MiniAppID
+Custom permissions and its status can be retrieved using the following interface. `getCustomPermissions` will return `MiniAppCustomPermission` that contains the meta-info as a `Pair` of 
+name and grant result (`ALLOWED` or `DENIED`). The custom permissions are stored per each miniAppId.
+```kotlin
+val permissions = miniapp.getCustomPermissions(miniAppId)
+```
+#### Store the Mini App Custom Permissions
+Custom permissions for a mini app are cached by the SDK and you can use the following interface to store permissions when needed.
+```kotlin
+var permissionPairs = listOf<Pair<MiniAppCustomPermissionType, MiniAppCustomPermissionResult>>()
+// .. .. ..
+val permissionsToSet = MiniAppCustomPermission(miniAppId, permissionPairs)
+miniapp.setCustomPermissions(permissionsToSet)
+```
 
 ## Troubleshooting
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -49,7 +49,13 @@ internal class RealMiniApp(
         miniAppId.isBlank() -> throw sdkExceptionForInvalidArguments()
         else -> {
             val (basePath, miniAppInfo) = miniAppDownloader.getMiniApp(miniAppId)
-            displayer.createMiniAppDisplay(basePath, miniAppInfo, miniAppMessageBridge, miniAppNavigator)
+            displayer.createMiniAppDisplay(
+                basePath,
+                miniAppInfo,
+                miniAppMessageBridge,
+                miniAppNavigator,
+                miniAppCustomPermissionCache
+            )
         }
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
@@ -5,6 +5,7 @@ import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 
 internal class Displayer(private val context: Context, private val hostAppUserAgentInfo: String) {
 
@@ -12,13 +13,15 @@ internal class Displayer(private val context: Context, private val hostAppUserAg
         basePath: String,
         miniAppInfo: MiniAppInfo,
         miniAppMessageBridge: MiniAppMessageBridge,
-        miniAppNavigator: MiniAppNavigator?
+        miniAppNavigator: MiniAppNavigator?,
+        miniAppCustomPermissionCache: MiniAppCustomPermissionCache
     ): MiniAppDisplay = RealMiniAppDisplay(
         context = context,
         basePath = basePath,
         miniAppInfo = miniAppInfo,
         miniAppMessageBridge = miniAppMessageBridge,
         miniAppNavigator = miniAppNavigator,
-        hostAppUserAgentInfo = hostAppUserAgentInfo
+        hostAppUserAgentInfo = hostAppUserAgentInfo,
+        miniAppCustomPermissionCache = miniAppCustomPermissionCache
     )
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -12,6 +12,7 @@ import com.rakuten.tech.mobile.miniapp.MiniAppScheme
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.miniapp.navigator.ExternalResultHandler
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 import java.io.File
 
 private const val SUB_DOMAIN_PATH = "miniapp"
@@ -25,7 +26,8 @@ internal class MiniAppWebView(
     miniAppMessageBridge: MiniAppMessageBridge,
     miniAppNavigator: MiniAppNavigator?,
     val hostAppUserAgentInfo: String,
-    val miniAppWebChromeClient: MiniAppWebChromeClient = MiniAppWebChromeClient(context, miniAppInfo)
+    val miniAppWebChromeClient: MiniAppWebChromeClient = MiniAppWebChromeClient(context, miniAppInfo),
+    val miniAppCustomPermissionCache: MiniAppCustomPermissionCache
 ) : WebView(context), WebViewListener {
 
     private val miniAppScheme = MiniAppScheme(miniAppInfo.id)
@@ -45,7 +47,12 @@ internal class MiniAppWebView(
 
         settings.javaScriptEnabled = true
         addJavascriptInterface(miniAppMessageBridge, MINI_APP_INTERFACE)
-        miniAppMessageBridge.setWebViewListener(this)
+
+        miniAppMessageBridge.init(
+            webViewListener = this,
+            customPermissionCache = miniAppCustomPermissionCache,
+            miniAppInfo = miniAppInfo
+        )
 
         settings.allowUniversalAccessFromFileURLs = true
         settings.domStorageEnabled = true

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
@@ -13,6 +13,7 @@ import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 import com.rakuten.tech.mobile.miniapp.sdkExceptionForNoActivityContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -24,7 +25,8 @@ internal class RealMiniAppDisplay(
     val miniAppInfo: MiniAppInfo,
     val miniAppMessageBridge: MiniAppMessageBridge,
     val miniAppNavigator: MiniAppNavigator?,
-    val hostAppUserAgentInfo: String
+    val hostAppUserAgentInfo: String,
+    val miniAppCustomPermissionCache: MiniAppCustomPermissionCache
 ) : MiniAppDisplay {
 
     @VisibleForTesting
@@ -74,7 +76,8 @@ internal class RealMiniAppDisplay(
                 miniAppInfo = miniAppInfo,
                 miniAppMessageBridge = miniAppMessageBridge,
                 miniAppNavigator = miniAppNavigator,
-                hostAppUserAgentInfo = hostAppUserAgentInfo
+                hostAppUserAgentInfo = hostAppUserAgentInfo,
+                miniAppCustomPermissionCache = miniAppCustomPermissionCache
             )
             miniAppWebView!!
         }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -137,7 +137,7 @@ abstract class MiniAppMessageBridge {
             postError(callbackId, MiniAppPermissionResult.getValue(isGranted).type)
     }
 
-    /** Inform the permission request result to MiniApp. **/
+    /** Inform the custom permission request result to MiniApp. **/
     @Suppress("LongMethod", "FunctionMaxLength")
     internal fun onRequestCustomPermissionsResult(callbackId: String, jsonResult: String) {
         postValue(callbackId, jsonResult)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -6,8 +6,12 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.display.WebViewListener
-import com.rakuten.tech.mobile.miniapp.permission.*
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermission
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionManager
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionResult
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppPermissionType
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppPermissionResult
 
 @Suppress("TooGenericExceptionCaught", "SwallowedException", "TooManyFunctions")

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionManager.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionManager.kt
@@ -7,7 +7,8 @@ import com.rakuten.tech.mobile.miniapp.js.CustomPermissionObj
 /**
  * A class to manage additional features involved with custom permissions in this SDK.
  */
-internal class MiniAppCustomPermissionManager {
+internal class
+MiniAppCustomPermissionManager {
 
     /**
      * Prepares a list of custom permissions Pair with names and description.
@@ -29,8 +30,8 @@ internal class MiniAppCustomPermissionManager {
 
     /**
      * Creates a JSON string by mapping with [MiniAppCustomPermissionResponse] class.
-     * @param [context] for using in SDK cache.
-     * @param [miniAppId] list of custom permissions Pair.
+     * @param [miniAppCustomPermissionCache] for filtering values from cache.
+     * @param [miniAppId] id of miniapp required by cache.
      * @param [suppliedPermissions] list of custom permissions Pair with names and description,
      * initially it was prepared in [MiniAppMessageBridge].
      * @return [String] as json response with permission grant results.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionManager.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionManager.kt
@@ -2,26 +2,47 @@ package com.rakuten.tech.mobile.miniapp.permission
 
 import androidx.annotation.VisibleForTesting
 import com.google.gson.Gson
-import com.rakuten.tech.mobile.miniapp.MiniApp
+import com.rakuten.tech.mobile.miniapp.js.CustomPermissionObj
 
 /**
  * A class to manage additional features involved with custom permissions in this SDK.
  */
-class MiniAppCustomPermissionManager(val miniapp: MiniApp) {
+internal class MiniAppCustomPermissionManager {
+
+    /**
+     * Prepares a list of custom permissions Pair with names and description.
+     * @param [permissionObjList] list of CustomPermissionObj.
+     * @return [List<Pair<MiniAppCustomPermissionType, String>>].
+     */
+    fun preparePermissionsWithDescription(
+        permissionObjList: ArrayList<CustomPermissionObj>
+    ): List<Pair<MiniAppCustomPermissionType, String>> {
+        val permissionsWithDescription =
+            arrayListOf<Pair<MiniAppCustomPermissionType, String>>()
+        permissionObjList.forEach {
+            MiniAppCustomPermissionType.getValue(it.name).let { type ->
+                permissionsWithDescription.add(Pair(type, it.description))
+            }
+        }
+        return permissionsWithDescription
+    }
 
     /**
      * Creates a JSON string by mapping with [MiniAppCustomPermissionResponse] class.
+     * @param [context] for using in SDK cache.
      * @param [miniAppId] list of custom permissions Pair.
      * @param [suppliedPermissions] list of custom permissions Pair with names and description,
      * initially it was prepared in [MiniAppMessageBridge].
      * @return [String] as json response with permission grant results.
      */
     fun createJsonResponse(
+        miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
         miniAppId: String,
         suppliedPermissions: List<Pair<MiniAppCustomPermissionType, String>>
     ): String {
         val responseObj = MiniAppCustomPermissionResponse(arrayListOf())
-        val permissions = filterPermissionsToSend(miniAppId, suppliedPermissions)
+        val permissions =
+            filterPermissionsToSend(miniAppCustomPermissionCache, miniAppId, suppliedPermissions)
         permissions.forEach {
             responseObj.permissions.add(
                 MiniAppCustomPermissionResponse.CustomPermissionResponseObj(
@@ -40,11 +61,12 @@ class MiniAppCustomPermissionManager(val miniapp: MiniApp) {
      * any unknown permission.
      */
     @VisibleForTesting
-    internal fun filterPermissionsToSend(
+    fun filterPermissionsToSend(
+        miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
         miniAppId: String,
         suppliedPermissions: List<Pair<MiniAppCustomPermissionType, String>>
     ): List<Pair<MiniAppCustomPermissionType, MiniAppCustomPermissionResult>> {
-        val cachedPermissions = miniapp.getCustomPermissions(miniAppId).pairValues
+        val cachedPermissions = miniAppCustomPermissionCache.readPermissions(miniAppId).pairValues
         val filteredPair =
             mutableListOf<Pair<MiniAppCustomPermissionType, MiniAppCustomPermissionResult>>()
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -75,7 +75,7 @@ class RealMiniAppSpec {
             verify(miniAppDownloader, times(1)).getMiniApp(TEST_MA_ID)
             verify(displayer, times(1))
                 .createMiniAppDisplay(getMiniAppResult.first, getMiniAppResult.second,
-                    miniAppMessageBridge, null)
+                    miniAppMessageBridge, null, miniAppCustomPermissionCache)
         }
 
     @Test
@@ -88,7 +88,7 @@ class RealMiniAppSpec {
             verify(miniAppDownloader, times(1)).getMiniApp(TEST_MA_ID)
             verify(displayer, times(1))
                 .createMiniAppDisplay(getMiniAppResult.first, getMiniAppResult.second,
-                    miniAppMessageBridge, miniAppNavigator)
+                    miniAppMessageBridge, miniAppNavigator, miniAppCustomPermissionCache)
         }
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerSpec.kt
@@ -42,6 +42,7 @@ class DisplayerSpec {
             basePath = context.filesDir.path,
             miniAppInfo = TEST_MA,
             miniAppMessageBridge = miniAppMessageBridge,
-            miniAppNavigator = mock()
+            miniAppNavigator = mock(),
+            miniAppCustomPermissionCache = mock()
         )
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -21,6 +21,7 @@ import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.miniapp.navigator.ExternalResultHandler
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppExternalUrlLoader
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 import org.amshove.kluent.*
 import org.junit.Before
 import org.junit.Test
@@ -36,6 +37,7 @@ open class BaseWebViewSpec {
     lateinit var webResourceRequest: WebResourceRequest
     val miniAppMessageBridge: MiniAppMessageBridge = mock()
     val miniAppNavigator: MiniAppNavigator = mock()
+    internal val miniAppCustomPermissionCache: MiniAppCustomPermissionCache = mock()
     internal lateinit var webChromeClient: MiniAppWebChromeClient
 
     @Before
@@ -51,7 +53,8 @@ open class BaseWebViewSpec {
             miniAppMessageBridge = miniAppMessageBridge,
             miniAppNavigator = miniAppNavigator,
             hostAppUserAgentInfo = TEST_HA_NAME,
-            miniAppWebChromeClient = webChromeClient
+            miniAppWebChromeClient = webChromeClient,
+            miniAppCustomPermissionCache = miniAppCustomPermissionCache
         )
         webResourceRequest = getWebResReq(miniAppWebView.getLoadUrl().toUri())
     }
@@ -111,7 +114,8 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
             miniAppMessageBridge = miniAppMessageBridge,
             miniAppNavigator = miniAppNavigator,
             hostAppUserAgentInfo = "",
-            miniAppWebChromeClient = webChromeClient
+            miniAppWebChromeClient = webChromeClient,
+            miniAppCustomPermissionCache = mock()
         )
         miniAppWebView.settings.userAgentString shouldNotEndWith TEST_HA_NAME
     }
@@ -129,16 +133,24 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
     @Test
     fun `each mini app should have different domain`() {
         val miniAppWebViewForMiniapp1 = MiniAppWebView(
-            context, miniAppWebView.basePath, TEST_MA, miniAppMessageBridge, miniAppNavigator, TEST_HA_NAME)
+            context,
+            miniAppWebView.basePath,
+            TEST_MA,
+            miniAppMessageBridge,
+            miniAppNavigator,
+            TEST_HA_NAME,
+            mock(),
+            mock()
+        )
         val miniAppWebViewForMiniapp2 = MiniAppWebView(
             context, miniAppWebView.basePath, TEST_MA.copy(id = "app-id-2"), miniAppMessageBridge,
-            miniAppNavigator, TEST_HA_NAME)
+            miniAppNavigator, TEST_HA_NAME, mock(), mock())
         miniAppWebViewForMiniapp1.url shouldNotBeEqualTo miniAppWebViewForMiniapp2.url
     }
 
     @Test
     fun `MiniAppMessageBridge should be connected with RealMiniAppDisplay`() {
-        verify(miniAppMessageBridge, atLeastOnce()).setWebViewListener(miniAppWebView)
+        verify(miniAppMessageBridge, atLeastOnce()).init(miniAppWebView, miniAppCustomPermissionCache, TEST_MA)
     }
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplaySpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplaySpec.kt
@@ -38,7 +38,8 @@ class RealMiniAppDisplaySpec {
             miniAppInfo = TEST_MA,
             miniAppMessageBridge = miniAppMessageBridge,
             miniAppNavigator = mock(),
-            hostAppUserAgentInfo = TEST_HA_NAME
+            hostAppUserAgentInfo = TEST_HA_NAME,
+            miniAppCustomPermissionCache = mock()
         )
     }
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.miniapp.js
 
+import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.gson.Gson
 import com.nhaarman.mockitokotlin2.mock
@@ -9,6 +10,7 @@ import com.rakuten.tech.mobile.miniapp.TEST_CALLBACK_ID
 import com.rakuten.tech.mobile.miniapp.TEST_CALLBACK_VALUE
 import com.rakuten.tech.mobile.miniapp.TEST_ERROR_MSG
 import com.rakuten.tech.mobile.miniapp.display.WebViewListener
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermission
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppPermissionResult
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppPermissionType
@@ -37,10 +39,10 @@ class MiniAppMessageBridgeSpec {
             }
 
             override fun requestCustomPermissions(
-                permissions: List<Pair<MiniAppCustomPermissionType, String>>,
-                callback: (grantResult: String) -> Unit
+                permissionsWithDescription: List<Pair<MiniAppCustomPermissionType, String>>,
+                callback: (context: Context, permissionsWithResult: MiniAppCustomPermission) -> Unit
             ) {
-                val grantResult = "{\"USER_NAME\":\"DENIED\"}"
+                val grantResult = "{\"rakuten.miniapp.user.USER_NAME\":\"DENIED\"}"
                 onRequestCustomPermissionsResult(TEST_CALLBACK_ID, grantResult)
             }
         }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionManagerSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionManagerSpec.kt
@@ -1,14 +1,14 @@
 package com.rakuten.tech.mobile.miniapp.permission
 
 import com.nhaarman.mockitokotlin2.*
-import com.rakuten.tech.mobile.miniapp.MiniApp
+import com.rakuten.tech.mobile.miniapp.js.CustomPermissionObj
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
 
 class MiniAppCustomPermissionManagerSpec {
     private lateinit var miniAppCustomPermissionManager: MiniAppCustomPermissionManager
-    private var miniApp: MiniApp = mock()
+    private var miniAppCustomPermissionCache: MiniAppCustomPermissionCache = mock()
     private val miniAppId: String = "miniAppId"
     private val miniAppCustomPermission = MiniAppCustomPermission(
         miniAppId,
@@ -22,18 +22,36 @@ class MiniAppCustomPermissionManagerSpec {
 
     @Before
     fun setUp() {
-        doReturn(miniAppCustomPermission).whenever(miniApp).getCustomPermissions(miniAppId)
-        miniAppCustomPermissionManager = MiniAppCustomPermissionManager(miniApp)
+        doReturn(miniAppCustomPermission).whenever(miniAppCustomPermissionCache)
+            .readPermissions(miniAppId)
+        miniAppCustomPermissionManager = MiniAppCustomPermissionManager()
+    }
+
+    @Test
+    fun `preparePermissionsWithDescription should return a list of pair with name and description`() {
+        val description = "dummy description"
+        val customPermissionObj = CustomPermissionObj(
+            "rakuten.miniapp.user.USER_NAME",
+            description
+        )
+        val actual = miniAppCustomPermissionManager.preparePermissionsWithDescription(
+            arrayListOf(customPermissionObj)
+        )
+        val expected = listOf(Pair(MiniAppCustomPermissionType.USER_NAME, description))
+        assertEquals(expected, actual)
     }
 
     @Test
     fun `createJsonResponse should return json string based on supplied custom permissions`() {
         val miniAppId = "miniAppId"
         val suppliedPermissions = listOf(
-            Pair(MiniAppCustomPermissionType.USER_NAME, "description")
+            Pair(MiniAppCustomPermissionType.USER_NAME, "dummy description")
         )
-        val actual =
-            miniAppCustomPermissionManager.createJsonResponse(miniAppId, suppliedPermissions)
+        val actual = miniAppCustomPermissionManager.createJsonResponse(
+            miniAppCustomPermissionCache,
+            miniAppId,
+            suppliedPermissions
+        )
         val expected =
             "{\"permissions\":[{\"name\":\"rakuten.miniapp.user.USER_NAME\",\"isGranted\":\"DENIED\"}]}"
 
@@ -44,11 +62,14 @@ class MiniAppCustomPermissionManagerSpec {
     fun `filterPermissionsToSend should return correct values based on known custom permissions`() {
         val miniAppId = "miniAppId"
         val suppliedPermissions = listOf(
-            Pair(MiniAppCustomPermissionType.USER_NAME, "description")
+            Pair(MiniAppCustomPermissionType.USER_NAME, "dummy description")
         )
 
-        val actual =
-            miniAppCustomPermissionManager.filterPermissionsToSend(miniAppId, suppliedPermissions)
+        val actual = miniAppCustomPermissionManager.filterPermissionsToSend(
+            miniAppCustomPermissionCache,
+            miniAppId,
+            suppliedPermissions
+        )
         val expected = miniAppCustomPermission.pairValues
 
         assertEquals(expected, actual)
@@ -58,11 +79,14 @@ class MiniAppCustomPermissionManagerSpec {
     fun `filterPermissionsToSend should return correct values based on unknown custom permissions`() {
         val miniAppId = "miniAppId"
         val suppliedPermissions = listOf(
-            Pair(MiniAppCustomPermissionType.UNKNOWN, "description")
+            Pair(MiniAppCustomPermissionType.UNKNOWN, "dummy description")
         )
 
-        val actual =
-            miniAppCustomPermissionManager.filterPermissionsToSend(miniAppId, suppliedPermissions)
+        val actual = miniAppCustomPermissionManager.filterPermissionsToSend(
+            miniAppCustomPermissionCache,
+            miniAppId,
+            suppliedPermissions
+        )
         val expected = listOf(
             Pair(
                 MiniAppCustomPermissionType.UNKNOWN,

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -19,6 +19,7 @@ import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppPermissionType
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 import com.rakuten.tech.mobile.miniapp.navigator.ExternalResultHandler
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermission
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.testapp.helper.AppPermission
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
@@ -111,13 +112,13 @@ class MiniAppDisplayActivity : BaseActivity() {
                 }
 
                 override fun requestCustomPermissions(
-                    permissions: List<Pair<MiniAppCustomPermissionType, String>>,
-                    callback: (grantResult: String) -> Unit
+                    permissionsWithDescription: List<Pair<MiniAppCustomPermissionType, String>>,
+                    callback: (context: Context, permissionResult: MiniAppCustomPermission) -> Unit
                 ) {
-                    CustomPermissionPresenter().promptForCustomPermissions(
+                    CustomPermissionPresenter().executeCustomPermissionsCallback(
                         this@MiniAppDisplayActivity,
                         appId,
-                        permissions,
+                        permissionsWithDescription,
                         callback
                     )
                 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -19,7 +19,7 @@ import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppPermissionType
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 import com.rakuten.tech.mobile.miniapp.navigator.ExternalResultHandler
-import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermission
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionResult
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.testapp.helper.AppPermission
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
@@ -113,7 +113,7 @@ class MiniAppDisplayActivity : BaseActivity() {
 
                 override fun requestCustomPermissions(
                     permissionsWithDescription: List<Pair<MiniAppCustomPermissionType, String>>,
-                    callback: (context: Context, permissionResult: MiniAppCustomPermission) -> Unit
+                    callback: (List<Pair<MiniAppCustomPermissionType, MiniAppCustomPermissionResult>>) -> Unit
                 ) {
                     CustomPermissionPresenter().executeCustomPermissionsCallback(
                         this@MiniAppDisplayActivity,

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/CustomPermissionPresenter.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/CustomPermissionPresenter.kt
@@ -7,7 +7,6 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.rakuten.tech.mobile.miniapp.MiniApp
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermission
-import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionManager
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionResult
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.ListCustomPermissionBinding
@@ -17,83 +16,64 @@ class CustomPermissionPresenter(private val miniapp: MiniApp) {
 
     constructor() : this(MiniApp.instance(AppSettings.instance.miniAppSettings))
 
-    fun promptForCustomPermissions(
+    fun executeCustomPermissionsCallback(
         context: Context,
         miniAppId: String,
-        permissionWithDescriptions: List<Pair<MiniAppCustomPermissionType, String>>,
-        callback: (grantResult: String) -> Unit
+        permissionsWithDescription: List<Pair<MiniAppCustomPermissionType, String>>,
+        callback: (context: Context, permissionsWithResult: MiniAppCustomPermission) -> Unit
     ) {
         if (miniAppId.isEmpty())
             return
 
-        // prepare UI for adapter
-        val layoutInflater = LayoutInflater.from(context)
-        val permissionLayout = ListCustomPermissionBinding.inflate(layoutInflater, null, false)
-        permissionLayout.listCustomPermission.layoutManager = LinearLayoutManager(context)
-        val adapter = CustomPermissionAdapter()
-
-        permissionLayout.listCustomPermission.addItemDecoration(
-            DividerItemDecoration(
-                context,
-                DividerItemDecoration.VERTICAL
-            )
-        )
-
-        // prepare adapter for showing items
+        // get cached data from SDK
         val cachedList = miniapp.getCustomPermissions(miniAppId).pairValues
-        val filteredPair = permissionWithDescriptions.filter { (first) ->
+
+        // prepare data for adapter to check if there is any denied permission
+        val permissionsForAdapter = permissionsWithDescription.filter { (first) ->
             cachedList.find {
                 it.first == first && it.second == MiniAppCustomPermissionResult.DENIED
             } != null
         }
 
-        val namesForAdapter: ArrayList<MiniAppCustomPermissionType> = arrayListOf()
-        val resultsForAdapter: ArrayList<MiniAppCustomPermissionResult> = arrayListOf()
-        val descriptionForAdapter: ArrayList<String> = arrayListOf()
-
-        filteredPair.forEach {
-            namesForAdapter.add(it.first)
-            descriptionForAdapter.add(it.second)
-            resultsForAdapter.add(MiniAppCustomPermissionResult.ALLOWED)
-        }
-
-        adapter.addPermissionList(namesForAdapter, resultsForAdapter, descriptionForAdapter)
-        permissionLayout.listCustomPermission.adapter = adapter
-
-        // prepare listener for adapter
-        val permissionsToStore = MiniAppCustomPermission(miniAppId, adapter.permissionPairs)
-
-        val listener = DialogInterface.OnClickListener { _, _ ->
-            miniapp.setCustomPermissions(permissionsToStore)
-
-            // send the callback with grant results
-            sendGrantResultCallback(miniAppId, permissionWithDescriptions, callback)
-        }
-
-        val permissionDialogBuilder =
-            CustomPermissionDialog.Builder().build(context).apply {
-                setView(permissionLayout.root)
-                setListener(listener)
+        // show dialog if there is any denied permission
+        if (permissionsForAdapter.isNotEmpty()) {
+            val adapter = CustomPermissionAdapter()
+            val namesForAdapter: ArrayList<MiniAppCustomPermissionType> = arrayListOf()
+            val resultsForAdapter: ArrayList<MiniAppCustomPermissionResult> = arrayListOf()
+            val descriptionForAdapter: ArrayList<String> = arrayListOf()
+            permissionsForAdapter.forEach {
+                namesForAdapter.add(it.first)
+                descriptionForAdapter.add(it.second)
+                resultsForAdapter.add(MiniAppCustomPermissionResult.ALLOWED)
             }
 
-        // show dialog if there is any denied permission,
-        // otherwise send the callback with grant results
-        if (filteredPair.isNotEmpty())
-            permissionDialogBuilder.show()
-        else
-            sendGrantResultCallback(miniAppId, permissionWithDescriptions, callback)
+            adapter.addPermissionList(namesForAdapter, resultsForAdapter, descriptionForAdapter)
+            val permissionLayout = getPermissionLayout(context)
+            permissionLayout.listCustomPermission.adapter = adapter
+
+            // show dialog with listener which will invoke the callback
+            CustomPermissionDialog.Builder().build(context).apply {
+                setView(permissionLayout.root)
+                setListener(DialogInterface.OnClickListener { _, _ ->
+                    callback.invoke(
+                        context,
+                        MiniAppCustomPermission(miniAppId, adapter.permissionPairs)
+                    )
+                })
+            }.show()
+        } else {
+            callback.invoke(context, MiniAppCustomPermission(miniAppId, cachedList))
+        }
     }
 
-    private fun sendGrantResultCallback(
-        miniAppId: String,
-        permissionWithDescriptions: List<Pair<MiniAppCustomPermissionType, String>>,
-        callback: (grantResult: String) -> Unit
-    ) {
-        // send json response to miniapp
-        val result = MiniAppCustomPermissionManager(miniapp).createJsonResponse(
-            miniAppId,
-            permissionWithDescriptions
+    private fun getPermissionLayout(context: Context): ListCustomPermissionBinding {
+        val layoutInflater = LayoutInflater.from(context)
+        val permissionLayout = ListCustomPermissionBinding.inflate(layoutInflater, null, false)
+        permissionLayout.listCustomPermission.layoutManager = LinearLayoutManager(context)
+        permissionLayout.listCustomPermission.addItemDecoration(
+            DividerItemDecoration(context, DividerItemDecoration.VERTICAL)
         )
-        callback.invoke(result)
+
+        return permissionLayout
     }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/CustomPermissionPresenter.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/CustomPermissionPresenter.kt
@@ -6,7 +6,6 @@ import android.view.LayoutInflater
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.rakuten.tech.mobile.miniapp.MiniApp
-import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermission
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionResult
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.ListCustomPermissionBinding
@@ -20,7 +19,7 @@ class CustomPermissionPresenter(private val miniapp: MiniApp) {
         context: Context,
         miniAppId: String,
         permissionsWithDescription: List<Pair<MiniAppCustomPermissionType, String>>,
-        callback: (context: Context, permissionsWithResult: MiniAppCustomPermission) -> Unit
+        callback: (List<Pair<MiniAppCustomPermissionType, MiniAppCustomPermissionResult>>) -> Unit
     ) {
         if (miniAppId.isEmpty())
             return
@@ -55,14 +54,11 @@ class CustomPermissionPresenter(private val miniapp: MiniApp) {
             CustomPermissionDialog.Builder().build(context).apply {
                 setView(permissionLayout.root)
                 setListener(DialogInterface.OnClickListener { _, _ ->
-                    callback.invoke(
-                        context,
-                        MiniAppCustomPermission(miniAppId, adapter.permissionPairs)
-                    )
+                    callback.invoke(adapter.permissionPairs)
                 })
             }.show()
         } else {
-            callback.invoke(context, MiniAppCustomPermission(miniAppId, cachedList))
+            callback.invoke(cachedList)
         }
     }
 


### PR DESCRIPTION
# Description
- Include instruction to use custom permission feature in [USERGUIDE](https://github.com/rakutentech/android-miniapp/blob/master/miniapp/USERGUIDE.md).
- Refactor code to make `MiniAppCustomPermissionManager` internal. HostApp doesn't need to call `setCustomPermissions` unless revoking permissions.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
