### PR TITLE
Rename "Test" postfixes to "Spec"

### DIFF
--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/AppInfoApiSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/AppInfoApiSpec.kt
@@ -14,7 +14,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 open class AppInfoApiSpec private constructor(
     internal val mockServer: MockWebServer
-) : MockWebServerBaseTest(mockServer) {
+) : MockWebServerBaseSpec(mockServer) {
 
     constructor() : this(MockWebServer())
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/DownloadApiSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/DownloadApiSpec.kt
@@ -14,7 +14,7 @@ import java.nio.charset.Charset
 
 open class DownloadApiSpec private constructor(
     internal val mockServer: MockWebServer
-) : MockWebServerBaseTest(mockServer) {
+) : MockWebServerBaseSpec(mockServer) {
 
     constructor() : this(MockWebServer())
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiSpec.kt
@@ -13,7 +13,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 open class ManifestApiSpec private constructor(
     internal val mockServer: MockWebServer
-) : MockWebServerBaseTest(mockServer) {
+) : MockWebServerBaseSpec(mockServer) {
 
     constructor() : this(MockWebServer())
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/MockWebServerBaseSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/MockWebServerBaseSpec.kt
@@ -6,7 +6,7 @@ import org.junit.Before
 import java.util.logging.Level
 import java.util.logging.LogManager
 
-open class MockWebServerBaseTest(private val mockServer: MockWebServer) {
+open class MockWebServerBaseSpec(private val mockServer: MockWebServer) {
     private lateinit var baseUrl: String
 
     init {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtilsSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtilsSpec.kt
@@ -13,7 +13,7 @@ import org.junit.Test
 
 class RetrofitCreatorUtilsSpec private constructor(
     private val mockServer: MockWebServer
-) : MockWebServerBaseTest(mockServer) {
+) : MockWebServerBaseSpec(mockServer) {
 
     constructor() : this(MockWebServer())
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
@@ -25,7 +25,7 @@ import java.net.UnknownHostException
 
 open class RetrofitRequestExecutorSpec private constructor(
     internal val mockServer: MockWebServer
-) : MockWebServerBaseTest(mockServer) {
+) : MockWebServerBaseSpec(mockServer) {
 
     constructor() : this(MockWebServer())
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerSpec.kt
@@ -15,7 +15,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class DisplayerTest {
+class DisplayerSpec {
 
     private lateinit var context: Context
     private val miniAppMessageBridge: MiniAppMessageBridge = mock()

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -29,7 +29,7 @@ import org.mockito.Mockito
 import java.io.ByteArrayInputStream
 import kotlin.test.assertTrue
 
-open class BaseWebViewTest {
+open class BaseWebViewSpec {
     lateinit var context: Context
     lateinit var basePath: String
     internal lateinit var miniAppWebView: MiniAppWebView
@@ -58,7 +58,7 @@ open class BaseWebViewTest {
 }
 
 @RunWith(AndroidJUnit4::class)
-class MiniAppWebviewTest : BaseWebViewTest() {
+class MiniAppWebviewSpec : BaseWebViewSpec() {
 
     @Test
     fun `for a given app id, creates corresponding view for the caller`() {
@@ -158,7 +158,7 @@ class MiniAppWebviewTest : BaseWebViewTest() {
 
 @Suppress("SwallowedException")
 @RunWith(AndroidJUnit4::class)
-class MiniAppWebClientTest : BaseWebViewTest() {
+class MiniAppWebClientSpec : BaseWebViewSpec() {
     private val externalResultHandler: ExternalResultHandler = spy()
     private val miniAppScheme = MiniAppScheme(TEST_MA_ID)
 
@@ -277,7 +277,7 @@ class MiniAppWebClientTest : BaseWebViewTest() {
 }
 
 @RunWith(AndroidJUnit4::class)
-class MiniAppWebChromeTest : BaseWebViewTest() {
+class MiniAppWebChromeTest : BaseWebViewSpec() {
 
     @Test
     fun `for a WebChromeClient, it should be MiniAppWebChromeClient`() {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplaySpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplaySpec.kt
@@ -22,7 +22,7 @@ import org.mockito.Mockito
 
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
-class RealMiniAppDisplayTest {
+class RealMiniAppDisplaySpec {
     private lateinit var context: Context
     private lateinit var basePath: String
     private lateinit var realDisplay: RealMiniAppDisplay

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStatusSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStatusSpec.kt
@@ -16,7 +16,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class MiniAppStatusTest {
+class MiniAppStatusSpec {
     private lateinit var context: Context
     private lateinit var miniAppStatus: MiniAppStatus
     private lateinit var prefs: SharedPreferences

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageSpec.kt
@@ -22,7 +22,7 @@ import java.util.zip.ZipOutputStream
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
-class MiniAppStorageTest {
+class MiniAppStorageSpec {
     private val fileWriter: FileWriter = mock()
     private val miniAppStorage: MiniAppStorage = MiniAppStorage(fileWriter, mock(), mock())
     private val zipFile = "test.zip"

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/UrlToFileInfoParserSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/UrlToFileInfoParserSpec.kt
@@ -5,7 +5,7 @@ import com.rakuten.tech.mobile.miniapp.VALID_FILE_URL_PATH
 import org.amshove.kluent.shouldEqual
 import org.junit.Test
 
-class UrlToFileInfoParserTest {
+class UrlToFileInfoParserSpec {
 
     private var urlParser = UrlToFileInfoParser()
 


### PR DESCRIPTION
# Description
We can use one postfix as convention while titling the test files. I have found two types of postfixes e.g. "Test" & "Spec" are using in this repository, so we can use "Spec" in everywhere.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
