### PR TITLE
refactor: default share implementation

### DIFF
--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -125,7 +125,7 @@ There are some methods have default implementation but host app can override the
 | shareContent                 | ✅       |
 
 ```kotlin
-val miniAppMessageBridge = object: MiniAppMessageBridge(activity) {
+val miniAppMessageBridge = object: MiniAppMessageBridge() {
     override fun getUniqueId() {
         val id: String = ""
         // Implementation details to generate a Unique ID

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -115,9 +115,14 @@ CoroutineScope(Dispatchers.IO).launch {
 ### #4 Implement the MiniAppMessageBridge
 
 The `MiniAppMessageBridge` is used for passing messages between the Mini App (JavaScript) and the Host App (your native Android App) and vice versa. Your App must provide the implementation for these functions and pass this implementation to the `MiniApp#create` function.
-
 There are some methods have default implementation but host app can override them to fully control.
-The parameter `activity` is not required for `MiniAppMessageBridge` but it is essential to ensure all default methods work as expected.
+
+| Method                       | Default  |
+|------------------------------|----------|
+| getUniqueId                  | 🚫       |
+| requestPermission            | 🚫       |
+| requestCustomPermissions     | 🚫       |
+| shareContent                 | ✅       |
 
 ```kotlin
 val miniAppMessageBridge = object: MiniAppMessageBridge(activity) {

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -116,8 +116,11 @@ CoroutineScope(Dispatchers.IO).launch {
 
 The `MiniAppMessageBridge` is used for passing messages between the Mini App (JavaScript) and the Host App (your native Android App) and vice versa. Your App must provide the implementation for these functions and pass this implementation to the `MiniApp#create` function.
 
