### PR TITLE
fix: provide keyboard visibility function to MiniApp

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -55,8 +55,7 @@ internal class MiniAppWebView(
             activity = context as Activity,
             webViewListener = this,
             customPermissionCache = miniAppCustomPermissionCache,
-            miniAppInfo = miniAppInfo,
-            webView = this
+            miniAppInfo = miniAppInfo
         )
 
         settings.allowUniversalAccessFromFileURLs = true

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -55,7 +55,8 @@ internal class MiniAppWebView(
             activity = context as Activity,
             webViewListener = this,
             customPermissionCache = miniAppCustomPermissionCache,
-            miniAppInfo = miniAppInfo
+            miniAppInfo = miniAppInfo,
+            webView = this
         )
 
         settings.allowUniversalAccessFromFileURLs = true

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/KeyboardBridgeDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/KeyboardBridgeDispatcher.kt
@@ -2,6 +2,9 @@ package com.rakuten.tech.mobile.miniapp.js
 
 import android.app.Activity
 import android.content.Context
+import android.os.Bundle
+import android.os.ResultReceiver
+import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 
 internal class KeyboardBridgeDispatcher(
@@ -11,15 +14,43 @@ internal class KeyboardBridgeDispatcher(
 
     fun onGetKeyboardVisibility(callbackId: String) {
         try {
+            val immResultReceiver = IMMResultReceiver()
+            val view = activity.findViewById(android.R.id.content) as ViewGroup
             val inputMethodManager: InputMethodManager =
                 activity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-
-            if (inputMethodManager.isActive && inputMethodManager.isAcceptingText)
+            inputMethodManager.showSoftInput(view.getChildAt(0), 0, immResultReceiver)
+            val result = immResultReceiver.findResult()
+            if (result == InputMethodManager.RESULT_UNCHANGED_SHOWN ||
+                result == InputMethodManager.RESULT_UNCHANGED_HIDDEN
+            ) {
                 bridgeExecutor.postValue(callbackId, VISIBLE)
-            else
+            } else {
                 bridgeExecutor.postValue(callbackId, INVISIBLE)
+            }
         } catch (e: Exception) {
             bridgeExecutor.postError(callbackId, "$ERR_KEYBOARD_VISIBILITY ${e.message}")
+        }
+    }
+
+    private class IMMResultReceiver : ResultReceiver(null) {
+        var currentResult = -1
+
+        override fun onReceiveResult(r: Int, data: Bundle?) {
+            currentResult = r
+        }
+
+        fun findResult(): Int {
+            try {
+                var sleep = 0
+                while (currentResult == -1 && sleep < 500) {
+                    Thread.sleep(100)
+                    sleep += 100
+                }
+            } catch (e: InterruptedException) {
+                e.printStackTrace()
+            }
+
+            return currentResult
         }
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/KeyboardBridgeDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/KeyboardBridgeDispatcher.kt
@@ -1,32 +1,31 @@
 package com.rakuten.tech.mobile.miniapp.js
 
-import android.graphics.Rect
-import android.webkit.WebView
+import android.app.Activity
+import android.content.Context
+import android.view.inputmethod.InputMethodManager
 
 internal class KeyboardBridgeDispatcher(
-    private val bridgeExecutor: MiniAppBridgeExecutor
+    private val bridgeExecutor: MiniAppBridgeExecutor,
+    private val activity: Activity
 ) {
 
-    fun onGetKeyboardVisibility(callbackId: String, webView: WebView) {
+    fun onGetKeyboardVisibility(callbackId: String) {
         try {
-            webView.viewTreeObserver
-                .addOnGlobalLayoutListener {
-                    val r = Rect()
-                    webView.getWindowVisibleDisplayFrame(r)
-                    val screenHeight: Int = webView.rootView.height
-                    val keypadHeight: Int = screenHeight - r.bottom
-                    if (keypadHeight > screenHeight * 0.15) {
-                        bridgeExecutor.postValue(callbackId, "visible")
-                    } else {
-                        bridgeExecutor.postValue(callbackId, "invisible")
-                    }
-                }
+            val inputMethodManager: InputMethodManager =
+                activity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+
+            if (inputMethodManager.isActive && inputMethodManager.isAcceptingText)
+                bridgeExecutor.postValue(callbackId, VISIBLE)
+            else
+                bridgeExecutor.postValue(callbackId, INVISIBLE)
         } catch (e: Exception) {
             bridgeExecutor.postError(callbackId, "$ERR_KEYBOARD_VISIBILITY ${e.message}")
         }
     }
 
     private companion object {
+        const val VISIBLE = "visible"
+        const val INVISIBLE = "invisible"
         const val ERR_KEYBOARD_VISIBILITY = "Cannot execute keyboard visibility:"
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/KeyboardBridgeDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/KeyboardBridgeDispatcher.kt
@@ -1,0 +1,32 @@
+package com.rakuten.tech.mobile.miniapp.js
+
+import android.graphics.Rect
+import android.webkit.WebView
+
+internal class KeyboardBridgeDispatcher(
+    private val bridgeExecutor: MiniAppBridgeExecutor
+) {
+
+    fun onGetKeyboardVisibility(callbackId: String, webView: WebView) {
+        try {
+            webView.viewTreeObserver
+                .addOnGlobalLayoutListener {
+                    val r = Rect()
+                    webView.getWindowVisibleDisplayFrame(r)
+                    val screenHeight: Int = webView.rootView.height
+                    val keypadHeight: Int = screenHeight - r.bottom
+                    if (keypadHeight > screenHeight * 0.15) {
+                        bridgeExecutor.postValue(callbackId, "visible")
+                    } else {
+                        bridgeExecutor.postValue(callbackId, "invisible")
+                    }
+                }
+        } catch (e: Exception) {
+            bridgeExecutor.postError(callbackId, "$ERR_KEYBOARD_VISIBILITY ${e.message}")
+        }
+    }
+
+    private companion object {
+        const val ERR_KEYBOARD_VISIBILITY = "Cannot execute keyboard visibility:"
+    }
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -3,7 +3,6 @@ package com.rakuten.tech.mobile.miniapp.js
 import android.app.Activity
 import android.content.Intent
 import android.webkit.JavascriptInterface
-import android.webkit.WebView
 import androidx.annotation.VisibleForTesting
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -31,7 +30,6 @@ abstract class MiniAppMessageBridge {
     private lateinit var customPermissionCache: MiniAppCustomPermissionCache
     private lateinit var miniAppInfo: MiniAppInfo
     private lateinit var activity: Activity
-    private lateinit var webView: WebView
     private lateinit var userInfoBridgeDispatcher: UserInfoBridgeDispatcher
     private lateinit var screenBridgeDispatcher: ScreenBridgeDispatcher
     private lateinit var adDisplayer: MiniAppAdDisplayer
@@ -42,16 +40,14 @@ abstract class MiniAppMessageBridge {
         activity: Activity,
         webViewListener: WebViewListener,
         customPermissionCache: MiniAppCustomPermissionCache,
-        miniAppInfo: MiniAppInfo,
-        webView: WebView
+        miniAppInfo: MiniAppInfo
     ) {
         this.activity = activity
         this.bridgeExecutor = createBridgeExecutor(webViewListener)
         this.customPermissionCache = customPermissionCache
         this.miniAppInfo = miniAppInfo
-        this.webView = webView
         this.screenBridgeDispatcher = ScreenBridgeDispatcher(activity, bridgeExecutor)
-        this.keyboardBridgeDispatcher = KeyboardBridgeDispatcher(bridgeExecutor)
+        this.keyboardBridgeDispatcher = KeyboardBridgeDispatcher(bridgeExecutor, activity)
 
         if (this::userInfoBridgeDispatcher.isInitialized)
             this.userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, miniAppInfo.id)
@@ -125,7 +121,7 @@ abstract class MiniAppMessageBridge {
             ActionType.GET_USER_NAME.action -> userInfoBridgeDispatcher.onGetUserName(callbackObj.id)
             ActionType.GET_PROFILE_PHOTO.action -> userInfoBridgeDispatcher.onGetProfilePhoto(callbackObj.id)
             ActionType.SET_SCREEN_ORIENTATION.action -> screenBridgeDispatcher.onScreenRequest(callbackObj)
-            ActionType.GET_KEYBOARD_VISIBILITY.action -> keyboardBridgeDispatcher.onGetKeyboardVisibility(callbackObj.id, webView)
+            ActionType.GET_KEYBOARD_VISIBILITY.action -> keyboardBridgeDispatcher.onGetKeyboardVisibility(callbackObj.id)
         }
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -3,6 +3,7 @@ package com.rakuten.tech.mobile.miniapp.js
 import android.app.Activity
 import android.content.Intent
 import android.webkit.JavascriptInterface
+import android.webkit.WebView
 import androidx.annotation.VisibleForTesting
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -30,22 +31,27 @@ abstract class MiniAppMessageBridge {
     private lateinit var customPermissionCache: MiniAppCustomPermissionCache
     private lateinit var miniAppInfo: MiniAppInfo
     private lateinit var activity: Activity
+    private lateinit var webView: WebView
     private lateinit var userInfoBridgeDispatcher: UserInfoBridgeDispatcher
     private lateinit var screenBridgeDispatcher: ScreenBridgeDispatcher
     private lateinit var adDisplayer: MiniAppAdDisplayer
+    private lateinit var keyboardBridgeDispatcher: KeyboardBridgeDispatcher
     private var isAdMobEnabled = false
 
     internal fun init(
         activity: Activity,
         webViewListener: WebViewListener,
         customPermissionCache: MiniAppCustomPermissionCache,
-        miniAppInfo: MiniAppInfo
+        miniAppInfo: MiniAppInfo,
+        webView: WebView
     ) {
         this.activity = activity
         this.bridgeExecutor = createBridgeExecutor(webViewListener)
         this.customPermissionCache = customPermissionCache
         this.miniAppInfo = miniAppInfo
+        this.webView = webView
         this.screenBridgeDispatcher = ScreenBridgeDispatcher(activity, bridgeExecutor)
+        this.keyboardBridgeDispatcher = KeyboardBridgeDispatcher(bridgeExecutor)
 
         if (this::userInfoBridgeDispatcher.isInitialized)
             this.userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, miniAppInfo.id)
@@ -119,6 +125,7 @@ abstract class MiniAppMessageBridge {
             ActionType.GET_USER_NAME.action -> userInfoBridgeDispatcher.onGetUserName(callbackObj.id)
             ActionType.GET_PROFILE_PHOTO.action -> userInfoBridgeDispatcher.onGetProfilePhoto(callbackObj.id)
             ActionType.SET_SCREEN_ORIENTATION.action -> screenBridgeDispatcher.onScreenRequest(callbackObj)
+            ActionType.GET_KEYBOARD_VISIBILITY.action -> keyboardBridgeDispatcher.onGetKeyboardVisibility(callbackObj.id, webView)
         }
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/Type.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/Type.kt
@@ -9,7 +9,8 @@ internal enum class ActionType(val action: String) {
     SHOW_AD("showAd"),
     GET_USER_NAME("getUserName"),
     GET_PROFILE_PHOTO("getProfilePhoto"),
-    SET_SCREEN_ORIENTATION("setScreenOrientation")
+    SET_SCREEN_ORIENTATION("setScreenOrientation"),
+    GET_KEYBOARD_VISIBILITY("getKeyboardVisibility")
 }
 
 internal enum class DialogType {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
@@ -364,7 +364,7 @@ class AdBridgeSpec : BridgeCommon() {
 
 @RunWith(AndroidJUnit4::class)
 class ScreenBridgeSpec : BridgeCommon() {
-    val miniAppBridge = Mockito.spy(createDefaultMiniAppMessageBridge())
+    private val miniAppBridge = Mockito.spy(createDefaultMiniAppMessageBridge())
 
     @Before
     fun setupScreenBridgeDispatcher() {
@@ -411,5 +411,46 @@ class ScreenBridgeSpec : BridgeCommon() {
         )
 
         verify(bridgeExecutor, times(0)).postValue(TEST_CALLBACK_ID, SUCCESS)
+    }
+}
+
+@RunWith(AndroidJUnit4::class)
+class KeyboardBridgeSpec : BridgeCommon() {
+    private val miniAppBridge = Mockito.spy(createDefaultMiniAppMessageBridge())
+
+    @Before
+    fun setupKeyboardBridgeDispatcher() {
+        When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
+        miniAppBridge.init(
+            activity = TestActivity(),
+            webViewListener = webViewListener,
+            customPermissionCache = mock(),
+            miniAppInfo = mock()
+        )
+    }
+
+    private val callbackJsonStr = Gson().toJson(
+        CallbackObj(
+            action = ActionType.GET_KEYBOARD_VISIBILITY.action,
+            param = null,
+            id = TEST_CALLBACK_ID
+        )
+    )
+
+    @Test
+    fun `postValue should be called when keyboard action is executed successfully`() {
+        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
+            val miniAppBridge = Mockito.spy(createDefaultMiniAppMessageBridge())
+            When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
+            miniAppBridge.init(
+                activity = activity,
+                webViewListener = webViewListener,
+                customPermissionCache = mock(),
+                miniAppInfo = mock()
+            )
+            miniAppBridge.postMessage(callbackJsonStr)
+
+            verify(bridgeExecutor).postValue(TEST_CALLBACK_ID, "invisible")
+        }
     }
 }


### PR DESCRIPTION
# Description
I was doing few investigations in Android to find a way to solve MINI-1706.  The issue is: when there is any bottom button inside JS MiniApp which is hidden because of keyboard is shown. 

By this PR, I came up with a solution is that, we can provide a functionality from MiniApp SDK called `getKeyboardVisibility()` which will return `"visible" / "invisible"`. Although, it's difficult to find when Android soft keyboard is shown or hidden since there is no way to detect if keyboard is opened or not, please have a look at the existing solution by this PR.

TODO: Unit test coverage once the solution looks good.

## Links
- MINI-1706

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
