### PR TITLE
fix: remove orientation request when fullscreen

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,10 @@
 ignore:
   - "miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt"
   - "miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt"
+coverage:
+  status:
+    patch: off
+    project:
+      default:
+        target: 80%
+        threshold: 4%

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
@@ -149,7 +149,7 @@ internal class MiniAppWebChromeClient(
     }
     // end region video fullscreen
 
-    fun destroy() {
+    fun onWebViewDetach() {
         if (customView != null)
             onHideCustomView()
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
@@ -2,7 +2,6 @@ package com.rakuten.tech.mobile.miniapp.display
 
 import android.app.Activity
 import android.content.Context
-import android.content.pm.ActivityInfo
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.GeolocationPermissions
@@ -95,7 +94,6 @@ internal class MiniAppWebChromeClient(
     @VisibleForTesting
     internal var customView: View? = null
     private var customViewCallback: CustomViewCallback? = null
-    private var originalOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
     private var originalSystemUiVisibility = View.SYSTEM_UI_FLAG_VISIBLE
     private val fullScreenFlag = View.SYSTEM_UI_FLAG_FULLSCREEN or
             View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or
@@ -110,12 +108,10 @@ internal class MiniAppWebChromeClient(
         if (context is Activity) {
             context.apply {
                 originalSystemUiVisibility = window.decorView.systemUiVisibility
-                originalOrientation = requestedOrientation
                 customViewCallback = paramCustomViewCallback
                 (window.decorView as FrameLayout).addView(customView, FrameLayout.LayoutParams(
                     ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
                 window.decorView.systemUiVisibility = fullScreenFlag
-                requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
                 customView?.setOnSystemUiVisibilityChangeListener { updateControls() }
             }
         }
@@ -127,10 +123,8 @@ internal class MiniAppWebChromeClient(
                 (window.decorView as FrameLayout).removeView(customView)
                 customView = null
                 window.decorView.systemUiVisibility = originalSystemUiVisibility
-                requestedOrientation = originalOrientation
                 customViewCallback!!.onCustomViewHidden()
                 customViewCallback = null
-                requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
             }
         }
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
@@ -97,7 +97,8 @@ internal class MiniAppWebChromeClient(
     private var originalSystemUiVisibility = View.SYSTEM_UI_FLAG_VISIBLE
     private val fullScreenFlag = View.SYSTEM_UI_FLAG_FULLSCREEN or
             View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or
-            View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+            View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY or
+            View.SYSTEM_UI_FLAG_LAYOUT_STABLE
 
     override fun onShowCustomView(paramView: View?, paramCustomViewCallback: CustomViewCallback?) {
         if (customView != null) {
@@ -112,6 +113,7 @@ internal class MiniAppWebChromeClient(
                 (window.decorView as FrameLayout).addView(customView, FrameLayout.LayoutParams(
                     ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
                 window.decorView.systemUiVisibility = fullScreenFlag
+                customView?.setBackgroundColor(getColor(android.R.color.black))
                 customView?.setOnSystemUiVisibilityChangeListener { updateControls() }
             }
         }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -73,16 +73,19 @@ internal class MiniAppWebView(
         loadUrl(getLoadUrl())
     }
 
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
-    fun destroyView() = try {
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+
+        if (!(context as Activity).isDestroyed) {
+            miniAppWebChromeClient.onWebViewDetach()
+            miniAppMessageBridge.onWebViewDetach()
+        }
+    }
+
+    fun destroyView() {
         stopLoading()
         webViewClient = null
-        miniAppWebChromeClient.destroy()
-        webChromeClient = null
-        miniAppMessageBridge.onWebViewDestroy()
         destroy()
-    } catch (e: Exception) {
-        // The activity may release before those executions.
     }
 
     override fun runSuccessCallback(callbackId: String, value: String) {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -73,9 +73,15 @@ internal class MiniAppWebView(
         loadUrl(getLoadUrl())
     }
 
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        onResume()
+    }
+
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
 
+        onPause()
         if (!(context as Activity).isDestroyed) {
             miniAppWebChromeClient.onWebViewDetach()
             miniAppMessageBridge.onWebViewDetach()

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -239,7 +239,7 @@ abstract class MiniAppMessageBridge {
         bridgeExecutor.postValue(callbackId, jsonResult)
     }
 
-    internal fun onWebViewDestroy() {
+    internal fun onWebViewDetach() {
         screenBridgeDispatcher.releaseLock()
     }
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.miniapp.display
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -130,10 +131,18 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
 
         verify(displayer).stopLoading()
         displayer.webViewClient shouldBe null
-        verify(displayer.miniAppWebChromeClient).destroy()
-        displayer.webChromeClient shouldBe null
-        verify(miniAppMessageBridge).onWebViewDestroy()
+
         verify(displayer).destroy()
+    }
+
+    @Test
+    fun `should restore the original state of activity when detach webview`() {
+        val displayer = Mockito.spy(miniAppWebView)
+        (context as Activity).setContentView(displayer)
+        (context as Activity).setContentView(R.layout.browser_actions_context_menu_page)
+
+        verify(displayer.miniAppWebChromeClient).onWebViewDetach()
+        verify(miniAppMessageBridge).onWebViewDetach()
     }
 
     @Test
@@ -379,7 +388,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
     fun `should exit fullscreen when destroy miniapp view`() {
         val webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA))
         webChromeClient.onShowCustomView(View(context), mock())
-        webChromeClient.destroy()
+        webChromeClient.onWebViewDetach()
 
         verify(webChromeClient).onHideCustomView()
     }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -11,6 +11,7 @@ import android.webkit.GeolocationPermissions
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import androidx.core.net.toUri
+import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -41,10 +42,13 @@ open class BaseWebViewSpec {
     val miniAppNavigator: MiniAppNavigator = mock()
     internal val miniAppCustomPermissionCache: MiniAppCustomPermissionCache = mock()
     internal lateinit var webChromeClient: MiniAppWebChromeClient
+    lateinit var activityScenario: ActivityScenario<TestActivity>
 
+    @Suppress("LongMethod")
     @Before
     fun setup() {
-        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
+        activityScenario = ActivityScenario.launch(TestActivity::class.java)
+        activityScenario.onActivity { activity ->
             context = activity
             basePath = context.filesDir.path
             webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA))
@@ -136,11 +140,24 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
     }
 
     @Test
-    fun `should restore the original state of activity when detach webview`() {
+    fun `should not restore the original state of activity when activity is destroyed`() {
+        val displayer = Mockito.spy(miniAppWebView)
+        (context as Activity).setContentView(displayer)
+        activityScenario.moveToState(Lifecycle.State.DESTROYED)
+        (context as Activity).setContentView(R.layout.browser_actions_context_menu_page)
+
+        verify(displayer.miniAppWebChromeClient, times(0)).onWebViewDetach()
+        verify(miniAppMessageBridge, times(0)).onWebViewDetach()
+    }
+
+    @Test
+    fun `should trigger executions when attach and detach webview`() {
         val displayer = Mockito.spy(miniAppWebView)
         (context as Activity).setContentView(displayer)
         (context as Activity).setContentView(R.layout.browser_actions_context_menu_page)
 
+        verify(displayer, times(1)).onResume()
+        verify(displayer).onPause()
         verify(displayer.miniAppWebChromeClient).onWebViewDetach()
         verify(miniAppMessageBridge).onWebViewDetach()
     }
@@ -367,7 +384,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
     fun `should close custom view when exit`() {
         val context = getApplicationContext<Context>()
         webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA))
-        webChromeClient.onShowCustomView(mock(), mock())
+        webChromeClient.onShowCustomView(null, mock())
         webChromeClient.customView = mock()
         webChromeClient.onShowCustomView(mock(), mock())
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
@@ -4,7 +4,6 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.gson.Gson
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.rakuten.tech.mobile.miniapp.*
@@ -402,7 +401,7 @@ class ScreenBridgeSpec : BridgeCommon() {
             miniAppBridge.postMessage(createCallbackJsonStr(ScreenOrientation.LOCK_PORTRAIT))
             miniAppBridge.postMessage(createCallbackJsonStr(ScreenOrientation.LOCK_LANDSCAPE))
             miniAppBridge.postMessage(createCallbackJsonStr(ScreenOrientation.LOCK_RELEASE))
-            miniAppBridge.onWebViewDestroy()
+            miniAppBridge.onWebViewDetach()
 
             verify(bridgeExecutor, times(3)).postValue(TEST_CALLBACK_ID, SUCCESS)
         }


### PR DESCRIPTION
# Description
- Fix rotation in fullscreen
Our sdk already has the forced screen orientation feature. That feature applies to every case including fullscreen so I have removed redundant codes here. This solves the problem of fullscreen miniapp in hostapp with no orientation change handling.

- Fix HTML video fullscreen
I notice that when video goes fullscreen, our toolbar is visible (but cannot touch) so the flag `View.SYSTEM_UI_FLAG_LAYOUT_STABLE` is required. Then there is white space in position of status bar and navigation so I have to set the background of fullscreen view in black.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