+There are some methods have default implementation but host app can override them to fully control.
+The parameter `activity` is not required for `MiniAppMessageBridge` but it is essential to ensure all default methods work as expected.
+
 ```kotlin
-val miniAppMessageBridge = object: MiniAppMessageBridge() {
+val miniAppMessageBridge = object: MiniAppMessageBridge(activity) {
     override fun getUniqueId() {
         val id: String = ""
         // Implementation details to generate a Unique ID

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -23,7 +23,7 @@ internal class MiniAppDownloader(
     private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : UpdatableApiClient {
 
-    @Suppress("SwallowedException")
+    @Suppress("SwallowedException", "LongMethod")
     suspend fun getMiniApp(appId: String): Pair<String, MiniAppInfo> {
         try {
             val miniAppInfo = apiClient.fetchInfo(appId)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppScheme.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppScheme.kt
@@ -7,10 +7,4 @@ internal class MiniAppScheme(miniAppId: String) {
     val miniAppCustomDomain = "https://$miniAppDomain/"
 
     fun isMiniAppUrl(url: String) = url.startsWith(miniAppCustomDomain) || url.startsWith(miniAppCustomScheme)
-
-    internal inline fun <T, R> ifLoadingCustomScheme(url: T, callback: (String) -> R): R? =
-        if (url is String && url.startsWith(miniAppCustomScheme))
-            url.replace(miniAppCustomScheme, miniAppCustomDomain).let(callback)
-        else
-            null
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -1,6 +1,7 @@
 package com.rakuten.tech.mobile.miniapp.display
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.Context
 import android.view.ViewGroup
 import android.webkit.WebView
@@ -49,6 +50,7 @@ internal class MiniAppWebView(
         addJavascriptInterface(miniAppMessageBridge, MINI_APP_INTERFACE)
 
         miniAppMessageBridge.init(
+            activity = context as Activity,
             webViewListener = this,
             customPermissionCache = miniAppCustomPermissionCache,
             miniAppInfo = miniAppInfo

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -36,10 +36,10 @@ internal class MiniAppWebView(
     @VisibleForTesting
     internal val externalResultHandler = ExternalResultHandler().apply {
         onResultChanged = { externalUrl ->
-            if (miniAppScheme.isMiniAppUrl(externalUrl))
-                miniAppScheme.ifLoadingCustomScheme(externalUrl) { customDomain ->
-                    loadUrl(customDomain)
-                }
+            if (externalUrl.startsWith(miniAppScheme.miniAppCustomScheme))
+                loadUrl(externalUrl.replace(miniAppScheme.miniAppCustomScheme, miniAppScheme.miniAppCustomDomain))
+            else if (externalUrl.startsWith(miniAppScheme.miniAppCustomDomain))
+                loadUrl(externalUrl)
         }
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
@@ -51,10 +51,11 @@ internal class MiniAppWebViewClient(
         request: WebResourceRequest,
         error: WebResourceError
     ) {
-        if (request.url != null) {
-            miniAppScheme.ifLoadingCustomScheme(request.url.toString()) { customDomain ->
-                loadWithCustomDomain(view, customDomain)
-            }
+        if (request.url != null && request.url.toString().startsWith(miniAppScheme.miniAppCustomScheme)) {
+            loadWithCustomDomain(
+                view,
+                request.url.toString().replace(miniAppScheme.miniAppCustomScheme, miniAppScheme.miniAppCustomDomain)
+            )
             return
         }
         super.onReceivedError(view, request, error)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -18,10 +18,11 @@ import com.rakuten.tech.mobile.miniapp.permission.MiniAppPermissionResult
 
 @Suppress("TooGenericExceptionCaught", "SwallowedException", "TooManyFunctions")
 /** Bridge interface for communicating with mini app. **/
-abstract class MiniAppMessageBridge(val activity: Activity? = null) {
+abstract class MiniAppMessageBridge {
     private lateinit var webViewListener: WebViewListener
     private lateinit var customPermissionCache: MiniAppCustomPermissionCache
     private lateinit var miniAppInfo: MiniAppInfo
+    private lateinit var activity: Activity
 
     /** Get provided id of mini app for any purpose. **/
     abstract fun getUniqueId(): String
@@ -53,7 +54,6 @@ abstract class MiniAppMessageBridge(val activity: Activity? = null) {
     ) {
         when {
             content.trim().isEmpty() -> callback.invoke(false, "content is empty")
-            activity == null -> callback.invoke(false, ErrorBridgeMessage.NO_ACTIVITY)
             else -> {
                 val sendIntent: Intent = Intent().apply {
                     action = Intent.ACTION_SEND
@@ -68,10 +68,12 @@ abstract class MiniAppMessageBridge(val activity: Activity? = null) {
     }
 
     internal fun init(
+        activity: Activity,
         webViewListener: WebViewListener,
         customPermissionCache: MiniAppCustomPermissionCache,
         miniAppInfo: MiniAppInfo
     ) {
+        this.activity = activity
         this.webViewListener = webViewListener
         this.customPermissionCache = customPermissionCache
         this.miniAppInfo = miniAppInfo
@@ -207,7 +209,6 @@ abstract class MiniAppMessageBridge(val activity: Activity? = null) {
 internal class ErrorBridgeMessage {
 
     companion object {
-        const val NO_ACTIVITY = "No Activity from MiniAppMessageBridge"
         const val ERR_UNIQUE_ID = "Cannot get unique id:"
         const val ERR_REQ_PERMISSION = "Cannot request permission:"
         const val ERR_REQ_CUSTOM_PERMISSION = "Cannot request custom permissions:"

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/CachedMiniAppVerifier.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/CachedMiniAppVerifier.kt
@@ -47,7 +47,7 @@ internal class CachedMiniAppVerifier
         }
     }
 
-    @SuppressWarnings("TooGenericExceptionCaught")
+    @SuppressWarnings("TooGenericExceptionCaught", "LongMethod", "NestedBlockDepth")
     private fun calculateHash(
         directory: File
     ): String = try {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -150,11 +150,6 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
     }
 
     @Test
-    fun `MiniAppMessageBridge should be connected with RealMiniAppDisplay`() {
-        verify(miniAppMessageBridge, atLeastOnce()).init(miniAppWebView, miniAppCustomPermissionCache, TEST_MA)
-    }
-
-    @Test
     fun `should load url which is internal mini app scheme from external emission`() {
         miniAppWebView.externalResultHandler.emitResult(TEST_URL_HTTPS_1)
         miniAppWebView.externalResultHandler.emitResult("mscheme.${miniAppWebView.miniAppInfo.id}://index.html")

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -43,21 +43,23 @@ open class BaseWebViewSpec {
 
     @Before
     fun setup() {
-        context = getApplicationContext()
-        basePath = context.filesDir.path
-        webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA))
+        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
+            context = activity
+            basePath = context.filesDir.path
+            webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA))
 
-        miniAppWebView = MiniAppWebView(
-            context,
-            basePath = basePath,
-            miniAppInfo = TEST_MA,
-            miniAppMessageBridge = miniAppMessageBridge,
-            miniAppNavigator = miniAppNavigator,
-            hostAppUserAgentInfo = TEST_HA_NAME,
-            miniAppWebChromeClient = webChromeClient,
-            miniAppCustomPermissionCache = miniAppCustomPermissionCache
-        )
-        webResourceRequest = getWebResReq(miniAppWebView.getLoadUrl().toUri())
+            miniAppWebView = MiniAppWebView(
+                context,
+                basePath = basePath,
+                miniAppInfo = TEST_MA,
+                miniAppMessageBridge = miniAppMessageBridge,
+                miniAppNavigator = miniAppNavigator,
+                hostAppUserAgentInfo = TEST_HA_NAME,
+                miniAppWebChromeClient = webChromeClient,
+                miniAppCustomPermissionCache = miniAppCustomPermissionCache
+            )
+            webResourceRequest = getWebResReq(miniAppWebView.getLoadUrl().toUri())
+        }
     }
 }
 
@@ -353,6 +355,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
 
     @Test
     fun `should only close custom view when exit`() {
+        val context = getApplicationContext<Context>()
         webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA))
         webChromeClient.onShowCustomView(mock(), mock())
         webChromeClient.customView = mock()
@@ -363,14 +366,12 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
 
     @Test
     fun `should execute custom view flow without error`() {
-        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
-            val webChromeClient = Mockito.spy(MiniAppWebChromeClient(activity, TEST_MA))
+        val webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA))
 
-            webChromeClient.onShowCustomView(View(activity), mock())
-            webChromeClient.updateControls()
-            webChromeClient.onHideCustomView()
-            webChromeClient.updateControls()
-        }
+        webChromeClient.onShowCustomView(View(context), mock())
+        webChromeClient.updateControls()
+        webChromeClient.onHideCustomView()
+        webChromeClient.updateControls()
     }
 }
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplaySpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplaySpec.kt
@@ -3,6 +3,7 @@ package com.rakuten.tech.mobile.miniapp.display
 import android.app.Activity
 import android.content.Context
 import android.webkit.WebView
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.mock
@@ -11,6 +12,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.TEST_HA_NAME
 import com.rakuten.tech.mobile.miniapp.TEST_MA
+import com.rakuten.tech.mobile.miniapp.TestActivity
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
@@ -30,17 +32,19 @@ class RealMiniAppDisplaySpec {
 
     @Before
     fun setup() {
-        context = getApplicationContext()
-        basePath = context.filesDir.path
-        realDisplay = RealMiniAppDisplay(
-            context,
-            basePath = basePath,
-            miniAppInfo = TEST_MA,
-            miniAppMessageBridge = miniAppMessageBridge,
-            miniAppNavigator = mock(),
-            hostAppUserAgentInfo = TEST_HA_NAME,
-            miniAppCustomPermissionCache = mock()
-        )
+        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
+            context = activity
+            basePath = context.filesDir.path
+            realDisplay = RealMiniAppDisplay(
+                context,
+                basePath = basePath,
+                miniAppInfo = TEST_MA,
+                miniAppMessageBridge = miniAppMessageBridge,
+                miniAppNavigator = mock(),
+                hostAppUserAgentInfo = TEST_HA_NAME,
+                miniAppCustomPermissionCache = mock()
+            )
+        }
     }
 
     @Test
@@ -65,7 +69,7 @@ class RealMiniAppDisplaySpec {
 
     @Test(expected = MiniAppSdkException::class)
     fun `should throw exception when the context provider is not activity context`() =
-        runBlockingTest { realDisplay.getMiniAppView(context) }
+        runBlockingTest { realDisplay.getMiniAppView(getApplicationContext()) }
 
     @Test
     fun `should create MiniAppWebView when provide activity context`() = runBlockingTest {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplaySpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplaySpec.kt
@@ -82,7 +82,6 @@ class RealMiniAppDisplaySpec {
     fun `for a given basePath, getMiniAppView should not return WebView to the caller`() =
         runBlockingTest {
             val displayer = Mockito.spy(realDisplay)
-            When calling displayer.isContextValid(context) itReturns true
             displayer.getMiniAppView(context) shouldNotHaveTheSameClassAs WebView::class
         }
 
@@ -95,7 +94,6 @@ class RealMiniAppDisplaySpec {
     @Test
     fun `should not navigate when MiniAppWebView cannot do navigation`() = runBlockingTest {
         val displayer = Mockito.spy(realDisplay)
-        When calling displayer.isContextValid(context) itReturns true
         displayer.getMiniAppView(context)
 
         displayer.navigateBackward() shouldBe false
@@ -105,7 +103,6 @@ class RealMiniAppDisplaySpec {
     @Test
     fun `should be able to do navigation when possible`() = runBlockingTest {
         val displayer = Mockito.spy(realDisplay)
-        When calling displayer.isContextValid(context) itReturns true
         val miniAppWebView: MiniAppWebView = mock()
         When calling (miniAppWebView as WebView).canGoBack() itReturns true
         When calling miniAppWebView.canGoForward() itReturns true

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
@@ -1,6 +1,5 @@
 package com.rakuten.tech.mobile.miniapp.js
 
-import android.app.Activity
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.gson.Gson
@@ -55,8 +54,8 @@ open class MiniAppMessageBridgeSpec {
             }
         }
 
-    protected fun createDefaultMiniAppMessageBridge(activity: Activity?): MiniAppMessageBridge =
-        object : MiniAppMessageBridge(activity) {
+    protected fun createDefaultMiniAppMessageBridge(): MiniAppMessageBridge =
+        object : MiniAppMessageBridge() {
             override fun getUniqueId() = TEST_CALLBACK_VALUE
 
             override fun requestPermission(
@@ -110,6 +109,7 @@ open class MiniAppMessageBridgeSpec {
     @Before
     fun setup() {
         miniAppBridge.init(
+            activity = TestActivity(),
             webViewListener = mock(),
             customPermissionCache = mock(),
             miniAppInfo = mock()
@@ -129,6 +129,7 @@ open class MiniAppMessageBridgeSpec {
         val isPermissionGranted = true
         val miniAppBridge = Mockito.spy(createMiniAppMessageBridge(isPermissionGranted))
         miniAppBridge.init(
+            activity = TestActivity(),
             webViewListener = createErrorWebViewListener("${ErrorBridgeMessage.ERR_REQ_PERMISSION} null"),
             customPermissionCache = mock(),
             miniAppInfo = mock()
@@ -159,6 +160,7 @@ open class MiniAppMessageBridgeSpec {
     fun `postError should be called when cannot get unique id`() {
         val errMsg = "Cannot get unique id: null"
         miniAppBridge.init(
+            activity = TestActivity(),
             webViewListener = createErrorWebViewListener("${ErrorBridgeMessage.ERR_UNIQUE_ID} null"),
             customPermissionCache = mock(),
             miniAppInfo = mock()
@@ -173,6 +175,7 @@ open class MiniAppMessageBridgeSpec {
         val isPermissionGranted = false
         val miniAppBridge = Mockito.spy(createMiniAppMessageBridge(isPermissionGranted))
         miniAppBridge.init(
+            activity = TestActivity(),
             webViewListener = createErrorWebViewListener("${ErrorBridgeMessage.ERR_REQ_CUSTOM_PERMISSION} null"),
             customPermissionCache = mock(),
             miniAppInfo = mock()
@@ -188,6 +191,7 @@ open class MiniAppMessageBridgeSpec {
     fun `postError should be called when cannot request custom permission`() {
         val errMsg = "${ErrorBridgeMessage.ERR_REQ_CUSTOM_PERMISSION} null"
         miniAppBridge.init(
+            activity = TestActivity(),
             webViewListener = createErrorWebViewListener(errMsg),
             customPermissionCache = mock(),
             miniAppInfo = mock()
@@ -199,11 +203,12 @@ open class MiniAppMessageBridgeSpec {
 }
 
 class ShareContentBridgeSpec : MiniAppMessageBridgeSpec() {
-    val miniAppBridge = Mockito.spy(createDefaultMiniAppMessageBridge(null))
+    val miniAppBridge = Mockito.spy(createDefaultMiniAppMessageBridge())
 
     @Before
     fun setupShareInfo() {
         miniAppBridge.init(
+            activity = TestActivity(),
             webViewListener = mock(),
             customPermissionCache = mock(),
             miniAppInfo = mock()
@@ -224,8 +229,9 @@ class ShareContentBridgeSpec : MiniAppMessageBridgeSpec() {
     @Test
     fun `postValue should be called when content is shared successfully`() {
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
-            val miniAppBridge = Mockito.spy(createDefaultMiniAppMessageBridge(activity))
+            val miniAppBridge = Mockito.spy(createDefaultMiniAppMessageBridge())
             miniAppBridge.init(
+                activity = activity,
                 webViewListener = mock(),
                 customPermissionCache = mock(),
                 miniAppInfo = mock()
@@ -241,6 +247,7 @@ class ShareContentBridgeSpec : MiniAppMessageBridgeSpec() {
         val miniAppBridge = Mockito.spy(createMiniAppMessageBridge(false))
         val errMsg = "${ErrorBridgeMessage.ERR_SHARE_CONTENT} null"
         miniAppBridge.init(
+            activity = TestActivity(),
             webViewListener = createErrorWebViewListener(errMsg),
             customPermissionCache = mock(),
             miniAppInfo = mock()

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -95,7 +95,7 @@ class MiniAppDisplayActivity : BaseActivity() {
                     })
                 }
 
-            miniAppMessageBridge = object : MiniAppMessageBridge() {
+            miniAppMessageBridge = object : MiniAppMessageBridge(this) {
                 override fun getUniqueId() = AppSettings.instance.uniqueId
 
                 override fun requestPermission(
@@ -120,20 +120,6 @@ class MiniAppDisplayActivity : BaseActivity() {
                         permissionsWithDescription,
                         callback
                     )
-                }
-
-                override fun shareContent(
-                    content: String,
-                    callback: (isSuccess: Boolean, message: String?) -> Unit
-                ) {
-                    val sendIntent: Intent = Intent().apply {
-                        action = Intent.ACTION_SEND
-                        putExtra(Intent.EXTRA_TEXT, content)
-                        type = "text/plain"
-                    }
-                    startActivity(Intent.createChooser(sendIntent, null))
-
-                    callback.invoke(true, null)
                 }
             }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -95,7 +95,7 @@ class MiniAppDisplayActivity : BaseActivity() {
                     })
                 }
 
-            miniAppMessageBridge = object : MiniAppMessageBridge(this) {
+            miniAppMessageBridge = object : MiniAppMessageBridge() {
                 override fun getUniqueId() = AppSettings.instance.uniqueId
 
                 override fun requestPermission(


### PR DESCRIPTION
# Description
Default implementation of Share feature in `MiniAppMessageBridge`.
Passing `Activity` to `MiniAppMessageBridge` as optional parameter. `Activity` is mandatory to execute some methods.

## Links
MINI-1695

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
