### PR TITLE
refactor: external phone dialer

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppScheme.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppScheme.kt
@@ -1,5 +1,9 @@
 package com.rakuten.tech.mobile.miniapp
 
+import android.content.Context
+import android.content.Intent
+import androidx.core.net.toUri
+
 internal class MiniAppScheme(miniAppId: String) {
 
     val miniAppDomain = "mscheme.$miniAppId"
@@ -7,4 +11,9 @@ internal class MiniAppScheme(miniAppId: String) {
     val miniAppCustomDomain = "https://$miniAppDomain/"
 
     fun isMiniAppUrl(url: String) = url.startsWith(miniAppCustomDomain) || url.startsWith(miniAppCustomScheme)
+
+    internal fun openPhoneDialer(context: Context, url: String) = Intent(Intent.ACTION_DIAL).let {
+        it.data = url.toUri()
+        context.startActivity(it)
+    }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
@@ -1,14 +1,12 @@
 package com.rakuten.tech.mobile.miniapp.display
 
 import android.content.Context
-import android.content.Intent
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.webkit.WebResourceError
 import androidx.annotation.VisibleForTesting
-import androidx.core.net.toUri
 import androidx.webkit.WebViewAssetLoader
 import com.rakuten.tech.mobile.miniapp.MiniAppScheme
 import com.rakuten.tech.mobile.miniapp.navigator.ExternalResultHandler
@@ -33,7 +31,7 @@ internal class MiniAppWebViewClient(
         var shouldCancelLoading = super.shouldOverrideUrlLoading(view, url)
         if (url != null) {
             if (url.startsWith("tel:")) {
-                openPhoneDialer(url)
+                miniAppScheme.openPhoneDialer(context, url)
                 shouldCancelLoading = true
             } else if (!miniAppScheme.isMiniAppUrl(url)) {
                 // check if there is navigator implementation on miniapp.
@@ -77,11 +75,5 @@ internal class MiniAppWebViewClient(
             { view.loadUrl(requestUrl) },
             100
         )
-    }
-
-    @VisibleForTesting
-    internal fun openPhoneDialer(requestUrl: String) = Intent(Intent.ACTION_DIAL).let {
-        it.data = requestUrl.toUri()
-        context.startActivity(it)
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/navigator/MiniAppExternalUrlLoader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/navigator/MiniAppExternalUrlLoader.kt
@@ -24,12 +24,16 @@ class MiniAppExternalUrlLoader(miniAppId: String, private val activity: Activity
      * Use this in the return value of [WebViewClient.shouldOverrideUrlLoading(WebView, WebResourceRequest)].
      **/
     fun shouldOverrideUrlLoading(url: String): Boolean {
-        if (shouldClose(url)) {
+        var shouldCancelLoading = false
+        if (url.startsWith("tel:") && activity != null) {
+            miniAppScheme.openPhoneDialer(activity, url)
+            shouldCancelLoading = true
+        } else if (shouldClose(url)) {
             closeExternalView(url)
-            return true
+            shouldCancelLoading = true
         }
 
-        return false
+        return shouldCancelLoading
     }
 
     /**

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
@@ -11,6 +11,7 @@ internal const val TEST_BASE_PATH = "dummy"
 internal const val TEST_URL_FILE = "file.storage/test/file.abc"
 internal const val TEST_URL_HTTPS_1 = "https://www.example.com/1"
 internal const val TEST_URL_HTTPS_2 = "https://www.example.com/2/"
+internal const val TEST_PHONE_URI = "tel:123456"
 
 internal const val TEST_MA_ID = "test_id"
 internal const val TEST_MA_DISPLAY_NAME = "test_name"

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -188,7 +188,7 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
 @RunWith(AndroidJUnit4::class)
 class MiniAppWebClientSpec : BaseWebViewSpec() {
     private val externalResultHandler: ExternalResultHandler = spy()
-    private val miniAppScheme = MiniAppScheme(TEST_MA_ID)
+    private val miniAppScheme = Mockito.spy(MiniAppScheme(TEST_MA_ID))
 
     @Test
     fun `for a WebViewClient, it should be MiniAppWebViewClient`() {
@@ -231,17 +231,16 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
         val webViewClient = Mockito.spy(MiniAppWebViewClient(context, webAssetLoader, miniAppNavigator,
             externalResultHandler, miniAppScheme))
         val displayer = Mockito.spy(miniAppWebView)
-        val phoneUri = "tel:123456"
 
         try {
             webViewClient.shouldOverrideUrlLoading(view = displayer, url = null)
             webViewClient.shouldOverrideUrlLoading(displayer, miniAppWebView.getLoadUrl())
-            webViewClient.shouldOverrideUrlLoading(displayer, phoneUri)
+            webViewClient.shouldOverrideUrlLoading(displayer, TEST_PHONE_URI)
         } catch (e: AndroidRuntimeException) {
             // context here is not activity
         }
 
-        verify(webViewClient, times(1)).openPhoneDialer(phoneUri)
+        verify(miniAppScheme, times(1)).openPhoneDialer(context, TEST_PHONE_URI)
     }
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/navigator/MiniAppExternalUrlLoaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/navigator/MiniAppExternalUrlLoaderSpec.kt
@@ -1,20 +1,39 @@
 package com.rakuten.tech.mobile.miniapp.navigator
 
-import com.nhaarman.mockitokotlin2.mock
-import com.rakuten.tech.mobile.miniapp.MiniAppScheme
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.rakuten.tech.mobile.miniapp.*
 import com.rakuten.tech.mobile.miniapp.TEST_MA_ID
+import com.rakuten.tech.mobile.miniapp.TEST_PHONE_URI
 import com.rakuten.tech.mobile.miniapp.TEST_URL_HTTPS_1
 import org.amshove.kluent.shouldBe
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class MiniAppExternalUrlLoaderSpec {
     private val miniAppScheme = MiniAppScheme(TEST_MA_ID)
-    private val externalUrlLoader = MiniAppExternalUrlLoader(TEST_MA_ID, mock())
+    private lateinit var externalUrlLoader: MiniAppExternalUrlLoader
+
+    @Before
+    fun setup() {
+        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
+            externalUrlLoader = MiniAppExternalUrlLoader(TEST_MA_ID, activity)
+        }
+    }
 
     @Test
     fun `should only override url when it is supported by mini app view`() {
         externalUrlLoader.shouldOverrideUrlLoading(TEST_URL_HTTPS_1) shouldBe false
         externalUrlLoader.shouldOverrideUrlLoading(miniAppScheme.miniAppCustomScheme) shouldBe true
         externalUrlLoader.shouldOverrideUrlLoading(miniAppScheme.miniAppCustomDomain) shouldBe true
+        externalUrlLoader.shouldOverrideUrlLoading(TEST_PHONE_URI) shouldBe true
+    }
+
+    @Test
+    fun `should not override phone url when there is no activity context`() {
+        val externalUrlLoader = MiniAppExternalUrlLoader(TEST_MA_ID, null)
+        externalUrlLoader.shouldOverrideUrlLoading(TEST_PHONE_URI) shouldBe false
     }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/component/SampleExternalWebView.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/component/SampleExternalWebView.kt
@@ -2,7 +2,6 @@ package com.rakuten.tech.mobile.testapp.ui.component
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppExternalUrlLoader
@@ -19,8 +18,6 @@ class SampleExternalWebView(context: Context, url: String, sampleWebViewClient: 
 
 class SampleWebViewClient(private val miniAppExternalUrlLoader: MiniAppExternalUrlLoader): WebViewClient() {
 
-    override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
-        val url = request.url.toString()
-        return miniAppExternalUrlLoader.shouldOverrideUrlLoading(url)
-    }
+    override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean =
+        miniAppExternalUrlLoader.shouldOverrideUrlLoading(url ?: "")
 }


### PR DESCRIPTION
# Description
SDK: Allow open dialer in external webview.
Sample: `shouldOverrideUrlLoading` for android 6+.

# Link
MINI-1827

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
