### PR TITLE
feat: Verify cached mini app files using SHA-256 hash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     ext.androidx_constraintLayout = '1.1.3'
     ext.androidx_coreKtx = '1.3.0'
     ext.androidx_lifecycle = '2.2.0'
+    ext.androidx_crypto = '1.0.0-rc03'
     ext.androidx_test_ext = '1.1.2-rc01'
     ext.detekt = '1.1.1'
     ext.dokka_version = '0.10.0'

--- a/miniapp/build.gradle
+++ b/miniapp/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 
     implementation "androidx.core:core-ktx:$androidx_coreKtx"
     implementation "androidx.webkit:webkit:$webkit"
+    implementation "androidx.security:security-crypto:$androidx_crypto"
     compileOnly "com.google.android.gms:play-services-ads:$google_ads"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -9,6 +9,7 @@ import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermission
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
+import com.rakuten.tech.mobile.miniapp.storage.CachedMiniAppVerifier
 import com.rakuten.tech.mobile.miniapp.storage.FileWriter
 import com.rakuten.tech.mobile.miniapp.storage.MiniAppStatus
 import com.rakuten.tech.mobile.miniapp.storage.MiniAppStorage
@@ -116,11 +117,12 @@ abstract class MiniApp internal constructor() {
 
             val miniAppStatus = MiniAppStatus(context)
             val storage = MiniAppStorage(FileWriter(), context.filesDir)
+            val verifier = CachedMiniAppVerifier(context)
 
             instance = RealMiniApp(
                 apiClientRepository = apiClientRepository,
                 displayer = Displayer(context, defaultConfig.hostAppUserAgentInfo),
-                miniAppDownloader = MiniAppDownloader(storage, apiClient, miniAppStatus),
+                miniAppDownloader = MiniAppDownloader(storage, apiClient, miniAppStatus, verifier),
                 miniAppInfoFetcher = MiniAppInfoFetcher(apiClient),
                 miniAppCustomPermissionCache = MiniAppCustomPermissionCache(context)
             )

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/CachedMiniAppVerifier.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/CachedMiniAppVerifier.kt
@@ -1,0 +1,79 @@
+package com.rakuten.tech.mobile.miniapp.storage
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Base64
+import android.util.Log
+import androidx.annotation.VisibleForTesting
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.security.MessageDigest
+
+internal class CachedMiniAppVerifier
+@VisibleForTesting constructor(
+    private val prefs: SharedPreferences,
+    private val coroutineDispatcher: CoroutineDispatcher
+) {
+
+    constructor(context: Context) : this(
+        prefs = EncryptedSharedPreferences.create(
+            "com.rakuten.tech.mobile.miniapp.cache.hash",
+            MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+            context,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        ),
+        coroutineDispatcher = Dispatchers.IO
+    )
+
+    /** Verifies that the cached files for the Mini App have not been modified. */
+    fun verify(appId: String, directory: File): Boolean {
+        val hash = calculateHash(directory)
+        val storedHash = prefs.getString(appId, null) ?: ""
+
+        return hash == storedHash
+    }
+
+    /** Stores hash in encrypted shared preferences. This runs asynchronously so it will return immediately. */
+    suspend fun storeHashAsync(appId: String, directory: File) = withContext(coroutineDispatcher) {
+        async {
+            val hash = calculateHash(directory)
+            prefs.edit().putString(appId, hash).apply()
+        }
+    }
+
+    @SuppressWarnings("TooGenericExceptionCaught")
+    private fun calculateHash(
+        directory: File
+    ): String = try {
+        val buffer = ByteArray(BUFFER_SIZE)
+        var count: Int
+        val digest = MessageDigest.getInstance("SHA-256")
+
+        directory.walk()
+            .filter { it.isFile }
+            .sortedBy { it.name }
+            .forEach { file ->
+                file.inputStream().use { stream ->
+                    while (stream.read(buffer).also { count = it } > 0) {
+                        digest.update(buffer, 0, count)
+                    }
+                }
+            }
+
+        Base64.encodeToString(digest.digest(), Base64.NO_WRAP)
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to calculate hash for the Mini App.", e)
+        ""
+    }
+
+    companion object {
+        private val TAG = this::class.simpleName
+        private const val BUFFER_SIZE = 8192
+    }
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorage.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorage.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.miniapp.storage
 
+import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import kotlinx.coroutines.flow.collect
@@ -49,7 +50,15 @@ internal class MiniAppStorage(
 
     fun getMiniAppVersionPath(appId: String, versionId: String) = "${getMiniAppPath(appId)}$versionId"
 
-    @Suppress("TooGenericExceptionCaught", "LongMethod")
+    fun removeApp(
+        appId: String,
+        appPath: String = getMiniAppPath(appId)
+    ) {
+        val parentFile = File(appPath)
+        deleteDirectory(parentFile)
+    }
+
+    @Suppress("LongMethod")
     suspend fun removeOutdatedVersionApp(
         appId: String,
         latestVersionId: String,
@@ -62,13 +71,20 @@ internal class MiniAppStorage(
                     if (!file.absolutePath.endsWith(latestVersionId))
                         emit(file)
                 }
-            }.collect { file ->
-                try {
-                    file.deleteRecursively()
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
-            }
+            }.collect { file -> deleteDirectory(file) }
         }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun deleteDirectory(file: File) {
+        try {
+            file.deleteRecursively()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to delete the directory: $file", e)
+        }
+    }
+
+    companion object {
+        private val TAG = this::class.simpleName
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSpec.kt
@@ -1,12 +1,9 @@
 package com.rakuten.tech.mobile.miniapp
 
-import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
-import com.rakuten.tech.mobile.sdkutils.AppInfo
-import org.amshove.kluent.shouldNotBe
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -23,22 +20,5 @@ class MiniAppSpec {
         miniAppCompanion.instance(miniAppSdkConfig)
 
         verify(miniApp, times(1)).updateConfiguration(miniAppSdkConfig)
-    }
-
-    @Test
-    fun `MiniApp should init without problem`() {
-        AppInfo.instance = mock()
-        MiniApp.init(
-            context = getApplicationContext(),
-            miniAppSdkConfig = MiniAppSdkConfig(
-                baseUrl = TEST_URL_HTTPS_2,
-                isTestMode = true,
-                rasAppId = TEST_HA_ID_APP,
-                subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
-                hostAppVersionId = TEST_HA_ID_VERSION,
-                hostAppUserAgentInfo = TEST_HA_NAME
-            )
-        )
-        MiniApp.instance shouldNotBe null
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializerSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializerSpec.kt
@@ -4,16 +4,11 @@ import android.content.Context
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.mock
-import org.amshove.kluent.When
-import org.amshove.kluent.calling
-import org.amshove.kluent.itReturns
 import org.amshove.kluent.shouldBe
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
-import com.rakuten.tech.mobile.sdkutils.AppInfo
 
 @RunWith(AndroidJUnit4::class)
 class MiniappSdkInitializerSpec {
@@ -23,24 +18,6 @@ class MiniappSdkInitializerSpec {
     @Before
     fun setup() {
         context = getApplicationContext()
-    }
-
-    @Test
-    fun `Miniapp should be initialized`() {
-        val sdkInitializer = Mockito.spy(miniappSdkInitializer)
-        val appManifestConfig: AppManifestConfig = mock()
-        AppInfo.instance = mock()
-
-        When calling sdkInitializer.context itReturns context
-        When calling sdkInitializer.createAppManifestConfig(context) itReturns appManifestConfig
-        When calling appManifestConfig.isTestMode() itReturns false
-        When calling appManifestConfig.baseUrl() itReturns TEST_URL_HTTPS_2
-        When calling appManifestConfig.rasAppId() itReturns TEST_HA_ID_APP
-        When calling appManifestConfig.subscriptionKey() itReturns TEST_HA_SUBSCRIPTION_KEY
-        When calling appManifestConfig.hostAppVersion() itReturns TEST_HA_ID_VERSION
-        When calling appManifestConfig.hostAppUserAgentInfo() itReturns TEST_HA_NAME
-
-        sdkInitializer.onCreate() shouldBe true
     }
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/CachedMiniAppVerifierSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/CachedMiniAppVerifierSpec.kt
@@ -1,0 +1,77 @@
+package com.rakuten.tech.mobile.miniapp.storage
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.amshove.kluent.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+@ExperimentalCoroutinesApi
+class CachedMiniAppVerifierSpec {
+
+    @Rule
+    @JvmField
+    val tempFolder = TemporaryFolder()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val prefs = context.getSharedPreferences("test-cache", Context.MODE_PRIVATE)
+    private val dispatcher = TestCoroutineDispatcher()
+
+    private val verifier = CachedMiniAppVerifier(prefs, dispatcher)
+    private val id = "test-miniapp-id"
+
+    @Test
+    fun `should verify hash for files`() = runBlockingTest {
+        val folder = tempFolder.newFolder("mini-app-folder")
+        File(folder, "file1.html").writeText("test content")
+        File(folder, "file2.html").writeText("test content")
+
+        verifier.storeHashAsync(id, folder)
+
+        verifier.verify(id, folder) shouldBe true
+    }
+
+    @Test
+    fun `should fail to verify hash when files have been modified`() = runBlockingTest {
+        val folder = tempFolder.newFolder("mini-app-folder")
+        val file = File(folder, "file1.html")
+        file.writeText("test content")
+
+        verifier.storeHashAsync(id, folder)
+        file.writeText("modified content")
+
+        verifier.verify(id, folder) shouldBe false
+    }
+
+    @Test
+    fun `should fail to verify hash when files in subdirectories have been modified`() = runBlockingTest {
+        val folder = tempFolder.newFolder("mini-app-folder", "sub-folder")
+        val file = File(folder, "file1.html")
+        file.writeText("test content")
+
+        verifier.storeHashAsync(id, folder)
+        file.writeText("modified content")
+
+        verifier.verify(id, folder) shouldBe false
+    }
+
+    @Test
+    fun `should fail to verify hash when mini app files are deleted`() = runBlockingTest {
+        val folder = tempFolder.newFolder("mini-app-folder")
+        val file = File(folder, "file1.html")
+        file.writeText("test content")
+
+        verifier.storeHashAsync(id, folder)
+        folder.deleteRecursively()
+
+        verifier.verify(id, folder) shouldBe false
+    }
+}

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageSpec.kt
@@ -73,6 +73,21 @@ class MiniAppStorageSpec {
     }
 
     @Test
+    fun `should delete all file data for the specified app id`() = runBlockingTest {
+        val oldFile1 = tempFolder.newFolder("old_package_id_1")
+        val oldFile2 = tempFolder.newFile()
+        val latestPackage = tempFolder.newFolder(TEST_ID_MINIAPP_VERSION)
+
+        miniAppStorage.removeApp(
+            TEST_ID_MINIAPP,
+            tempFolder.root.path)
+
+        oldFile1.exists() shouldBe false
+        oldFile2.exists() shouldBe false
+        latestPackage.exists() shouldBe false
+    }
+
+    @Test
     fun `should extract file with FileWriter`() = runBlockingTest {
         val file = tempFolder.newFile()
         When calling miniAppStorage.getFileName(file.path) itReturns file.name


### PR DESCRIPTION
# Description
This is to prevent a cache poisining vulnerability. This works by saving an encrypted hash of the Mini App fils. If someone modifies the cached files for the Mini App (i.e. on a rooted device), then the hash verification will fail and the Mini App will be re-downloaded. It's also not possible for someone to modify the hash since it's encrypted - if they attempt to modify it then the decryption of the hash will fail.

I also needed to delete some unit tests related to SDK initialization - this is because the CachedMiniAppVerifier needs to use the AndroidKeyStore which isn't mocked by the test runner. However I think it's okay to not test the initialization code because part of it's purpose is to be the place where we can initialize things which aren't mockable.

## Links
MINI-1405

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
