### PR TITLE
fix: admob minified

### DIFF
--- a/miniapp/proguard-rules.pro
+++ b/miniapp/proguard-rules.pro
@@ -9,6 +9,7 @@
 # Gson specific classes
 -dontwarn sun.misc.**
 #-keep class com.google.gson.stream.** { *; }
+-keep class com.google.android.gms.ads.** { *; }
 
 # Application classes that will be serialized/deserialized over Gson
 -keep class com.google.gson.examples.android.model.** { <fields>; }

--- a/miniapp/proguard-rules.pro
+++ b/miniapp/proguard-rules.pro
@@ -9,7 +9,6 @@
 # Gson specific classes
 -dontwarn sun.misc.**
 #-keep class com.google.gson.stream.** { *; }
--keep class com.google.android.gms.ads.** { *; }
 
 # Application classes that will be serialized/deserialized over Gson
 -keep class com.google.gson.examples.android.model.** { <fields>; }
@@ -27,3 +26,5 @@
 }
 
 ##---------------End: proguard configuration for Gson  ----------
+
+-keep class com.google.android.gms.ads.MobileAds { *; }


### PR DESCRIPTION
# Description
Fix problem: AdMob does not work on STG build with R8 enabled. The issue is for this [class](https://github.com/rakutentech/android-miniapp/blob/22f551246dd71451cf076fda459e263c6464f2e9/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/ads/AdMob.kt#L19) check while running.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
