### PR TITLE
fix: redirecting to default browser when window.open anchor

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/component/SampleExternalWebView.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/component/SampleExternalWebView.kt
@@ -2,6 +2,8 @@ package com.rakuten.tech.mobile.testapp.ui.component
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.os.Message
+import android.webkit.WebChromeClient
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppExternalUrlLoader
@@ -15,7 +17,9 @@ class SampleExternalWebView(context: Context, url: String, sampleWebViewClient: 
         settings.domStorageEnabled = true
         settings.databaseEnabled = true
         settings.mediaPlaybackRequiresUserGesture = false
+        settings.setSupportMultipleWindows(true)
         webViewClient = sampleWebViewClient
+        webChromeClient = SampleWebChromeClient(context)
         loadUrl(url)
     }
 }
@@ -24,4 +28,19 @@ class SampleWebViewClient(private val miniAppExternalUrlLoader: MiniAppExternalU
 
     override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean =
         miniAppExternalUrlLoader.shouldOverrideUrlLoading(url ?: "")
+}
+
+class SampleWebChromeClient(val context: Context) : WebChromeClient() {
+
+    override fun onCreateWindow(
+        view: WebView?,
+        isDialog: Boolean,
+        isUserGesture: Boolean,
+        resultMsg: Message?
+    ): Boolean {
+        // redirect to default browser when there is window.open / _blank type anchor
+        (resultMsg?.obj as WebView.WebViewTransport).webView = WebView(context)
+        resultMsg.sendToTarget()
+        return true
+    }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/component/SampleExternalWebView.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/component/SampleExternalWebView.kt
@@ -38,9 +38,11 @@ class SampleWebChromeClient(val context: Context) : WebChromeClient() {
         isUserGesture: Boolean,
         resultMsg: Message?
     ): Boolean {
-        // redirect to default browser when there is window.open / _blank type anchor
-        (resultMsg?.obj as WebView.WebViewTransport).webView = WebView(context)
-        resultMsg.sendToTarget()
-        return true
+        return if (isUserGesture) {
+            // redirect to default browser when there is window.open / _blank type anchor
+            (resultMsg?.obj as WebView.WebViewTransport).webView = WebView(context)
+            resultMsg.sendToTarget()
+            true
+        } else false
     }
 }


### PR DESCRIPTION
# Description
This PR adds a change for secondary webview in sample app, something like redirecting to default browser when there is `window.open` / `_blank` anchor href. Since, SDK has a default implementation for external url handling, so this change doesn't affect anything in sample app. But still we can test this PR by using `miniapp.create(appId, miniAppMessageBridge, miniAppNavigator)` inside `MiniAppDisplayViewModel`.

Note: There is a way to detect `window.open` distinctly in `WebChromeClient.onCreateWindow()`, but it's not reliable solution, so haven't included it.

## Links
- MINI-1928

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
