### PR TITLE
fix: clean fullscreen view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## CHANGELOG
 
-### x.x.x
+### 2.4.0
 **SDK**
 - **Feature:** Handle the screen orientation change request from miniapp.
+- **Fix:** Clean up fullscreen view when exit miniapp. `MiniAppDisplay.destroyView` is mandatory for single activity architect.
 
 ### 2.3.0 (2020-10-15)
 **SDK**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 2.4.0
 **SDK**
 - **Feature:** Handle the screen orientation change request from miniapp.
-- **Fix:** Clean up fullscreen view when exit miniapp. `MiniAppDisplay.destroyView` is mandatory for single activity architect.
+- **Fix:** Clean up fullscreen view when exit miniapp. `MiniAppDisplay.destroyView` is mandatory for single activity architecture.
 
 ### 2.3.0 (2020-10-15)
 **SDK**

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -216,11 +216,14 @@ class MiniAppActivity : Activity(), CoroutineScope {
 
 `MiniAppDisplay.navigateBackward` and `MiniAppDisplay.navigateForward` facilitates the navigation inside a mini app if the history stack is available in it. A common usage pattern could be to link it up to the Android Back Key navigation.
 
+**Note:** Clearing up the mini app display is essential. `MiniAppDisplay.destroyView` is required to be called when exit miniapp.
+
 ## Advanced
 
 ### #1 Clearing up mini app display
 
-For a mini app, it is required to destroy necessary view state and any services registered with, either automatically or manually. `MiniAppDisplay` complies to Android's `LifecycleObserver` contract. It is quite easy to setup for automatic clean up of resources.
+For a mini app, it is required to destroy necessary view state and any services registered with.
+The automatic way can be used only if we want to end the `Activity` container along with mini app display.  `MiniAppDisplay` complies to Android's `LifecycleObserver` contract. It is quite easy to setup for automatic clean up of resources.
 
 ```kotlin
 class MiniAppActivity : Activity(), CoroutineScope {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDisplay.kt
@@ -15,7 +15,7 @@ interface MiniAppDisplay : LifecycleObserver {
     /**
      * Provides the view associated with the mini app to the caller for showing the mini app.
      * @param activityContext is used by the view for initializing the internal services.
-     * Should be the context of activity to ensure that all standard html components work properly.
+     * Must be the context of activity to ensure that all standard html components work properly.
      * @return [View] as mini app's view with [LayoutParams] set to match
      * the parent's dimensions.
      * @throws MiniAppSdkException when a non-matching context is supplied

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
@@ -152,4 +152,9 @@ internal class MiniAppWebChromeClient(
         }
     }
     // end region video fullscreen
+
+    fun destroy() {
+        if (customView != null)
+            onHideCustomView()
+    }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -24,7 +24,7 @@ internal class MiniAppWebView(
     context: Context,
     val basePath: String,
     val miniAppInfo: MiniAppInfo,
-    miniAppMessageBridge: MiniAppMessageBridge,
+    val miniAppMessageBridge: MiniAppMessageBridge,
     miniAppNavigator: MiniAppNavigator?,
     val hostAppUserAgentInfo: String,
     val miniAppWebChromeClient: MiniAppWebChromeClient = MiniAppWebChromeClient(context, miniAppInfo),
@@ -73,12 +73,16 @@ internal class MiniAppWebView(
         loadUrl(getLoadUrl())
     }
 
-    fun destroyView() {
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    fun destroyView() = try {
         stopLoading()
         webViewClient = null
         miniAppWebChromeClient.destroy()
         webChromeClient = null
+        miniAppMessageBridge.screenBridgeDispatcher.releaseLock()
         destroy()
+    } catch (e: Exception) {
+        // The activity may release before those executions.
     }
 
     override fun runSuccessCallback(callbackId: String, value: String) {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -76,6 +76,8 @@ internal class MiniAppWebView(
     fun destroyView() {
         stopLoading()
         webViewClient = null
+        miniAppWebChromeClient.destroy()
+        webChromeClient = null
         destroy()
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -31,7 +31,7 @@ abstract class MiniAppMessageBridge {
     private lateinit var miniAppInfo: MiniAppInfo
     private lateinit var activity: Activity
     private lateinit var userInfoBridgeDispatcher: UserInfoBridgeDispatcher
-    private lateinit var screenBridgeDispatcher: ScreenBridgeDispatcher
+    internal lateinit var screenBridgeDispatcher: ScreenBridgeDispatcher
     private lateinit var adDisplayer: MiniAppAdDisplayer
     private var isAdMobEnabled = false
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -128,9 +128,11 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
         val displayer = Mockito.spy(miniAppWebView)
         displayer.destroyView()
 
-        verify(displayer, times(1)).stopLoading()
+        verify(displayer).stopLoading()
         displayer.webViewClient shouldBe null
-        verify(displayer, times(1)).destroy()
+        verify(displayer.miniAppWebChromeClient).destroy()
+        displayer.webChromeClient shouldBe null
+        verify(displayer).destroy()
     }
 
     @Test
@@ -352,7 +354,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
     }
 
     @Test
-    fun `should only close custom view when exit`() {
+    fun `should close custom view when exit`() {
         val context = getApplicationContext<Context>()
         webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA))
         webChromeClient.onShowCustomView(mock(), mock())
@@ -370,6 +372,15 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
         webChromeClient.updateControls()
         webChromeClient.onHideCustomView()
         webChromeClient.updateControls()
+    }
+
+    @Test
+    fun `should exit fullscreen when destroy miniapp view`() {
+        val webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA))
+        webChromeClient.onShowCustomView(View(context), mock())
+        webChromeClient.destroy()
+
+        verify(webChromeClient).onHideCustomView()
     }
 }
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.miniapp.display
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -19,6 +20,7 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.rakuten.tech.mobile.miniapp.*
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
+import com.rakuten.tech.mobile.miniapp.js.ScreenBridgeDispatcher
 import com.rakuten.tech.mobile.miniapp.navigator.ExternalResultHandler
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppExternalUrlLoader
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
@@ -126,12 +128,15 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
     @Test
     fun `when destroyView called then the MiniAppWebView should be disposed`() {
         val displayer = Mockito.spy(miniAppWebView)
+        val screenBridgeDispatcher = Mockito.spy(ScreenBridgeDispatcher(context as Activity, mock()))
+        When calling miniAppMessageBridge.screenBridgeDispatcher itReturns screenBridgeDispatcher
         displayer.destroyView()
 
         verify(displayer).stopLoading()
         displayer.webViewClient shouldBe null
         verify(displayer.miniAppWebChromeClient).destroy()
         displayer.webChromeClient shouldBe null
+        verify(screenBridgeDispatcher).releaseLock()
         verify(displayer).destroy()
     }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListFragment.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListFragment.kt
@@ -26,7 +26,6 @@ import com.rakuten.tech.mobile.testapp.ui.base.BaseFragment
 import com.rakuten.tech.mobile.testapp.ui.display.MiniAppDisplayActivity
 import com.rakuten.tech.mobile.testapp.ui.input.MiniAppInputActivity
 import com.rakuten.tech.mobile.testapp.ui.settings.OnSearchListener
-import kotlinx.android.synthetic.main.mini_app_list_fragment.*
 import java.util.Locale
 
 import kotlin.collections.ArrayList
@@ -67,8 +66,8 @@ class MiniAppListFragment : BaseFragment(), MiniAppList, OnSearchListener,
 
     override fun onStart() {
         super.onStart()
-        swipeRefreshLayout.post {
-            swipeRefreshLayout.isRefreshing = true
+        binding.swipeRefreshLayout.post {
+            binding.swipeRefreshLayout.isRefreshing = true
             executeLoadingList()
         }
     }
@@ -79,7 +78,7 @@ class MiniAppListFragment : BaseFragment(), MiniAppList, OnSearchListener,
         viewModel =
             ViewModelProvider.NewInstanceFactory().create(MiniAppListViewModel::class.java).apply {
                 miniAppListData.observe(viewLifecycleOwner, Observer {
-                    swipeRefreshLayout.isRefreshing = false
+                    binding.swipeRefreshLayout.isRefreshing = false
                     addMiniAppList(it)
                     MiniAppListStore.instance.saveMiniAppList(it)
                 })
@@ -89,12 +88,12 @@ class MiniAppListFragment : BaseFragment(), MiniAppList, OnSearchListener,
                         updateEmptyView(list)
                     else {
                         addMiniAppList(list)
-                        swipeRefreshLayout.isRefreshing = false
+                        binding.swipeRefreshLayout.isRefreshing = false
                     }
                 })
             }
 
-        swipeRefreshLayout.setOnRefreshListener {
+        binding.swipeRefreshLayout.setOnRefreshListener {
             executeLoadingList()
             resetSearchBox()
         }
@@ -174,7 +173,7 @@ class MiniAppListFragment : BaseFragment(), MiniAppList, OnSearchListener,
             return true
 
         updateMiniAppListState(produceSearchResult(newText))
-        swipeRefreshLayout.isEnabled = newText.isNullOrEmpty()
+        binding.swipeRefreshLayout.isEnabled = newText.isNullOrEmpty()
 
         return true
     }
@@ -189,14 +188,14 @@ class MiniAppListFragment : BaseFragment(), MiniAppList, OnSearchListener,
     private fun resetSearchBox() {
         if (searchView.query.isNotEmpty() || !searchView.isIconified) {
             searchView.onActionViewCollapsed()
-            swipeRefreshLayout.isEnabled = true
+            binding.swipeRefreshLayout.isEnabled = true
         }
     }
 
     private fun updateEmptyView(collection: List<MiniAppInfo>) {
         if (collection.isEmpty())
-            emptyView.visibility = View.VISIBLE
+            binding.emptyView.visibility = View.VISIBLE
         else
-            emptyView.visibility = View.GONE
+            binding.emptyView.visibility = View.GONE
     }
 }


### PR DESCRIPTION
# Description
Remove fullscreen view when the hostapp has to clear miniapp view manually.
Update document about clearing miniapp.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
