### PR TITLE
fix: Keep custom permission response from being obfuscated

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionResponse.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionResponse.kt
@@ -1,14 +1,18 @@
 package com.rakuten.tech.mobile.miniapp.permission
 
+import androidx.annotation.Keep
+
 /**
  * A data class to prepare the json response of custom permissions to be sent from this SDK.
  */
+@Keep
 data class MiniAppCustomPermissionResponse(
     val permissions: ArrayList<CustomPermissionResponseObj>
 ) {
     /**
      * A data class to hold the json elements to be sent as inside the response.
      */
+    @Keep
     data class CustomPermissionResponseObj(
         val name: String,
         val status: String


### PR DESCRIPTION
# Description
Added `@Keep` annotation to `MiniAppCustomPermissionResponse`. The JavaScript side relies on the key names of the response, so these shouldn't be obfuscated.

## Links
MINI-1715

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
