### PR TITLE
refactor: default external link handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Feature:** Provide the access token to miniapp.
 - **Feature:** Added default UI support for managing custom permissions in case `requestCustomPermissions` hasn't been implemented in Host App.
 - **Feature:** Added `MiniAppHasNoPublishedVersionException` and `MiniAppNotFoundException` exception types to `MiniApp.create` and `MiniApp.fetchInfo`.
+- **Change:** Added the default implementation for external link handler. Using [custom tab](https://developers.google.com/web/android/custom-tabs).
 
 ### 2.4.0 (2020-10-30)
 **SDK**

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ buildscript {
     ext.recyclerview = '1.1.0'
     ext.gson = '2.8.6'
     ext.google_ads = '19.4.0'
+    ext.custom_tab = '1.2.0'
 
 //  Build Config.
     apply from: 'config/index.gradle'

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -292,6 +292,8 @@ The mini app is loaded with the specific custom scheme and custom domain in mini
 
 In default, the external link will be opened in custom tab. See [this](https://developers.google.com/web/android/custom-tabs).
 
+HostApp also can implement their own way by passing `MiniAppNavigator` object to `MiniApp.create(appId: String, miniAppMessageBridge: MiniAppMessageBridge, miniAppNavigator: MiniAppNavigator)`.
+
 - Implement `MiniAppNavigator`.
 
 ```kotlin

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -290,8 +290,7 @@ override fun onBackPressed() {
 
 The mini app is loaded with the specific custom scheme and custom domain in mini app view.
 
-In default, the external link is also loaded in mini app view.
-It is possible for hostapp to load this external link with its own webview / browser.
+In default, the external link will be opened in custom tab. See [this](https://developers.google.com/web/android/custom-tabs).
 
 - Implement `MiniAppNavigator`.
 

--- a/miniapp/build.gradle
+++ b/miniapp/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidx_appcompat"
     implementation "androidx.constraintlayout:constraintlayout:$androidx_constraintLayout"
     implementation "androidx.recyclerview:recyclerview:$recyclerview"
+    implementation "androidx.browser:browser:$custom_tab"
 
     kapt "com.rakuten.tech.mobile:manifest-config-processor:$manifest_config"
     implementation "com.rakuten.tech.mobile:manifest-config-annotations:$manifest_config"

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -31,23 +31,6 @@ abstract class MiniApp internal constructor() {
     abstract suspend fun listMiniApp(): List<MiniAppInfo>
 
     /**
-     * Creates a mini app.
-     * The mini app is downloaded, saved and provides a [MiniAppDisplay] when successful.
-     * @param appId mini app id.
-     * @param miniAppMessageBridge the interface for communicating between host app & mini app
-     * @throws [MiniAppNotFoundException] when the specified mini app ID does not exist on the server
-     * @throws [MiniAppHasNoPublishedVersionException] when the specified mini app ID exists on the
-     * server but has no published versions
-     * @throws [MiniAppSdkException] when there is any other issue during fetching,
-     * downloading or creating the view.
-     */
-    @Throws(MiniAppNotFoundException::class, MiniAppHasNoPublishedVersionException::class, MiniAppSdkException::class)
-    abstract suspend fun create(
-        appId: String,
-        miniAppMessageBridge: MiniAppMessageBridge
-    ): MiniAppDisplay
-
-    /**
      * Same as [create(String, MiniAppMessageBridge)].
      * Use this to control external url loader.
      * @param miniAppNavigator allow host app to handle specific urls such as external link.
@@ -56,7 +39,7 @@ abstract class MiniApp internal constructor() {
     abstract suspend fun create(
         appId: String,
         miniAppMessageBridge: MiniAppMessageBridge,
-        miniAppNavigator: MiniAppNavigator
+        miniAppNavigator: MiniAppNavigator? = null
     ): MiniAppDisplay
 
     /**

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -31,9 +31,16 @@ abstract class MiniApp internal constructor() {
     abstract suspend fun listMiniApp(): List<MiniAppInfo>
 
     /**
-     * Same as [create(String, MiniAppMessageBridge)].
-     * Use this to control external url loader.
+     * Creates a mini app.
+     * The mini app is downloaded, saved and provides a [MiniAppDisplay] when successful.
+     * @param appId mini app id.
+     * @param miniAppMessageBridge the interface for communicating between host app & mini app.
      * @param miniAppNavigator allow host app to handle specific urls such as external link.
+     * @throws [MiniAppNotFoundException] when the specified mini app ID does not exist on the server
+     * @throws [MiniAppHasNoPublishedVersionException] when the specified mini app ID exists on the
+     * server but has no published versions
+     * @throws [MiniAppSdkException] when there is any other issue during fetching,
+     * downloading or creating the view.
      */
     @Throws(MiniAppNotFoundException::class, MiniAppHasNoPublishedVersionException::class, MiniAppSdkException::class)
     abstract suspend fun create(

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -39,19 +39,14 @@ internal class RealMiniApp(
 
     override suspend fun create(
         appId: String,
-        miniAppMessageBridge: MiniAppMessageBridge
-    ): MiniAppDisplay = executingCreate(appId, miniAppMessageBridge)
-
-    override suspend fun create(
-        appId: String,
         miniAppMessageBridge: MiniAppMessageBridge,
-        miniAppNavigator: MiniAppNavigator
+        miniAppNavigator: MiniAppNavigator?
     ): MiniAppDisplay = executingCreate(appId, miniAppMessageBridge, miniAppNavigator)
 
     private suspend fun executingCreate(
         miniAppId: String,
         miniAppMessageBridge: MiniAppMessageBridge,
-        miniAppNavigator: MiniAppNavigator? = null
+        miniAppNavigator: MiniAppNavigator?
     ): MiniAppDisplay = when {
         miniAppId.isBlank() -> throw sdkExceptionForInvalidArguments()
         else -> {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -69,7 +69,7 @@ internal class MiniAppWebView(
                 String.format("%s %s", settings.userAgentString, hostAppUserAgentInfo)
 
         setupMiniAppNavigator()
-        webViewClient = MiniAppWebViewClient(context, getWebViewAssetLoader(), miniAppNavigator,
+        webViewClient = MiniAppWebViewClient(context, getWebViewAssetLoader(), miniAppNavigator!!,
             externalResultHandler, miniAppScheme)
         webChromeClient = miniAppWebChromeClient
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -7,6 +7,8 @@ import android.view.ViewGroup
 import android.webkit.WebView
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.core.net.toUri
 import androidx.webkit.WebViewAssetLoader
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.MiniAppScheme
@@ -25,7 +27,7 @@ internal class MiniAppWebView(
     val basePath: String,
     val miniAppInfo: MiniAppInfo,
     val miniAppMessageBridge: MiniAppMessageBridge,
-    miniAppNavigator: MiniAppNavigator?,
+    var miniAppNavigator: MiniAppNavigator?,
     val hostAppUserAgentInfo: String,
     val miniAppWebChromeClient: MiniAppWebChromeClient = MiniAppWebChromeClient(context, miniAppInfo),
     val miniAppCustomPermissionCache: MiniAppCustomPermissionCache
@@ -66,6 +68,7 @@ internal class MiniAppWebView(
             settings.userAgentString =
                 String.format("%s %s", settings.userAgentString, hostAppUserAgentInfo)
 
+        setupMiniAppNavigator()
         webViewClient = MiniAppWebViewClient(context, getWebViewAssetLoader(), miniAppNavigator,
             externalResultHandler, miniAppScheme)
         webChromeClient = miniAppWebChromeClient
@@ -92,6 +95,18 @@ internal class MiniAppWebView(
         stopLoading()
         webViewClient = null
         destroy()
+    }
+
+    @VisibleForTesting
+    internal fun setupMiniAppNavigator() {
+        if (miniAppNavigator == null) {
+            miniAppNavigator = object : MiniAppNavigator {
+                override fun openExternalUrl(url: String, externalResultHandler: ExternalResultHandler) {
+                    val customTabsIntent = CustomTabsIntent.Builder().build()
+                    customTabsIntent.launchUrl(context, url.toUri())
+                }
+            }
+        }
     }
 
     override fun runSuccessCallback(callbackId: String, value: String) {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -102,7 +102,9 @@ internal class MiniAppWebView(
         if (miniAppNavigator == null) {
             miniAppNavigator = object : MiniAppNavigator {
                 override fun openExternalUrl(url: String, externalResultHandler: ExternalResultHandler) {
-                    val customTabsIntent = CustomTabsIntent.Builder().build()
+                    val customTabsIntent = CustomTabsIntent.Builder()
+                        .setShowTitle(true)
+                        .build()
                     customTabsIntent.launchUrl(context, url.toUri())
                 }
             }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
@@ -15,7 +15,7 @@ import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 internal class MiniAppWebViewClient(
     private val context: Context,
     @VisibleForTesting internal val loader: WebViewAssetLoader,
-    private val miniAppNavigator: MiniAppNavigator?,
+    private val miniAppNavigator: MiniAppNavigator,
     private val externalResultHandler: ExternalResultHandler,
     private val miniAppScheme: MiniAppScheme
 ) : WebViewClient() {
@@ -34,11 +34,8 @@ internal class MiniAppWebViewClient(
                 miniAppScheme.openPhoneDialer(context, url)
                 shouldCancelLoading = true
             } else if (!miniAppScheme.isMiniAppUrl(url)) {
-                // check if there is navigator implementation on miniapp.
-                if (miniAppNavigator != null) {
-                    miniAppNavigator.openExternalUrl(url, externalResultHandler)
-                    shouldCancelLoading = true
-                }
+                miniAppNavigator.openExternalUrl(url, externalResultHandler)
+                shouldCancelLoading = true
             }
         }
         return shouldCancelLoading

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -172,7 +172,7 @@ abstract class MiniAppMessageBridge {
         }
     }
 
-    @Suppress("LongMethod")
+    @Suppress("SwallowedException", "LongMethod")
     private fun onRequestCustomPermissions(jsonStr: String) {
         // initialize required properties using jsonStr before executing operations
         customPermissionBridgeDispatcher.initCallBackObject(jsonStr)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -286,7 +286,7 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
         ))
         val miniAppNavigator = Mockito.spy(displayer.miniAppNavigator)
         val webAssetLoader: WebViewAssetLoader = (displayer.webViewClient as MiniAppWebViewClient).loader
-        val webViewClient = Mockito.spy(MiniAppWebViewClient(context, webAssetLoader, miniAppNavigator,
+        val webViewClient = Mockito.spy(MiniAppWebViewClient(context, webAssetLoader, miniAppNavigator!!,
             externalResultHandler, miniAppScheme))
 
         try {
@@ -296,7 +296,7 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
         }
 
         miniAppNavigator shouldNotBe null
-        verify(miniAppNavigator)!!.openExternalUrl(TEST_URL_HTTPS_1, externalResultHandler)
+        verify(miniAppNavigator).openExternalUrl(TEST_URL_HTTPS_1, externalResultHandler)
     }
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -213,7 +213,7 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
     }
 }
 
-@Suppress("SwallowedException")
+@Suppress("SwallowedException", "LongMethod")
 @RunWith(AndroidJUnit4::class)
 class MiniAppWebClientSpec : BaseWebViewSpec() {
     private val externalResultHandler: ExternalResultHandler = spy()
@@ -273,11 +273,21 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
     }
 
     @Test
-    fun `should not open external url loader when there is no config for navigation`() {
-        val webAssetLoader: WebViewAssetLoader = (miniAppWebView.webViewClient as MiniAppWebViewClient).loader
-        val webViewClient = Mockito.spy(MiniAppWebViewClient(context, webAssetLoader, null,
+    fun `should have default external link handler when there is no config for navigation`() {
+        val displayer = Mockito.spy(MiniAppWebView(
+            context,
+            basePath = basePath,
+            miniAppInfo = TEST_MA,
+            miniAppMessageBridge = miniAppMessageBridge,
+            miniAppNavigator = null,
+            hostAppUserAgentInfo = TEST_HA_NAME,
+            miniAppWebChromeClient = webChromeClient,
+            miniAppCustomPermissionCache = miniAppCustomPermissionCache
+        ))
+        val miniAppNavigator = Mockito.spy(displayer.miniAppNavigator)
+        val webAssetLoader: WebViewAssetLoader = (displayer.webViewClient as MiniAppWebViewClient).loader
+        val webViewClient = Mockito.spy(MiniAppWebViewClient(context, webAssetLoader, miniAppNavigator,
             externalResultHandler, miniAppScheme))
-        val displayer = Mockito.spy(miniAppWebView)
 
         try {
             webViewClient.shouldOverrideUrlLoading(displayer, TEST_URL_HTTPS_1)
@@ -285,7 +295,8 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
             // context here is not activity
         }
 
-        verify(miniAppNavigator, times(0)).openExternalUrl(TEST_URL_HTTPS_1, externalResultHandler)
+        miniAppNavigator shouldNotBe null
+        verify(miniAppNavigator)!!.openExternalUrl(TEST_URL_HTTPS_1, externalResultHandler)
     }
 
     @Test

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
@@ -42,7 +42,7 @@ class MiniAppDisplayViewModel constructor(
     ) = viewModelScope.launch(Dispatchers.IO) {
         try {
             _isLoading.postValue(true)
-            miniAppDisplay = miniapp.create(appId, miniAppMessageBridge, miniAppNavigator)
+            miniAppDisplay = miniapp.create(appId, miniAppMessageBridge)
             hostLifeCycle?.addObserver(miniAppDisplay)
             _miniAppView.postValue(miniAppDisplay.getMiniAppView(context))
         } catch (e: MiniAppSdkException) {


### PR DESCRIPTION
# Description
Default implementation of handling external link.
The link will be opened in [Custom Tab](https://developers.google.com/web/android/custom-tabs). There is no support for returning data back to sdk native webview at the moment.

## Links
MINI-1697

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
