### PR TITLE
JS Bridge updates for Custom Permission support

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -78,7 +78,7 @@ internal class MiniAppWebView(
     override fun runSuccessCallback(callbackId: String, value: String) {
         post {
             evaluateJavascript(
-                "MiniAppBridge.execSuccessCallback(\"$callbackId\", \"$value\")"
+                "MiniAppBridge.execSuccessCallback(`$callbackId`, `${value.replace("`", "\\`")}`)"
             ) {}
         }
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionResponse.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionResponse.kt
@@ -11,6 +11,6 @@ data class MiniAppCustomPermissionResponse(
      */
     data class CustomPermissionResponseObj(
         val name: String,
-        val isGranted: String
+        val status: String
     )
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -15,6 +15,7 @@ import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.webkit.WebViewAssetLoader
 import com.nhaarman.mockitokotlin2.*
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.rakuten.tech.mobile.miniapp.*
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
@@ -165,6 +166,24 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
 
         miniAppWebView.getLoadUrl() shouldBeEqualTo
                 "https://mscheme.${miniAppWebView.miniAppInfo.id}/miniapp/index.html"
+    }
+
+    @Test
+    fun `should send response for the specified ID over the mini app bridge`() {
+        val spyMiniAppWebView = spy(miniAppWebView)
+        spyMiniAppWebView.runSuccessCallback("test_id", "test_value")
+
+        Verify on spyMiniAppWebView that spyMiniAppWebView.evaluateJavascript(
+            argWhere { it.contains("""MiniAppBridge.execSuccessCallback(`test_id`""") }, any())
+    }
+
+    @Test
+    fun `should send response with escaped backtick characters`() {
+        val spyMiniAppWebView = spy(miniAppWebView)
+        spyMiniAppWebView.runSuccessCallback("test_id", "`test response`")
+
+        Verify on spyMiniAppWebView that spyMiniAppWebView.evaluateJavascript(
+            argWhere { it.contains("""`\`test response\``""") }, any())
     }
 }
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionManagerSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionManagerSpec.kt
@@ -53,7 +53,7 @@ class MiniAppCustomPermissionManagerSpec {
             suppliedPermissions
         )
         val expected =
-            "{\"permissions\":[{\"name\":\"rakuten.miniapp.user.USER_NAME\",\"isGranted\":\"DENIED\"}]}"
+            "{\"permissions\":[{\"name\":\"rakuten.miniapp.user.USER_NAME\",\"status\":\"DENIED\"}]}"
 
         assertEquals(expected, actual)
     }


### PR DESCRIPTION
# Description
- build: Update JS bridge submodule
  - This fixes an issue where the response was being returned to the user as as string rather than an object
- refactor: (Custom permissions) Rename 'isGranted' param to 'status'
  -  This param doesn't represent a boolean - it represents a status of allowed, denied, or not available so it should be named accordingly.
- fix: JS objects weren't being sent correctly over JS bridge
  - Objects were being sent with normal double quotes which causes problems because the keys/values in the object are surrounded by double quotes. So I have changed this to use backticks and also added a fix so that backticks will be escaped if included in the response value.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
