### PR TITLE
sample: external webview update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - **Feature:** Mini App can call media execution play/pause programmatically.
 - **Change:** Added the default implementation for external link handler. Using [custom tab](https://developers.google.com/web/android/custom-tabs).
 
+**Sample App**
+- **Change:** Update setting of external webview.
+
 ### 2.4.0 (2020-10-30)
 **SDK**
 - **Feature:** Handle the screen orientation change request from miniapp.

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/component/SampleExternalWebView.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/component/SampleExternalWebView.kt
@@ -11,6 +11,9 @@ class SampleExternalWebView(context: Context, url: String, sampleWebViewClient: 
 
     init {
         settings.javaScriptEnabled = true
+        settings.allowUniversalAccessFromFileURLs = true
+        settings.domStorageEnabled = true
+        settings.databaseEnabled = true
         webViewClient = sampleWebViewClient
         loadUrl(url)
     }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/component/SampleExternalWebView.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/component/SampleExternalWebView.kt
@@ -14,6 +14,7 @@ class SampleExternalWebView(context: Context, url: String, sampleWebViewClient: 
         settings.allowUniversalAccessFromFileURLs = true
         settings.domStorageEnabled = true
         settings.databaseEnabled = true
+        settings.mediaPlaybackRequiresUserGesture = false
         webViewClient = sampleWebViewClient
         loadUrl(url)
     }


### PR DESCRIPTION
# Description
Turn on some setting flags on external webview to cover some errors.

Why: The hostapp is responsible for external webview implementation but we don't want our clients & partners see errors while testing in our demo app.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
