### PR TITLE
feat: Added exception types for some cases of server responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### 2.X.X (In progress)
 **SDK**
 - **Feature:** Provide the access token to miniapp.
-- **Feature:** Added default UI support for managing custom permissions in case `requestCustomPermissions` hasn't been implemented in Host App. 
+- **Feature:** Added default UI support for managing custom permissions in case `requestCustomPermissions` hasn't been implemented in Host App.
+- **Feature:** Added `MiniAppHasNoPublishedVersionException` and `MiniAppNotFoundException` exception types to `MiniApp.create` and `MiniApp.fetchInfo`.
 
 ### 2.4.0 (2020-10-30)
 **SDK**

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -242,6 +242,11 @@ class MiniAppActivity : Activity(), CoroutineScope {
 
 **Note:** Clearing up the mini app display is essential. `MiniAppDisplay.destroyView` is required to be called when exit miniapp.
 
+**Note:** There are several different types of exceptions which could be thrown by `MiniApp.create`, but all are sub-classes of `MiniAppSdkException`.
+You can handle each exception type differently if you would like different behavior for different cases.
+For example you may wish to display a different error message when the server contains no published versions of a mini app.
+See the full list of exceptions in the [API docs](api/com.rakuten.tech.mobile.miniapp/-mini-app/create.html).
+
 ## Advanced
 
 ### #1 Clearing up mini app display

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -35,10 +35,13 @@ abstract class MiniApp internal constructor() {
      * The mini app is downloaded, saved and provides a [MiniAppDisplay] when successful.
      * @param appId mini app id.
      * @param miniAppMessageBridge the interface for communicating between host app & mini app
-     * @throws MiniAppSdkException when there is some issue during fetching,
+     * @throws [MiniAppNotFoundException] when the specified mini app ID does not exist on the server
+     * @throws [MiniAppHasNoPublishedVersionException] when the specified mini app ID exists on the
+     * server but has no published versions
+     * @throws [MiniAppSdkException] when there is any other issue during fetching,
      * downloading or creating the view.
      */
-    @Throws(MiniAppSdkException::class)
+    @Throws(MiniAppNotFoundException::class, MiniAppHasNoPublishedVersionException::class, MiniAppSdkException::class)
     abstract suspend fun create(
         appId: String,
         miniAppMessageBridge: MiniAppMessageBridge
@@ -49,7 +52,7 @@ abstract class MiniApp internal constructor() {
      * Use this to control external url loader.
      * @param miniAppNavigator allow host app to handle specific urls such as external link.
      */
-    @Throws(MiniAppSdkException::class)
+    @Throws(MiniAppNotFoundException::class, MiniAppHasNoPublishedVersionException::class, MiniAppSdkException::class)
     abstract suspend fun create(
         appId: String,
         miniAppMessageBridge: MiniAppMessageBridge,
@@ -59,9 +62,12 @@ abstract class MiniApp internal constructor() {
     /**
      * Fetches meta data information of a mini app.
      * @return [MiniAppInfo] for the provided appId of a mini app
-     * @throws [MiniAppSdkException] when fetching fails from the BE server for any reason.
+     * @throws [MiniAppNotFoundException] when the specified mini app ID does not exist on the server
+     * @throws [MiniAppHasNoPublishedVersionException] when the specified mini app ID exists on the
+     * server but has no published versions
+     * @throws [MiniAppSdkException] when fetching fails from the BE server for any other reason.
      */
-    @Throws(MiniAppSdkException::class)
+    @Throws(MiniAppNotFoundException::class, MiniAppHasNoPublishedVersionException::class, MiniAppSdkException::class)
     abstract suspend fun fetchInfo(appId: String): MiniAppInfo
 
     /**

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
@@ -15,6 +15,20 @@ open class MiniAppSdkException(message: String, cause: Throwable?) : Exception(m
 }
 
 /**
+ * Exception which is thrown when the server returns no published
+ * versions for the provided mini app ID.
+ */
+class MiniAppHasNoPublishedVersionException(appId: String) :
+    MiniAppSdkException("Server returned no published version info for the provided Mini App Id: $appId")
+
+/**
+ * Exception which is thrown when the provided mini app ID
+ * does not exist on the server.
+ */
+class MiniAppNotFoundException(serverMessage: String) :
+    MiniAppSdkException("$serverMessage: Server returned no mini app for the provided Mini App ID.")
+
+/**
  * Exception which is thrown when HostApp doesn't implement requestCustomPermissions interface.
  */
 internal class CustomPermissionsNotImplementedException :

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
@@ -102,8 +102,9 @@ open class ApiClientSpec {
         apiClient.fetchInfo(TEST_MA_ID) shouldNotBe secondItem
     }
 
-    @Test(expected = MiniAppSdkException::class)
-    fun `fetchInfo should throw MiniAppSdkException when the API returns zero items`() = runBlockingTest {
+    @Test(expected = MiniAppHasNoPublishedVersionException::class)
+    fun `fetchInfo should throw MiniAppHasNoPublishedVersionException when the API returns zero items`() =
+            runBlockingTest {
         val mockCall: Call<List<MiniAppInfo>> = mock()
 
         When calling mockAppInfoApi.fetchInfo(any(), any(), any(), any()) itReturns mockCall

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
@@ -171,6 +171,16 @@ open class RetrofitRequestExecutorErrorSpec : RetrofitRequestExecutorSpec() {
         executor.executeRequest(request)
     }
 
+    @Test(expected = MiniAppNotFoundException::class)
+    fun `should throw MiniAppNotFoundException when the server returns 404`() = runBlockingTest {
+        mockServer.enqueue(
+            MockResponse().setResponseCode(404)
+        )
+
+        createRequestExecutor()
+            .executeRequest(createApi().fetch())
+    }
+
     private val standardErrorBody = { code: Int, message: String ->
         """
             {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
@@ -7,10 +7,8 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.rakuten.tech.mobile.miniapp.MiniApp
-import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
+import com.rakuten.tech.mobile.miniapp.*
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
-import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
 import kotlinx.coroutines.Dispatchers
@@ -49,7 +47,13 @@ class MiniAppDisplayViewModel constructor(
             _miniAppView.postValue(miniAppDisplay.getMiniAppView(context))
         } catch (e: MiniAppSdkException) {
             e.printStackTrace()
-            _errorData.postValue(e.message)
+            when (e) {
+                is MiniAppHasNoPublishedVersionException ->
+                    _errorData.postValue("No published versions for the provided Mini App ID.")
+                is MiniAppNotFoundException ->
+                    _errorData.postValue("No Mini App found for the provided Mini App ID.")
+                else -> _errorData.postValue(e.message)
+            }
         } finally {
             _isLoading.postValue(false)
         }


### PR DESCRIPTION
# Description
Added MiniAppHasNoPublishedVersionException for the case when the mini app id exists on the server but the server has no published versions, and added MiniAppNotFoundException for the case that the server returns 404.

## Links
MINI-1971

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
