### PR TITLE
refactor: enable media play/pause programmatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Feature:** Provide the access token to miniapp.
 - **Feature:** Added default UI support for managing custom permissions in case `requestCustomPermissions` hasn't been implemented in Host App.
 - **Feature:** Added `MiniAppHasNoPublishedVersionException` and `MiniAppNotFoundException` exception types to `MiniApp.create` and `MiniApp.fetchInfo`.
+- **Feature:** Mini App can call media execution play/pause programmatically.
 
 ### 2.4.0 (2020-10-30)
 **SDK**

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -61,6 +61,7 @@ internal class MiniAppWebView(
         settings.allowUniversalAccessFromFileURLs = true
         settings.domStorageEnabled = true
         settings.databaseEnabled = true
+        settings.mediaPlaybackRequiresUserGesture = false
 
         if (hostAppUserAgentInfo.isNotEmpty())
             settings.userAgentString =

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -99,12 +99,17 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
 
     @Test
     fun `when MiniAppWebView is created then domStorageEnabled should be enabled`() {
-        miniAppWebView.settings.allowUniversalAccessFromFileURLs shouldBe true
+        miniAppWebView.settings.domStorageEnabled shouldBe true
     }
 
     @Test
     fun `when MiniAppWebView is created then databaseEnabled should be enabled`() {
-        miniAppWebView.settings.allowUniversalAccessFromFileURLs shouldBe true
+        miniAppWebView.settings.databaseEnabled shouldBe true
+    }
+
+    @Test
+    fun `when MiniAppWebView is created then mediaPlaybackRequiresUserGesture should be disabled`() {
+        miniAppWebView.settings.mediaPlaybackRequiresUserGesture shouldBe false
     }
 
     @Test


### PR DESCRIPTION
# Description
Enable the miniapp to call media execution play/pause programmatically.

## Links
MINI-1973

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
