### PR TITLE
fix: support back pressed operation for default permission UI 

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -172,7 +172,7 @@ abstract class MiniAppMessageBridge {
         }
     }
 
-    @Suppress("LongMethod")
+    @Suppress("LongMethod", "SwallowedException")
     private fun onRequestCustomPermissions(jsonStr: String) {
         // initialize required properties using jsonStr before executing operations
         customPermissionBridgeDispatcher.initCallBackObject(jsonStr)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionWindow.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionWindow.kt
@@ -1,6 +1,7 @@
 package com.rakuten.tech.mobile.miniapp.permission.ui
 
 import android.app.Activity
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.TextView
@@ -10,9 +11,9 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.rakuten.tech.mobile.miniapp.R
-import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
-import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionResult
 import com.rakuten.tech.mobile.miniapp.permission.CustomPermissionBridgeDispatcher
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionResult
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -107,8 +108,19 @@ internal class MiniAppCustomPermissionWindow(
 
         customPermissionLayout.findViewById<TextView>(R.id.permissionCloseWindow)
             .setOnClickListener {
-                customPermissionBridgeDispatcher.sendCachedCustomPermissions()
-                customPermissionAlertDialog.dismiss()
+                onNoPermissionsSaved()
             }
+
+        customPermissionAlertDialog.setOnKeyListener { _, keyCode, event ->
+            if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_DOWN) {
+                onNoPermissionsSaved()
+                true
+            } else false
+        }
+    }
+
+    private fun onNoPermissionsSaved() {
+        customPermissionBridgeDispatcher.sendCachedCustomPermissions()
+        customPermissionAlertDialog.dismiss()
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionWindow.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionWindow.kt
@@ -112,7 +112,7 @@ internal class MiniAppCustomPermissionWindow(
             }
 
         customPermissionAlertDialog.setOnKeyListener { _, keyCode, event ->
-            if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_DOWN) {
+            if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {
                 onNoPermissionsSaved()
                 true
             } else false


### PR DESCRIPTION
# Description
Previously, there was no support for back pressed when opening default permission UI. It should be the same operation while users press "Close" button. This PR added the fix for back button pressed.

## Links
- MINI-2033

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
