### PR TITLE
refactor: android 23 compatibility

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
@@ -28,6 +28,7 @@ internal class MiniAppWebViewClient(
         return response
     }
 
+    // ToDo When the minimum support is upgraded to android 24, replace this function.
     override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
         var shouldCancelLoading = super.shouldOverrideUrlLoading(view, url)
         if (url != null) {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
@@ -28,17 +28,16 @@ internal class MiniAppWebViewClient(
         return response
     }
 
-    override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
-        var shouldCancelLoading = super.shouldOverrideUrlLoading(view, request)
-        if (request.url != null) {
-            val requestUrl = request.url.toString()
-            if (requestUrl.startsWith("tel:")) {
-                openPhoneDialer(requestUrl)
+    override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
+        var shouldCancelLoading = super.shouldOverrideUrlLoading(view, url)
+        if (url != null) {
+            if (url.startsWith("tel:")) {
+                openPhoneDialer(url)
                 shouldCancelLoading = true
-            } else if (!miniAppScheme.isMiniAppUrl(requestUrl)) {
+            } else if (!miniAppScheme.isMiniAppUrl(url)) {
                 // check if there is navigator implementation on miniapp.
                 if (miniAppNavigator != null) {
-                    miniAppNavigator.openExternalUrl(requestUrl, externalResultHandler)
+                    miniAppNavigator.openExternalUrl(url, externalResultHandler)
                     shouldCancelLoading = true
                 }
             }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -234,6 +234,7 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
         val phoneUri = "tel:123456"
 
         try {
+            webViewClient.shouldOverrideUrlLoading(view = displayer, url = null)
             webViewClient.shouldOverrideUrlLoading(displayer, miniAppWebView.getLoadUrl())
             webViewClient.shouldOverrideUrlLoading(displayer, phoneUri)
         } catch (e: AndroidRuntimeException) {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -234,8 +234,8 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
         val phoneUri = "tel:123456"
 
         try {
-            webViewClient.shouldOverrideUrlLoading(displayer, webResourceRequest)
-            webViewClient.shouldOverrideUrlLoading(displayer, getWebResReq(phoneUri.toUri()))
+            webViewClient.shouldOverrideUrlLoading(displayer, miniAppWebView.getLoadUrl())
+            webViewClient.shouldOverrideUrlLoading(displayer, phoneUri)
         } catch (e: AndroidRuntimeException) {
             // context here is not activity
         }
@@ -249,10 +249,9 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
         val webViewClient = Mockito.spy(MiniAppWebViewClient(context, webAssetLoader, null,
             externalResultHandler, miniAppScheme))
         val displayer = Mockito.spy(miniAppWebView)
-        val externalUri = TEST_URL_HTTPS_1.toUri()
 
         try {
-            webViewClient.shouldOverrideUrlLoading(displayer, getWebResReq(externalUri))
+            webViewClient.shouldOverrideUrlLoading(displayer, TEST_URL_HTTPS_1)
         } catch (e: AndroidRuntimeException) {
             // context here is not activity
         }
@@ -266,10 +265,9 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
         val webViewClient = Mockito.spy(MiniAppWebViewClient(context, webAssetLoader, miniAppNavigator,
             externalResultHandler, miniAppScheme))
         val displayer = Mockito.spy(miniAppWebView)
-        val externalUri = TEST_URL_HTTPS_1.toUri()
 
         try {
-            webViewClient.shouldOverrideUrlLoading(displayer, getWebResReq(externalUri))
+            webViewClient.shouldOverrideUrlLoading(displayer, TEST_URL_HTTPS_1)
         } catch (e: AndroidRuntimeException) {
             // context here is not activity
         }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/UUIDHelper.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/UUIDHelper.kt
@@ -3,9 +3,10 @@ package com.rakuten.tech.mobile.testapp.helper
 import java.lang.IllegalArgumentException
 import java.util.UUID
 
+private const val UUID_LENGTH = 36
 fun String.isInvalidUuid(): Boolean = try {
     UUID.fromString(this)
-    false
+    this.length != UUID_LENGTH
 } catch (e: IllegalArgumentException) {
     true
 }


### PR DESCRIPTION
# Description
SDK:
Resolve phone scheme detection issue on Android 6 by replacing the current`shouldOverrideUrlLoading`. Have tested on other OS and found no problem as well.

Sample app:
Add UUID length check.

## Links
MINI-1614
MINI-1620

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
