### PR TITLE
fix: use binding as a reference for the views to import

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/adapter/MiniAppListAdapter.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/adapter/MiniAppListAdapter.kt
@@ -17,7 +17,7 @@ import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.ItemFooterMiniappBinding
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.ItemListMiniappBinding
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.ItemSectionMiniappBinding
-import java.util.*
+import java.util.TreeSet
 
 class MiniAppListAdapter(val miniapps: ArrayList<MiniAppInfo>, val miniAppList: MiniAppList) :
     ListAdapter<MiniAppInfo, MiniAppsListViewHolder>(MiniAppDiffCallback()) {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -11,6 +11,7 @@ import android.view.View
 import android.webkit.WebView
 import android.widget.Toast
 import androidx.core.app.ActivityCompat
+import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
@@ -23,11 +24,11 @@ import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
 import com.rakuten.tech.mobile.miniapp.navigator.ExternalResultHandler
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionResult
 import com.rakuten.tech.mobile.miniapp.testapp.R
+import com.rakuten.tech.mobile.miniapp.testapp.databinding.MiniAppDisplayActivityBinding
 import com.rakuten.tech.mobile.testapp.helper.AppPermission
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import com.rakuten.tech.mobile.testapp.ui.permission.CustomPermissionPresenter
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
-import kotlinx.android.synthetic.main.mini_app_display_activity.*
 
 class MiniAppDisplayActivity : BaseActivity() {
 
@@ -36,6 +37,7 @@ class MiniAppDisplayActivity : BaseActivity() {
     private lateinit var miniAppNavigator: MiniAppNavigator
     private var miniappPermissionCallback: (isGranted: Boolean) -> Unit = {}
     private lateinit var sampleWebViewExternalResultHandler: ExternalResultHandler
+    private lateinit var binding: MiniAppDisplayActivityBinding
 
     private val externalWebViewReqCode = 100
 
@@ -75,7 +77,7 @@ class MiniAppDisplayActivity : BaseActivity() {
             if (appId.isEmpty())
                 appId = intent.getParcelableExtra<MiniAppInfo>(miniAppTag)!!.id
 
-            setContentView(R.layout.mini_app_display_activity)
+            binding = DataBindingUtil.setContentView(this, R.layout.mini_app_display_activity)
 
             viewModel = ViewModelProvider.NewInstanceFactory()
                 .create(MiniAppDisplayViewModel::class.java).apply {
@@ -173,11 +175,9 @@ class MiniAppDisplayActivity : BaseActivity() {
     }
 
     private fun toggleProgressLoading(isOn: Boolean) {
-        if (findViewById<View>(R.id.pb) != null) {
-            when (isOn) {
-                true -> pb.visibility = View.VISIBLE
-                false -> pb.visibility = View.GONE
-            }
+        when (isOn) {
+            true -> binding.pb.visibility = View.VISIBLE
+            false -> binding.pb.visibility = View.GONE
         }
     }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
@@ -2,7 +2,11 @@ package com.rakuten.tech.mobile.testapp.ui.display
 
 import android.content.Context
 import android.view.View
-import androidx.lifecycle.*
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.rakuten.tech.mobile.miniapp.MiniApp
 import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/WebViewActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/WebViewActivity.kt
@@ -9,7 +9,7 @@ import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import com.rakuten.tech.mobile.testapp.ui.component.SampleExternalWebView
 import com.rakuten.tech.mobile.testapp.ui.component.SampleWebViewClient
 
-class WebViewActivity: BaseActivity() {
+class WebViewActivity : BaseActivity() {
     private lateinit var sampleExternalWebView: SampleExternalWebView
 
     companion object {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/input/MiniAppInputActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/input/MiniAppInputActivity.kt
@@ -4,7 +4,9 @@ import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
+import androidx.databinding.DataBindingUtil
 import com.rakuten.tech.mobile.miniapp.testapp.R
+import com.rakuten.tech.mobile.miniapp.testapp.databinding.MiniAppInputActivityBinding
 import com.rakuten.tech.mobile.testapp.AppScreen.MINI_APP_INPUT_ACTIVITY
 import com.rakuten.tech.mobile.testapp.helper.isInvalidUuid
 import com.rakuten.tech.mobile.testapp.launchActivity
@@ -12,17 +14,18 @@ import com.rakuten.tech.mobile.testapp.ui.display.MiniAppDisplayActivity
 import com.rakuten.tech.mobile.testapp.ui.miniapplist.MiniAppListActivity
 import com.rakuten.tech.mobile.testapp.ui.settings.MenuBaseActivity
 import com.rakuten.tech.mobile.testapp.ui.settings.SettingsMenuActivity
-import kotlinx.android.synthetic.main.mini_app_input_activity.*
 
 class MiniAppInputActivity : MenuBaseActivity() {
 
+    private lateinit var binding: MiniAppInputActivityBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.mini_app_input_activity)
+        binding = DataBindingUtil.setContentView(this, R.layout.mini_app_input_activity)
 
-        edtAppId.requestFocus()
-        validateAppId(edtAppId.text.toString())
-        edtAppId.addTextChangedListener(object: TextWatcher {
+        binding.edtAppId.requestFocus()
+        validateAppId(binding.edtAppId.text.toString())
+        binding.edtAppId.addTextChangedListener(object: TextWatcher {
             override fun afterTextChanged(s: Editable?) {}
 
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
@@ -32,24 +35,24 @@ class MiniAppInputActivity : MenuBaseActivity() {
             }
         })
 
-        btnDisplay.setOnClickListener {
+        binding.btnDisplay.setOnClickListener {
             raceExecutor.run { display() }
         }
-        btnDisplayList.setOnClickListener {
+        binding.btnDisplayList.setOnClickListener {
             raceExecutor.run { launchActivity<MiniAppListActivity>() }
         }
     }
 
     private fun validateAppId(appId: String) {
         if (appId.isBlank())
-            btnDisplay.isEnabled = false
+            binding.btnDisplay.isEnabled = false
         else {
             if (appId.isInvalidUuid()) {
-                edtAppId.error = getString(R.string.error_invalid_input)
-                btnDisplay.isEnabled = false
+                binding.edtAppId.error = getString(R.string.error_invalid_input)
+                binding.btnDisplay.isEnabled = false
             } else {
-                edtAppId.error = null
-                btnDisplay.isEnabled = true
+                binding.edtAppId.error = null
+                binding.btnDisplay.isEnabled = true
             }
         }
     }
@@ -57,7 +60,7 @@ class MiniAppInputActivity : MenuBaseActivity() {
     private fun display() {
         MiniAppDisplayActivity.start(
             this,
-            edtAppId.text.toString().trim()
+            binding.edtAppId.text.toString().trim()
         )
     }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListFragment.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListFragment.kt
@@ -26,7 +26,6 @@ import com.rakuten.tech.mobile.testapp.ui.base.BaseFragment
 import com.rakuten.tech.mobile.testapp.ui.display.MiniAppDisplayActivity
 import com.rakuten.tech.mobile.testapp.ui.input.MiniAppInputActivity
 import com.rakuten.tech.mobile.testapp.ui.settings.OnSearchListener
-import kotlinx.android.synthetic.main.mini_app_list_fragment.*
 import java.util.Locale
 
 import kotlin.collections.ArrayList
@@ -67,8 +66,8 @@ class MiniAppListFragment : BaseFragment(), MiniAppList, OnSearchListener,
 
     override fun onStart() {
         super.onStart()
-        swipeRefreshLayout.post {
-            swipeRefreshLayout.isRefreshing = true
+        binding.swipeRefreshLayout.post {
+            binding.swipeRefreshLayout.isRefreshing = true
             executeLoadingList()
         }
     }
@@ -79,7 +78,7 @@ class MiniAppListFragment : BaseFragment(), MiniAppList, OnSearchListener,
         viewModel =
             ViewModelProvider.NewInstanceFactory().create(MiniAppListViewModel::class.java).apply {
                 miniAppListData.observe(viewLifecycleOwner, Observer {
-                    swipeRefreshLayout.isRefreshing = false
+                    binding.swipeRefreshLayout.isRefreshing = false
                     addMiniAppList(it)
                     MiniAppListStore.instance.saveMiniAppList(it)
                 })
@@ -89,12 +88,12 @@ class MiniAppListFragment : BaseFragment(), MiniAppList, OnSearchListener,
                         updateEmptyView(list)
                     else {
                         addMiniAppList(list)
-                        swipeRefreshLayout.isRefreshing = false
+                        binding.swipeRefreshLayout.isRefreshing = false
                     }
                 })
             }
 
-        swipeRefreshLayout.setOnRefreshListener {
+        binding.swipeRefreshLayout.setOnRefreshListener {
             executeLoadingList()
             resetSearchBox()
         }
@@ -174,7 +173,7 @@ class MiniAppListFragment : BaseFragment(), MiniAppList, OnSearchListener,
             return true
 
         updateMiniAppListState(produceSearchResult(newText))
-        swipeRefreshLayout.isEnabled = newText.isNullOrEmpty()
+        binding.swipeRefreshLayout.isEnabled = newText.isNullOrEmpty()
 
         return true
     }
@@ -189,14 +188,14 @@ class MiniAppListFragment : BaseFragment(), MiniAppList, OnSearchListener,
     private fun resetSearchBox() {
         if (searchView.query.isNotEmpty() || !searchView.isIconified) {
             searchView.onActionViewCollapsed()
-            swipeRefreshLayout.isEnabled = true
+            binding.swipeRefreshLayout.isEnabled = true
         }
     }
 
     private fun updateEmptyView(collection: List<MiniAppInfo>) {
         if (collection.isEmpty())
-            emptyView.visibility = View.VISIBLE
+            binding.emptyView.visibility = View.VISIBLE
         else
-            emptyView.visibility = View.GONE
+            binding.emptyView.visibility = View.GONE
     }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/MiniAppDownloadedListActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/MiniAppDownloadedListActivity.kt
@@ -5,16 +5,16 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
+import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.rakuten.tech.mobile.miniapp.MiniApp
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.testapp.R
+import com.rakuten.tech.mobile.miniapp.testapp.databinding.MiniappDownloadedListActivityBinding
 import com.rakuten.tech.mobile.testapp.adapter.MiniAppList
 import com.rakuten.tech.mobile.testapp.adapter.MiniAppListAdapter
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
-import kotlinx.android.synthetic.main.miniapp_downloaded_list_activity.*
-import kotlinx.android.synthetic.main.miniapp_downloaded_list_activity.emptyView
 
 class MiniAppDownloadedListActivity(private val miniapp: MiniApp) : BaseActivity(), MiniAppList {
 
@@ -22,11 +22,12 @@ class MiniAppDownloadedListActivity(private val miniapp: MiniApp) : BaseActivity
 
     private lateinit var miniAppListAdapter: MiniAppListAdapter
     private var miniAppList: ArrayList<MiniAppInfo> = arrayListOf()
+    private lateinit var binding: MiniappDownloadedListActivityBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         showBackIcon()
-        setContentView(R.layout.miniapp_downloaded_list_activity)
+        binding = DataBindingUtil.setContentView(this, R.layout.miniapp_downloaded_list_activity)
         renderScreen()
     }
 
@@ -48,8 +49,8 @@ class MiniAppDownloadedListActivity(private val miniapp: MiniApp) : BaseActivity
 
     private fun initAdapter() {
         miniAppListAdapter = MiniAppListAdapter(ArrayList(), this)
-        listDownloadedMiniApp.layoutManager = LinearLayoutManager(applicationContext)
-        listDownloadedMiniApp.adapter = miniAppListAdapter
+        binding.listDownloadedMiniApp.layoutManager = LinearLayoutManager(applicationContext)
+        binding.listDownloadedMiniApp.adapter = miniAppListAdapter
     }
 
     private fun executeLoadingList() {
@@ -75,9 +76,9 @@ class MiniAppDownloadedListActivity(private val miniapp: MiniApp) : BaseActivity
 
     private fun updateEmptyView() {
         if (miniAppListAdapter.itemCount == 0)
-            emptyView.visibility = View.VISIBLE
+            binding.emptyView.visibility = View.VISIBLE
         else
-            emptyView.visibility = View.GONE
+            binding.emptyView.visibility = View.GONE
     }
 
     companion object {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/MiniAppPermissionSettingsActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/MiniAppPermissionSettingsActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.rakuten.tech.mobile.miniapp.MiniApp
@@ -12,9 +13,9 @@ import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermission
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionResult
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
 import com.rakuten.tech.mobile.miniapp.testapp.R
+import com.rakuten.tech.mobile.miniapp.testapp.databinding.ListCustomPermissionBinding
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
-import kotlinx.android.synthetic.main.list_custom_permission.*
 
 class MiniAppPermissionSettingsActivity(private val miniapp: MiniApp) : BaseActivity() {
 
@@ -22,6 +23,7 @@ class MiniAppPermissionSettingsActivity(private val miniapp: MiniApp) : BaseActi
 
     private lateinit var permissionSettingsAdapter: MiniAppPermissionSettingsAdapter
     private lateinit var miniAppId: String
+    private lateinit var binding: ListCustomPermissionBinding
 
     companion object {
         private const val miniAppIdTag = "mini_app_id_tag"
@@ -37,7 +39,7 @@ class MiniAppPermissionSettingsActivity(private val miniapp: MiniApp) : BaseActi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         showBackIcon()
-        setContentView(R.layout.list_custom_permission)
+        binding = DataBindingUtil.setContentView(this, R.layout.list_custom_permission)
 
         renderScreen()
     }
@@ -65,9 +67,9 @@ class MiniAppPermissionSettingsActivity(private val miniapp: MiniApp) : BaseActi
 
     private fun initAdapter() {
         permissionSettingsAdapter = MiniAppPermissionSettingsAdapter()
-        listCustomPermission.layoutManager = LinearLayoutManager(applicationContext)
-        listCustomPermission.adapter = permissionSettingsAdapter
-        listCustomPermission.addItemDecoration(
+        binding.listCustomPermission.layoutManager = LinearLayoutManager(applicationContext)
+        binding.listCustomPermission.adapter = permissionSettingsAdapter
+        binding.listCustomPermission.addItemDecoration(
             DividerItemDecoration(this, DividerItemDecoration.VERTICAL)
         )
     }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/MiniAppPermissionSettingsAdapter.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/MiniAppPermissionSettingsAdapter.kt
@@ -9,7 +9,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionResult
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.ItemListCustomPermissionBinding
-import kotlinx.android.synthetic.main.item_list_custom_permission.view.*
 
 class MiniAppPermissionSettingsAdapter : RecyclerView.Adapter<MiniAppPermissionSettingsAdapter.ViewHolder?>() {
     private var permissionNames = ArrayList<MiniAppCustomPermissionType>()
@@ -22,7 +21,7 @@ class MiniAppPermissionSettingsAdapter : RecyclerView.Adapter<MiniAppPermissionS
         val layoutInflater = LayoutInflater.from(parent.context)
         val binding = ItemListCustomPermissionBinding.inflate(layoutInflater, parent, false)
 
-        return ViewHolder(binding.root)
+        return ViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
@@ -68,7 +67,7 @@ class MiniAppPermissionSettingsAdapter : RecyclerView.Adapter<MiniAppPermissionS
         notifyDataSetChanged()
     }
 
-    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    inner class ViewHolder(itemView: ItemListCustomPermissionBinding) : RecyclerView.ViewHolder(itemView.root) {
         val permissionName: TextView = itemView.permissionText
         val permissionDescription: TextView = itemView.permissionDescription
         val permissionSwitch: SwitchCompat = itemView.permissionSwitch

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
@@ -10,9 +10,11 @@ import android.view.Menu
 import android.view.MenuItem
 import android.widget.Toast
 import androidx.appcompat.widget.Toolbar
+import androidx.databinding.DataBindingUtil
 import com.rakuten.tech.mobile.miniapp.MiniApp
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.testapp.R
+import com.rakuten.tech.mobile.miniapp.testapp.databinding.SettingsMenuActivityBinding
 import com.rakuten.tech.mobile.testapp.AppScreen.MINI_APP_INPUT_ACTIVITY
 import com.rakuten.tech.mobile.testapp.AppScreen.MINI_APP_LIST_ACTIVITY
 import com.rakuten.tech.mobile.testapp.helper.isInvalidUuid
@@ -25,7 +27,6 @@ import com.rakuten.tech.mobile.testapp.ui.permission.MiniAppDownloadedListActivi
 import com.rakuten.tech.mobile.testapp.ui.settings.MenuBaseActivity.Companion.MENU_SCREEN_NAME
 import com.rakuten.tech.mobile.testapp.ui.userdata.ContactListActivity
 import com.rakuten.tech.mobile.testapp.ui.userdata.ProfileSettingsActivity
-import kotlinx.android.synthetic.main.settings_menu_activity.*
 import kotlinx.coroutines.launch
 import kotlin.properties.Delegates
 
@@ -33,6 +34,7 @@ class SettingsMenuActivity : BaseActivity() {
 
     private lateinit var settings: AppSettings
     private lateinit var settingsProgressDialog: SettingsProgressDialog
+    private lateinit var binding: SettingsMenuActivityBinding
 
     private var saveViewEnabled by Delegates.observable(true) { _, old, new ->
         if (new != old) {
@@ -53,7 +55,7 @@ class SettingsMenuActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         settings = AppSettings.instance
-        setContentView(R.layout.settings_menu_activity)
+        binding = DataBindingUtil.setContentView(this, R.layout.settings_menu_activity)
 
         initializeActionBar()
         settingsProgressDialog = SettingsProgressDialog(this)
@@ -84,9 +86,9 @@ class SettingsMenuActivity : BaseActivity() {
         settingsProgressDialog.show()
 
         updateSettings(
-            editAppId.text.toString(),
-            editSubscriptionKey.text.toString(),
-            switchTestMode.isChecked
+            binding.editAppId.text.toString(),
+            binding.editSubscriptionKey.text.toString(),
+            binding.switchTestMode.isChecked
         )
     }
 
@@ -97,23 +99,23 @@ class SettingsMenuActivity : BaseActivity() {
     }
 
     private fun renderAppSettingsScreen() {
-        textInfo.text = createBuildInfo()
-        editAppId.setText(settings.appId)
-        editSubscriptionKey.setText(settings.subscriptionKey)
-        switchTestMode.isChecked = settings.isTestMode
+        binding.textInfo.text = createBuildInfo()
+        binding.editAppId.setText(settings.appId)
+        binding.editSubscriptionKey.setText(settings.subscriptionKey)
+        binding.switchTestMode.isChecked = settings.isTestMode
 
-        editAppId.addTextChangedListener(settingsTextWatcher)
-        editSubscriptionKey.addTextChangedListener(settingsTextWatcher)
+        binding.editAppId.addTextChangedListener(settingsTextWatcher)
+        binding.editSubscriptionKey.addTextChangedListener(settingsTextWatcher)
 
-        buttonProfile.setOnClickListener {
+        binding.buttonProfile.setOnClickListener {
             ProfileSettingsActivity.start(this@SettingsMenuActivity)
         }
 
-        buttonContacts.setOnClickListener {
+        binding.buttonContacts.setOnClickListener {
             ContactListActivity.start(this@SettingsMenuActivity)
         }
 
-        buttonCustomPermissions.setOnClickListener {
+        binding.buttonCustomPermissions.setOnClickListener {
             MiniAppDownloadedListActivity.start(this@SettingsMenuActivity)
         }
 
@@ -127,18 +129,18 @@ class SettingsMenuActivity : BaseActivity() {
     }
 
     private fun validateInputIDs() {
-        val isAppIdInvalid = editAppId.text.toString().isInvalidUuid()
+        val isAppIdInvalid = binding.editAppId.text.toString().isInvalidUuid()
 
-        saveViewEnabled = !(isInputEmpty(editAppId)
-                || isInputEmpty(editSubscriptionKey)
+        saveViewEnabled = !(isInputEmpty(binding.editAppId)
+                || isInputEmpty(binding.editSubscriptionKey)
                 || isAppIdInvalid)
 
-        if (isInputEmpty(editAppId) || isAppIdInvalid) {
-            editAppId.error = getString(R.string.error_invalid_input)
+        if (isInputEmpty(binding.editAppId) || isAppIdInvalid) {
+            binding.editAppId.error = getString(R.string.error_invalid_input)
         }
 
-        if (isInputEmpty(editSubscriptionKey)) {
-            editSubscriptionKey.error = getString(R.string.error_invalid_input)
+        if (isInputEmpty(binding.editSubscriptionKey)) {
+            binding.editSubscriptionKey.error = getString(R.string.error_invalid_input)
         }
     }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactListActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactListActivity.kt
@@ -13,18 +13,20 @@ import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
 import androidx.appcompat.widget.AppCompatEditText
+import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.rakuten.tech.mobile.miniapp.testapp.R
+import com.rakuten.tech.mobile.miniapp.testapp.databinding.ContactsActivityBinding
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
-import kotlinx.android.synthetic.main.contacts_activity.*
 import java.util.UUID
 
 class ContactListActivity : BaseActivity() {
 
     private lateinit var settings: AppSettings
+    private lateinit var binding: ContactsActivityBinding
     private val adapter = ContactListAdapter()
     private var contactListPrefs: SharedPreferences? = null
     private var isFirstLaunch: Boolean
@@ -40,9 +42,9 @@ class ContactListActivity : BaseActivity() {
         )
         settings = AppSettings.instance
         showBackIcon()
-        setContentView(R.layout.contacts_activity)
+        binding = DataBindingUtil.setContentView(this, R.layout.contacts_activity)
         renderContactList()
-        fabAddContact.setOnClickListener { onAddAction() }
+        binding.fabAddContact.setOnClickListener { onAddAction() }
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -121,9 +123,9 @@ class ContactListActivity : BaseActivity() {
 
     private fun renderAdapter(contactNames: ArrayList<String>) {
         adapter.addContactList(contactNames)
-        listContacts.adapter = adapter
-        listContacts.layoutManager = LinearLayoutManager(applicationContext)
-        listContacts.addItemDecoration(
+        binding.listContacts.adapter = adapter
+        binding.listContacts.layoutManager = LinearLayoutManager(applicationContext)
+        binding.listContacts.addItemDecoration(
             DividerItemDecoration(this, DividerItemDecoration.VERTICAL)
         )
         adapter.registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
@@ -148,7 +150,7 @@ class ContactListActivity : BaseActivity() {
     }
 
     private fun checkEmpty() {
-        viewEmptyContact.visibility =
+        binding.viewEmptyContact.visibility =
             if (adapter.itemCount == 0) View.VISIBLE else View.GONE
     }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactListAdapter.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactListAdapter.kt
@@ -1,13 +1,11 @@
 package com.rakuten.tech.mobile.testapp.ui.userdata
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.recyclerview.widget.RecyclerView
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.ItemListContactBinding
-import kotlinx.android.synthetic.main.item_list_contact.view.*
 
 class ContactListAdapter : RecyclerView.Adapter<ContactListAdapter.ViewHolder?>(),
     ContactAdapterPresenter {
@@ -17,7 +15,7 @@ class ContactListAdapter : RecyclerView.Adapter<ContactListAdapter.ViewHolder?>(
         val layoutInflater = LayoutInflater.from(parent.context)
         val binding = ItemListContactBinding.inflate(layoutInflater, parent, false)
 
-        return ViewHolder(binding.root)
+        return ViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
@@ -45,7 +43,7 @@ class ContactListAdapter : RecyclerView.Adapter<ContactListAdapter.ViewHolder?>(
 
     override fun provideContactEntries() = contactEntries
 
-    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    inner class ViewHolder(itemView: ItemListContactBinding) : RecyclerView.ViewHolder(itemView.root) {
         val contactName: AppCompatTextView = itemView.textContact
         val contactRemoveButton: ImageView = itemView.buttonRemoveContact
     }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ProfileSettingsActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ProfileSettingsActivity.kt
@@ -10,13 +10,14 @@ import android.util.Base64
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.ImageView
+import androidx.databinding.DataBindingUtil
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
 import com.rakuten.tech.mobile.miniapp.testapp.R
+import com.rakuten.tech.mobile.miniapp.testapp.databinding.ProfileSettingsActivityBinding
 import com.rakuten.tech.mobile.testapp.helper.MiniAppCoroutines
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
-import kotlinx.android.synthetic.main.profile_settings_activity.*
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -29,6 +30,7 @@ class ProfileSettingsActivity : BaseActivity() {
     private lateinit var settings: AppSettings
     private lateinit var profileUrl: String
     private lateinit var profileUrlBase64: String
+    private lateinit var binding: ProfileSettingsActivityBinding
     private val coroutines = MiniAppCoroutines()
     private val encodePhotoUrlJob: Job = Job()
 
@@ -39,7 +41,7 @@ class ProfileSettingsActivity : BaseActivity() {
         profileUrlBase64 = settings.profilePictureUrlBase64
 
         showBackIcon()
-        setContentView(R.layout.profile_settings_activity)
+        binding = DataBindingUtil.setContentView(this, R.layout.profile_settings_activity)
         renderProfileSettingsScreen()
     }
 
@@ -55,7 +57,7 @@ class ProfileSettingsActivity : BaseActivity() {
                 return true
             }
             R.id.settings_menu_save -> {
-                updateProfile(editProfileName.text.toString())
+                updateProfile(binding.editProfileName.text.toString())
                 return true
             }
             else -> super.onOptionsItemSelected(item)
@@ -64,9 +66,9 @@ class ProfileSettingsActivity : BaseActivity() {
 
     private fun renderProfileSettingsScreen() {
         setProfileImage(Uri.parse(settings.profilePictureUrl))
-        editProfileName.setText(settings.profileName)
-        imageProfile.setOnClickListener { openGallery() }
-        textEditPhoto.setOnClickListener { openGallery() }
+        binding.editProfileName.setText(settings.profileName)
+        binding.imageProfile.setOnClickListener { openGallery() }
+        binding.textEditPhoto.setOnClickListener { openGallery() }
     }
 
     private fun updateProfile(name: String) {
@@ -122,7 +124,7 @@ class ProfileSettingsActivity : BaseActivity() {
         Glide.with(this@ProfileSettingsActivity)
             .load(uri).apply(RequestOptions().circleCrop())
             .placeholder(R.drawable.r_logo)
-            .into(imageProfile as ImageView)
+            .into(binding.imageProfile as ImageView)
     }
 
     override fun onDestroy() {

--- a/testapp/src/main/res/layout/contacts_activity.xml
+++ b/testapp/src/main/res/layout/contacts_activity.xml
@@ -1,45 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  xmlns:tools="http://schemas.android.com/tools">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
 
-  <LinearLayout
+  <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <androidx.recyclerview.widget.RecyclerView
-      android:id="@+id/listContacts"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:padding="@dimen/small_8"
-      tools:listitem="@layout/item_list_contact" />
-
-    <TextView
-      android:id="@+id/viewEmptyContact"
+    <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:gravity="center"
-      android:text="@string/userdata_warning_empty_contact_list"
-      android:textColor="@color/colorAccent"
-      android:textSize="@dimen/text_large_18"
-      android:visibility="gone"
-      tools:visibility="visible" />
-  </LinearLayout>
+      android:orientation="vertical"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent">
 
-  <com.google.android.material.floatingactionbutton.FloatingActionButton
-    android:id="@+id/fabAddContact"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_margin="@dimen/large_24"
-    android:layout_gravity="end|bottom"
-    android:contentDescription="@string/action_add"
-    android:src="@drawable/ic_add_24dp"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+      <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/listContacts"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/small_8"
+        tools:listitem="@layout/item_list_contact" />
+
+      <TextView
+        android:id="@+id/viewEmptyContact"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:text="@string/userdata_warning_empty_contact_list"
+        android:textColor="@color/colorAccent"
+        android:textSize="@dimen/text_large_18"
+        android:visibility="gone"
+        tools:visibility="visible" />
+    </LinearLayout>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+      android:id="@+id/fabAddContact"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_margin="@dimen/large_24"
+      android:layout_gravity="end|bottom"
+      android:contentDescription="@string/action_add"
+      android:src="@drawable/ic_add_24dp"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent" />
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/testapp/src/main/res/layout/mini_app_display_activity.xml
+++ b/testapp/src/main/res/layout/mini_app_display_activity.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent" android:layout_height="match_parent">
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <RelativeLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
     <ProgressBar
-        android:id="@+id/pb"
-        android:layout_width="56dp"
-        android:layout_height="56dp"
-        android:layout_centerInParent="true" />
-</RelativeLayout>
+      android:id="@+id/pb"
+      android:layout_width="@dimen/progress_size"
+      android:layout_height="@dimen/progress_size"
+      android:layout_centerInParent="true" />
+  </RelativeLayout>
+</layout>

--- a/testapp/src/main/res/layout/mini_app_input_activity.xml
+++ b/testapp/src/main/res/layout/mini_app_input_activity.xml
@@ -1,51 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <LinearLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:padding="@dimen/medium_16"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_height="match_parent">
 
-        <com.google.android.material.textfield.TextInputLayout
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/large_24">
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:padding="@dimen/medium_16"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/edtAppId"
+            <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/lb_app_id"
-                android:inputType="text" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:layout_marginBottom="@dimen/large_24">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/edtAppId"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/lb_app_id"
+                    android:inputType="text" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <Button
+                android:id="@+id/btnDisplay"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start"
+                android:layout_marginTop="@dimen/large_24"
+                android:text="@string/action_display" />
+        </LinearLayout>
 
         <Button
-            android:id="@+id/btnDisplay"
-            android:layout_width="wrap_content"
+            android:id="@+id/btnDisplayList"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="start"
-            android:layout_marginTop="@dimen/large_24"
-            android:text="@string/action_display" />
-    </LinearLayout>
+            android:background="@color/colorAccent"
+            android:text="@string/action_display_list"
+            android:textColor="@android:color/white"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
 
-    <Button
-        android:id="@+id/btnDisplayList"
-        style="?android:attr/borderlessButtonStyle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@color/colorAccent"
-        android:text="@string/action_display_list"
-        android:textColor="@android:color/white"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/testapp/src/main/res/layout/miniapp_downloaded_list_activity.xml
+++ b/testapp/src/main/res/layout/miniapp_downloaded_list_activity.xml
@@ -1,34 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
   xmlns:tools="http://schemas.android.com/tools">
 
-  <LinearLayout
+  <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent">
+    android:layout_height="match_parent">
 
-    <androidx.recyclerview.widget.RecyclerView
-      android:id="@+id/listDownloadedMiniApp"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      tools:listitem="@layout/item_list_miniapp" />
-
-    <androidx.appcompat.widget.AppCompatTextView
-      android:id="@+id/emptyView"
+    <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:layout_margin="@dimen/large_24"
-      android:gravity="top|center"
-      android:text="@string/message_empty_miniapps"
-      android:textSize="@dimen/text_large_18"
-      android:visibility="gone"
-      tools:visibility="visible" />
-  </LinearLayout>
+      android:orientation="vertical"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+      <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/listDownloadedMiniApp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:listitem="@layout/item_list_miniapp" />
+
+      <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/emptyView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="@dimen/large_24"
+        android:gravity="top|center"
+        android:text="@string/message_empty_miniapps"
+        android:textSize="@dimen/text_large_18"
+        android:visibility="gone"
+        tools:visibility="visible" />
+    </LinearLayout>
+
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/testapp/src/main/res/layout/profile_settings_activity.xml
+++ b/testapp/src/main/res/layout/profile_settings_activity.xml
@@ -1,54 +1,57 @@
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  xmlns:tools="http://schemas.android.com/tools">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
 
-  <LinearLayout
+  <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:padding="@dimen/small_8"
-    android:orientation="vertical"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent">
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <de.hdodenhof.circleimageview.CircleImageView
-      android:id="@+id/imageProfile"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_gravity="center"
-      tools:src="@drawable/r_logo" />
-
-    <androidx.appcompat.widget.AppCompatTextView
-      android:id="@+id/textEditPhoto"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="@dimen/small_8"
-      android:layout_gravity="center"
-      android:text="@string/userdata_edit_photo"
-      android:textColor="@color/colorAccent"
-      android:textSize="@dimen/text_large_16" />
-
-    <View
+    <LinearLayout
       android:layout_width="match_parent"
-      android:layout_height="@dimen/horizontal_divider_height"
-      android:layout_marginTop="@dimen/small_12"
-      android:layout_marginBottom="@dimen/small_12"
-      android:background="@color/bg_section" />
+      android:layout_height="wrap_content"
+      android:padding="@dimen/small_8"
+      android:orientation="vertical"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent">
 
-    <com.google.android.material.textfield.TextInputLayout
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content">
-
-      <androidx.appcompat.widget.AppCompatEditText
-        android:id="@+id/editProfileName"
-        android:layout_width="match_parent"
+      <de.hdodenhof.circleimageview.CircleImageView
+        android:id="@+id/imageProfile"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/small_4"
-        android:hint="@string/userdata_hint_edit_name"
-        android:imeOptions="actionDone"
-        android:inputType="text" />
-    </com.google.android.material.textfield.TextInputLayout>
-  </LinearLayout>
-</androidx.constraintlayout.widget.ConstraintLayout>
+        android:layout_gravity="center"
+        tools:src="@drawable/r_logo" />
+
+      <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/textEditPhoto"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/small_8"
+        android:layout_gravity="center"
+        android:text="@string/userdata_edit_photo"
+        android:textColor="@color/colorAccent"
+        android:textSize="@dimen/text_large_16" />
+
+      <View
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/horizontal_divider_height"
+        android:layout_marginTop="@dimen/small_12"
+        android:layout_marginBottom="@dimen/small_12"
+        android:background="@color/bg_section" />
+
+      <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <androidx.appcompat.widget.AppCompatEditText
+          android:id="@+id/editProfileName"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginBottom="@dimen/small_4"
+          android:hint="@string/userdata_hint_edit_name"
+          android:imeOptions="actionDone"
+          android:inputType="text" />
+      </com.google.android.material.textfield.TextInputLayout>
+    </LinearLayout>
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/testapp/src/main/res/layout/settings_menu_activity.xml
+++ b/testapp/src/main/res/layout/settings_menu_activity.xml
@@ -1,172 +1,175 @@
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
-  xmlns:tools="http://schemas.android.com/tools"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent">
+  xmlns:tools="http://schemas.android.com/tools">
 
-  <androidx.appcompat.widget.Toolbar
-    android:id="@+id/toolbar"
+  <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
-    android:layout_height="?attr/actionBarSize"
-    android:theme="@style/SettingsToolBarTheme"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent"
-    app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+    android:layout_height="match_parent">
 
-  <LinearLayout
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    app:layout_constraintStart_toStartOf="@id/toolbar"
-    app:layout_constraintTop_toBottomOf="@id/toolbar">
+    <androidx.appcompat.widget.Toolbar
+      android:id="@+id/toolbar"
+      android:layout_width="match_parent"
+      android:layout_height="?attr/actionBarSize"
+      android:theme="@style/SettingsToolBarTheme"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
 
-    <androidx.appcompat.widget.AppCompatTextView
-      android:id="@+id/textInfo"
+    <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_margin="@dimen/small_8"
-      android:padding="@dimen/small_8"
-      android:textColor="@android:color/black"
-      tools:text="Build Info" />
+      android:orientation="vertical"
+      app:layout_constraintStart_toStartOf="@id/toolbar"
+      app:layout_constraintTop_toBottomOf="@id/toolbar">
 
-    <androidx.appcompat.widget.AppCompatTextView
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:paddingTop="@dimen/small_4"
-      android:paddingBottom="@dimen/small_4"
-      android:paddingStart="@dimen/medium_16"
-      android:paddingEnd="@dimen/medium_16"
-      android:background="@color/bg_section"
-      android:text="@string/lb_ras" />
-
-    <com.google.android.material.textfield.TextInputLayout
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_margin="@dimen/small_8">
-
-      <androidx.appcompat.widget.AppCompatEditText
-        android:id="@+id/editAppId"
+      <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/textInfo"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/hint_host_app_id"
-        android:imeOptions="actionDone"
-        android:inputType="text" />
-    </com.google.android.material.textfield.TextInputLayout>
+        android:layout_margin="@dimen/small_8"
+        android:padding="@dimen/small_8"
+        android:textColor="@android:color/black"
+        tools:text="Build Info" />
 
-    <com.google.android.material.textfield.TextInputLayout
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_margin="@dimen/small_8">
-
-      <androidx.appcompat.widget.AppCompatEditText
-        android:id="@+id/editSubscriptionKey"
+      <androidx.appcompat.widget.AppCompatTextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/hint_subscription_key"
-        android:imeOptions="actionDone"
-        android:inputType="text" />
-    </com.google.android.material.textfield.TextInputLayout>
+        android:paddingTop="@dimen/small_4"
+        android:paddingBottom="@dimen/small_4"
+        android:paddingStart="@dimen/medium_16"
+        android:paddingEnd="@dimen/medium_16"
+        android:background="@color/bg_section"
+        android:text="@string/lb_ras" />
 
-    <androidx.appcompat.widget.AppCompatTextView
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:paddingTop="@dimen/small_4"
-      android:paddingBottom="@dimen/small_4"
-      android:paddingStart="@dimen/medium_16"
-      android:paddingEnd="@dimen/medium_16"
-      android:background="@color/bg_section"
-      android:text="@string/lb_user_details" />
+      <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/small_8">
 
-    <RelativeLayout
-      android:id="@+id/buttonProfile"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:padding="@dimen/medium_16"
-      android:foreground="?attr/selectableItemBackground">
+        <androidx.appcompat.widget.AppCompatEditText
+          android:id="@+id/editAppId"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:hint="@string/hint_host_app_id"
+          android:imeOptions="actionDone"
+          android:inputType="text" />
+      </com.google.android.material.textfield.TextInputLayout>
 
-      <ImageView
-        android:layout_width="@dimen/sec_icon_size"
-        android:layout_height="@dimen/sec_icon_size"
-        android:layout_alignParentEnd="true"
-        android:src="@drawable/ic_arrow_forward" />
+      <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/small_8">
+
+        <androidx.appcompat.widget.AppCompatEditText
+          android:id="@+id/editSubscriptionKey"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:hint="@string/hint_subscription_key"
+          android:imeOptions="actionDone"
+          android:inputType="text" />
+      </com.google.android.material.textfield.TextInputLayout>
 
       <androidx.appcompat.widget.AppCompatTextView
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_centerVertical="true"
-        android:text="@string/action_profile"
-        android:textColor="@android:color/black"
-        android:textSize="@dimen/text_large_16" />
-    </RelativeLayout>
+        android:paddingTop="@dimen/small_4"
+        android:paddingBottom="@dimen/small_4"
+        android:paddingStart="@dimen/medium_16"
+        android:paddingEnd="@dimen/medium_16"
+        android:background="@color/bg_section"
+        android:text="@string/lb_user_details" />
 
-    <View
-      android:layout_width="match_parent"
-      android:layout_height="@dimen/horizontal_divider_height"
-      android:background="@color/bg_section" />
-
-    <RelativeLayout
-      android:id="@+id/buttonContacts"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:padding="@dimen/medium_16"
-      android:foreground="?attr/selectableItemBackground">
-
-      <ImageView
-        android:layout_width="@dimen/sec_icon_size"
-        android:layout_height="@dimen/sec_icon_size"
-        android:layout_alignParentEnd="true"
-        android:src="@drawable/ic_arrow_forward" />
-
-      <androidx.appcompat.widget.AppCompatTextView
-        android:layout_width="wrap_content"
+      <RelativeLayout
+        android:id="@+id/buttonProfile"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_centerVertical="true"
-        android:text="@string/action_contacts"
-        android:textColor="@android:color/black"
-        android:textSize="@dimen/text_large_16" />
-    </RelativeLayout>
+        android:padding="@dimen/medium_16"
+        android:foreground="?attr/selectableItemBackground">
 
-    <View
-      android:layout_width="match_parent"
-      android:layout_height="@dimen/horizontal_divider_height"
-      android:background="@color/bg_section" />
+        <ImageView
+          android:layout_width="@dimen/sec_icon_size"
+          android:layout_height="@dimen/sec_icon_size"
+          android:layout_alignParentEnd="true"
+          android:src="@drawable/ic_arrow_forward" />
 
-    <RelativeLayout
-      android:id="@+id/buttonCustomPermissions"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:padding="@dimen/medium_16"
-      android:foreground="?attr/selectableItemBackground">
+        <androidx.appcompat.widget.AppCompatTextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_centerVertical="true"
+          android:text="@string/action_profile"
+          android:textColor="@android:color/black"
+          android:textSize="@dimen/text_large_16" />
+      </RelativeLayout>
 
-      <ImageView
-        android:layout_width="@dimen/sec_icon_size"
-        android:layout_height="@dimen/sec_icon_size"
-        android:layout_alignParentEnd="true"
-        android:src="@drawable/ic_arrow_forward" />
+      <View
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/horizontal_divider_height"
+        android:background="@color/bg_section" />
 
-      <androidx.appcompat.widget.AppCompatTextView
-        android:layout_width="wrap_content"
+      <RelativeLayout
+        android:id="@+id/buttonContacts"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_centerVertical="true"
-        android:text="@string/action_custom_permissions"
-        android:textColor="@android:color/black"
-        android:textSize="@dimen/text_large_16" />
-    </RelativeLayout>
+        android:padding="@dimen/medium_16"
+        android:foreground="?attr/selectableItemBackground">
 
-    <View
-      android:layout_width="match_parent"
-      android:layout_height="@dimen/horizontal_divider_height"
-      android:background="@color/bg_section" />
+        <ImageView
+          android:layout_width="@dimen/sec_icon_size"
+          android:layout_height="@dimen/sec_icon_size"
+          android:layout_alignParentEnd="true"
+          android:src="@drawable/ic_arrow_forward" />
 
-    <com.google.android.material.switchmaterial.SwitchMaterial
-      android:id="@+id/switchTestMode"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="@dimen/small_12"
-      android:text="@string/lb_test_mode"
-      android:visibility="gone" />
+        <androidx.appcompat.widget.AppCompatTextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_centerVertical="true"
+          android:text="@string/action_contacts"
+          android:textColor="@android:color/black"
+          android:textSize="@dimen/text_large_16" />
+      </RelativeLayout>
 
-  </LinearLayout>
+      <View
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/horizontal_divider_height"
+        android:background="@color/bg_section" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+      <RelativeLayout
+        android:id="@+id/buttonCustomPermissions"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/medium_16"
+        android:foreground="?attr/selectableItemBackground">
+
+        <ImageView
+          android:layout_width="@dimen/sec_icon_size"
+          android:layout_height="@dimen/sec_icon_size"
+          android:layout_alignParentEnd="true"
+          android:src="@drawable/ic_arrow_forward" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_centerVertical="true"
+          android:text="@string/action_custom_permissions"
+          android:textColor="@android:color/black"
+          android:textSize="@dimen/text_large_16" />
+      </RelativeLayout>
+
+      <View
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/horizontal_divider_height"
+        android:background="@color/bg_section" />
+
+      <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/switchTestMode"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/small_12"
+        android:text="@string/lb_test_mode"
+        android:visibility="gone" />
+
+    </LinearLayout>
+
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/testapp/src/main/res/values/dimens.xml
+++ b/testapp/src/main/res/values/dimens.xml
@@ -6,6 +6,7 @@
     <dimen name="fab_margin">16dp</dimen>
     <dimen name="appbar_padding_top">8dp</dimen>
     <dimen name="horizontal_divider_height">1dp</dimen>
+    <dimen name="progress_size">56dp</dimen>
 
     <dimen name="tiny_2dp">2dp</dimen>
     <dimen name="small_4">4dp</dimen>


### PR DESCRIPTION
# Description
Recently, we have encountered one issue in sample app while importing the views which throws sometimes:
```
java.lang.IllegalStateException: swipeRefreshLayout must not be null
        at com.rakuten.tech.mobile.testapp.ui.miniapplist.MiniAppListFragment$onStart$1.run(MiniAppListFragment.kt:71)
        .....
```

This is happened because synthetic import of `swipeRefreshLayout` sometimes executes too early which can produce `NPE`.
We can solve this issue either using `swipeRefreshLayout?.` but it'll not execute the action we want when it's `null` at `onStart()`.

Another way is using a global reference i.e. `binding` for getting `swipeRefreshLayout`. I added the same solution in other views as well.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
