### PR TITLE
Add keystore files in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,9 +43,8 @@ captures/
 .idea
 
 # Keystore files
-# Uncomment the following lines if you do not want to check your keystore files in.
-#*.jks
-#*.keystore
+*.jks
+*.keystore
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild


### PR DESCRIPTION
# Description
We can uncomment `*.jks` and `*.keystore` in` .gitignore` to avoid accidental push of keystore files.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
