### PR TITLE
Fix/permissions public api

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -45,7 +45,7 @@ abstract class MiniApp internal constructor() {
     ): MiniAppDisplay
 
     /**
-     * Same as {@link #create(String, MiniAppMessageBridge)}.
+     * Same as [create(String, MiniAppMessageBridge)].
      * Use this to control external url loader.
      * @param miniAppNavigator allow host app to handle specific urls such as external link.
      */

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -7,6 +7,7 @@ import androidx.annotation.VisibleForTesting
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
+import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.display.WebViewListener
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermission
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
@@ -38,10 +39,12 @@ abstract class MiniAppMessageBridge {
      * @param permissionsWithDescription list of name and descriptions of custom permissions sent from external.
      * @param callback to invoke a list of name and grant results of custom permissions sent from hostapp.
      */
-    abstract fun requestCustomPermissions(
+    open fun requestCustomPermissions(
         permissionsWithDescription: List<Pair<MiniAppCustomPermissionType, String>>,
         callback: (List<Pair<MiniAppCustomPermissionType, MiniAppCustomPermissionResult>>) -> Unit
-    )
+    ) {
+        throw MiniAppSdkException("The `MiniAppMessageBridge.requestCustomPermissions` method has not been implemented by the Host App.")
+    }
 
     /**
      * Share content info [ShareInfo]. This info is provided by mini app.


### PR DESCRIPTION
# Description
This is to avoid making a breaking change to the SDK - if we add a new 'abstract' method, then the Host App's builds will fail unless they implement the new method. Instead, we can make the new method be 'open' and throw an error if a Mini App tries to use it when it's not implemented. In the future, we can add a default implementation of 'requestCustomPermissions' instead of throwing an error

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
