### PR TITLE
change: App ID configuration setting to use Project ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 **Sample App**
 - **Change:** Updated setting of external webview.
-- **Change:** Use `isPreviewMode` in sample app. "Preview Mode" switch in the settings screen is visible now.
+- **Change:** Used `isPreviewMode` in sample app. "Preview Mode" switch in the settings screen is visible now.
 - **Change:** Updated sample app Manifest configuration with replacing RAS App ID by Project ID.
 
 ### 2.5.0 (2020-11-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **SDK**
 - **Feature:** Mini App can call media execution play/pause programmatically.
 - **Change:** Added the default implementation for external link handler. Using [custom tab](https://developers.google.com/web/android/custom-tabs).
-- **Change:** `MiniAppSdkConfig.rasAppId` has been deprecated, use `MiniAppSdkConfig.rasProjectId` instead
+- **Change:** `com.rakuten.tech.mobile.ras.AppId` has been deprecated, use `com.rakuten.tech.mobile.ras.ProjectId` instead. See [this](miniapp/USERGUIDE.md#2-configure-sdk-settings-in-androidmanifestxml).
 
 **Sample App**
 - **Change:** Updated setting of external webview.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 - **Feature:** Added `MiniAppHasNoPublishedVersionException` and `MiniAppNotFoundException` exception types to `MiniApp.create` and `MiniApp.fetchInfo`.
 - **Feature:** Mini App can call media execution play/pause programmatically.
 - **Change:** Added the default implementation for external link handler. Using [custom tab](https://developers.google.com/web/android/custom-tabs).
+- **Change:** `MiniAppSdkConfig.rasAppId` has been deprecated, use `MiniAppSdkConfig.rasProjectId` instead
 
 **Sample App**
-- **Change:** Update setting of external webview.
+- **Change:** Updated setting of external webview.
+- **Change:** Updated sample app Manifest configuration with replacing RAS App ID by Project ID.
 
 ### 2.4.0 (2020-10-30)
 **SDK**

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Next, you must define a few settings used by the Sample App. These can be define
 ```
 MINIAPP_SERVER_BASE_URL=https://www.example.com/
 HOST_PROJECT_ID=test-host-project-id
-HOST_APP_ID=test-host-app-id (deprecated, use HOST_PROJECT_ID)
 HOST_APP_SUBSCRIPTION_KEY=test-subs-key
 HOST_APP_UA_INFO=MiniAppDemoApp/1.0.0-SNAPSHOT
 HOST_APP_VERSION=test-host-app-version
@@ -49,7 +48,6 @@ Next, you must define the prod settings for the Sample App as either environment
 ```
 MINIAPP_PROD_SERVER_BASE_URL=https://www.example.com/
 HOST_PROJECT_PROD_ID=test-host-project-id
-HOST_APP_PROD_ID=test-host-app-id (deprecated, use HOST_PROJECT_PROD_ID)
 HOST_APP_PROD_SUBSCRIPTION_KEY=test-subs-key
 HOST_APP_PROD_UA_INFO=MiniAppDemoApp/1.0.0
 HOST_APP_PROD_VERSION=test-host-app-version

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Next, you must define a few settings used by the Sample App. These can be define
 ```
 MINIAPP_SERVER_BASE_URL=https://www.example.com/
 HOST_PROJECT_ID=test-host-project-id
-HOST_APP_ID=test-host-app-id
+HOST_APP_ID=test-host-app-id (deprecated, use HOST_PROJECT_ID)
 HOST_APP_SUBSCRIPTION_KEY=test-subs-key
 HOST_APP_UA_INFO=MiniAppDemoApp/1.0.0-SNAPSHOT
 HOST_APP_VERSION=test-host-app-version
@@ -48,7 +48,8 @@ Next, you must define the prod settings for the Sample App as either environment
 
 ```
 MINIAPP_PROD_SERVER_BASE_URL=https://www.example.com/
-HOST_APP_PROD_ID=test-host-app-id
+HOST_PROJECT_PROD_ID=test-host-project-id
+HOST_APP_PROD_ID=test-host-app-id (deprecated, use HOST_PROJECT_PROD_ID)
 HOST_APP_PROD_SUBSCRIPTION_KEY=test-subs-key
 HOST_APP_PROD_UA_INFO=MiniAppDemoApp/1.0.0
 HOST_APP_PROD_VERSION=test-host-app-version

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Next, you must define a few settings used by the Sample App. These can be define
 
 ```
 MINIAPP_SERVER_BASE_URL=https://www.example.com/
+HOST_PROJECT_ID=test-host-project-id
 HOST_APP_ID=test-host-app-id
 HOST_APP_SUBSCRIPTION_KEY=test-subs-key
 HOST_APP_UA_INFO=MiniAppDemoApp/1.0.0-SNAPSHOT

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -58,10 +58,10 @@ In your `AndroidManifest.xml`:
             android:name="com.rakuten.tech.mobile.miniapp.BaseUrl"
             android:value="https://www.example.com" />
 
-        <!-- App ID for the Platform API -->
+        <!-- Project ID for the Platform API -->
         <meta-data
-            android:name="com.rakuten.tech.mobile.ras.AppId"
-            android:value="your_app_id" />
+            android:name="com.rakuten.tech.mobile.ras.ProjectId"
+            android:value="your_project_id" />
 
         <!-- Subscription Key for the Platform API -->
         <meta-data

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -38,7 +38,6 @@ The SDK is configured via manifest meta-data, the configurable values are:
 |------------------------------|---------|--------------------------------------------------------|----------- |--------- |
 | Base URL                     | String  | `com.rakuten.tech.mobile.miniapp.BaseUrl`              | ❌         | 🚫        |
 | Project ID                   | String  | `com.rakuten.tech.mobile.ras.ProjectId`                | ❌         | 🚫        |
-| App ID (deprecated)          | String  | `com.rakuten.tech.mobile.ras.AppId`                    | ❌         | 🚫        |
 | RAS Project Subscription Key | String  | `com.rakuten.tech.mobile.ras.ProjectSubscriptionKey`   | ❌         | 🚫        |
 | Host App Version             | String  | `com.rakuten.tech.mobile.miniapp.HostAppVersion`       | ❌         | 🚫        |
 | Host App User Agent Info     | String  | `com.rakuten.tech.mobile.miniapp.HostAppUserAgentInfo` | ✅         | 🚫        |
@@ -47,7 +46,6 @@ The SDK is configured via manifest meta-data, the configurable values are:
 * We don't currently host a public API, so you will need to provide your own Base URL for API requests.
 * All meta-data values must be string values, including the value for `com.rakuten.tech.mobile.miniapp.HostAppVersion`. For example it could be set to the string value `1.0.0`, but if you need to use a number value such as `1.0` or `1`, then you must declare the value in your string resources (`res/values/strings.xml`) and reference the string ID in the manifest, for example `@string/app_version`.
 * The host app info is the string which is appended to user-agent of webview. It should be a meaningful keyword such as host app name to differentiate other host apps.
-* `com.rakuten.tech.mobile.ras.AppId` has been deprecated, use `com.rakuten.tech.mobile.ras.ProjectId` instead.
 
 In your `AndroidManifest.xml`:
 
@@ -64,11 +62,6 @@ In your `AndroidManifest.xml`:
         <meta-data
             android:name="com.rakuten.tech.mobile.ras.ProjectId"
             android:value="your_project_id" />
-
-        <!-- App ID for the Platform API - currently it's deprecated, use Project ID instead -->
-        <meta-data
-            android:name="com.rakuten.tech.mobile.ras.AppId"
-            android:value="your_app_id" />
 
         <!-- Subscription Key for the Platform API -->
         <meta-data

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -37,7 +37,7 @@ The SDK is configured via manifest meta-data, the configurable values are:
 | Field                        | Datatype| Manifest Key                                           | Optional   | Default  |
 |------------------------------|---------|--------------------------------------------------------|----------- |--------- |
 | Base URL                     | String  | `com.rakuten.tech.mobile.miniapp.BaseUrl`              | ❌         | 🚫        |
-| App ID                       | String  | `com.rakuten.tech.mobile.ras.AppId`                    | ❌         | 🚫        |
+| Project ID                   | String  | `com.rakuten.tech.mobile.ras.ProjectId`                | ❌         | 🚫        |
 | RAS Project Subscription Key | String  | `com.rakuten.tech.mobile.ras.ProjectSubscriptionKey`   | ❌         | 🚫        |
 | Host App Version             | String  | `com.rakuten.tech.mobile.miniapp.HostAppVersion`       | ❌         | 🚫        |
 | Host App User Agent Info     | String  | `com.rakuten.tech.mobile.miniapp.HostAppUserAgentInfo` | ✅         | 🚫        |

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -38,6 +38,7 @@ The SDK is configured via manifest meta-data, the configurable values are:
 |------------------------------|---------|--------------------------------------------------------|----------- |--------- |
 | Base URL                     | String  | `com.rakuten.tech.mobile.miniapp.BaseUrl`              | ❌         | 🚫        |
 | Project ID                   | String  | `com.rakuten.tech.mobile.ras.ProjectId`                | ❌         | 🚫        |
+| App ID (deprecated)          | String  | `com.rakuten.tech.mobile.ras.AppId`                    | ❌         | 🚫        |
 | RAS Project Subscription Key | String  | `com.rakuten.tech.mobile.ras.ProjectSubscriptionKey`   | ❌         | 🚫        |
 | Host App Version             | String  | `com.rakuten.tech.mobile.miniapp.HostAppVersion`       | ❌         | 🚫        |
 | Host App User Agent Info     | String  | `com.rakuten.tech.mobile.miniapp.HostAppUserAgentInfo` | ✅         | 🚫        |
@@ -46,6 +47,7 @@ The SDK is configured via manifest meta-data, the configurable values are:
 * We don't currently host a public API, so you will need to provide your own Base URL for API requests.
 * All meta-data values must be string values, including the value for `com.rakuten.tech.mobile.miniapp.HostAppVersion`. For example it could be set to the string value `1.0.0`, but if you need to use a number value such as `1.0` or `1`, then you must declare the value in your string resources (`res/values/strings.xml`) and reference the string ID in the manifest, for example `@string/app_version`.
 * The host app info is the string which is appended to user-agent of webview. It should be a meaningful keyword such as host app name to differentiate other host apps.
+* `com.rakuten.tech.mobile.ras.AppId` has been deprecated, use `com.rakuten.tech.mobile.ras.ProjectId` instead.
 
 In your `AndroidManifest.xml`:
 
@@ -62,6 +64,11 @@ In your `AndroidManifest.xml`:
         <meta-data
             android:name="com.rakuten.tech.mobile.ras.ProjectId"
             android:value="your_project_id" />
+
+        <!-- App ID for the Platform API - currently it's deprecated, use Project ID instead -->
+        <meta-data
+            android:name="com.rakuten.tech.mobile.ras.AppId"
+            android:value="your_app_id" />
 
         <!-- Subscription Key for the Platform API -->
         <meta-data

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -111,7 +111,7 @@ abstract class MiniApp internal constructor() {
             defaultConfig = miniAppSdkConfig
             val apiClient = ApiClient(
                 baseUrl = miniAppSdkConfig.baseUrl,
-                rasAppId = miniAppSdkConfig.rasAppId,
+                rasProjectId = miniAppSdkConfig.rasProjectId,
                 subscriptionKey = miniAppSdkConfig.subscriptionKey,
                 hostAppVersionId = miniAppSdkConfig.hostAppVersionId,
                 isTestMode = miniAppSdkConfig.isTestMode

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -111,7 +111,7 @@ abstract class MiniApp internal constructor() {
             defaultConfig = miniAppSdkConfig
             val apiClient = ApiClient(
                 baseUrl = miniAppSdkConfig.baseUrl,
-                rasProjectOrAppId = miniAppSdkConfig.projectOrAppId,
+                rasProjectId = miniAppSdkConfig.rasProjectId,
                 subscriptionKey = miniAppSdkConfig.subscriptionKey,
                 hostAppVersionId = miniAppSdkConfig.hostAppVersionId,
                 isTestMode = miniAppSdkConfig.isTestMode

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -111,7 +111,7 @@ abstract class MiniApp internal constructor() {
             defaultConfig = miniAppSdkConfig
             val apiClient = ApiClient(
                 baseUrl = miniAppSdkConfig.baseUrl,
-                rasProjectId = miniAppSdkConfig.rasProjectId,
+                rasProjectOrAppId = miniAppSdkConfig.projectOrAppId,
                 subscriptionKey = miniAppSdkConfig.subscriptionKey,
                 hostAppVersionId = miniAppSdkConfig.hostAppVersionId,
                 isTestMode = miniAppSdkConfig.isTestMode

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -4,6 +4,7 @@ package com.rakuten.tech.mobile.miniapp
  * This represents the configuration settings for the Mini App SDK.
  * @property baseUrl Base URL used for retrieving a Mini App.
  * @property rasProjectId Project ID for the Platform API.
+ * @property rasAppId App ID for the Platform API (Deprecated).
  * @property subscriptionKey Subscription Key for the Platform API.
  * @property hostAppVersionId Version of the host app, used to determine feature compatibility for Mini App.
  * @property hostAppUserAgentInfo User Agent information from Host App.
@@ -11,26 +12,35 @@ package com.rakuten.tech.mobile.miniapp
  */
 data class MiniAppSdkConfig(
     val baseUrl: String,
-    val rasProjectId: String,
+    var rasProjectId: String,
+    @Deprecated("Use rasProjectId") var rasAppId: String,
     val subscriptionKey: String,
     val hostAppVersionId: String,
     val hostAppUserAgentInfo: String,
     val isTestMode: Boolean
 ) {
-    internal val key = "$baseUrl-$isTestMode-$rasProjectId-$subscriptionKey-$hostAppVersionId"
+    internal var projectOrAppId = ""
 
     init {
         when {
             !isBaseUrlValid(baseUrl) ->
                 throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid baseUrl")
-            rasProjectId.isBlank() ->
-                throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid rasAppId")
             subscriptionKey.isBlank() ->
                 throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid subscriptionKey")
             hostAppVersionId.isBlank() ->
                 throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid hostAppVersionId")
+            rasProjectId.isBlank() && rasAppId.isBlank() ->
+                throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid either rasProjectId or rasAppId")
+            rasProjectId.isNotBlank() && rasAppId.isNotBlank() ->
+                projectOrAppId = rasProjectId // Project ID has the first priority
+            rasProjectId.isBlank() && rasAppId.isNotBlank() ->
+                projectOrAppId = rasAppId
+            rasProjectId.isNotBlank() && rasAppId.isBlank() ->
+                projectOrAppId = rasProjectId
         }
     }
+
+    internal val key = "$baseUrl-$isTestMode-$projectOrAppId-$subscriptionKey-$hostAppVersionId"
 }
 
 private fun isBaseUrlValid(url: String) = url.startsWith("https://")

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -41,12 +41,12 @@ data class MiniAppSdkConfig(
         when {
             !isBaseUrlValid(baseUrl) ->
                 throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid baseUrl")
+            rasProjectId.isBlank() ->
+                throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid rasProjectId")
             subscriptionKey.isBlank() ->
                 throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid subscriptionKey")
             hostAppVersionId.isBlank() ->
                 throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid hostAppVersionId")
-            rasProjectId.isBlank() ->
-                throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid rasProjectId")
         }
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -3,7 +3,7 @@ package com.rakuten.tech.mobile.miniapp
 /**
  * This represents the configuration settings for the Mini App SDK.
  * @property baseUrl Base URL used for retrieving a Mini App.
- * @property rasAppId App ID for the Platform API.
+ * @property rasProjectId Project ID for the Platform API.
  * @property subscriptionKey Subscription Key for the Platform API.
  * @property hostAppVersionId Version of the host app, used to determine feature compatibility for Mini App.
  * @property hostAppUserAgentInfo User Agent information from Host App.
@@ -11,19 +11,19 @@ package com.rakuten.tech.mobile.miniapp
  */
 data class MiniAppSdkConfig(
     val baseUrl: String,
-    val rasAppId: String,
+    val rasProjectId: String,
     val subscriptionKey: String,
     val hostAppVersionId: String,
     val hostAppUserAgentInfo: String,
     val isTestMode: Boolean
 ) {
-    internal val key = "$baseUrl-$isTestMode-$rasAppId-$subscriptionKey-$hostAppVersionId"
+    internal val key = "$baseUrl-$isTestMode-$rasProjectId-$subscriptionKey-$hostAppVersionId"
 
     init {
         when {
             !isBaseUrlValid(baseUrl) ->
                 throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid baseUrl")
-            rasAppId.isBlank() ->
+            rasProjectId.isBlank() ->
                 throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid rasAppId")
             subscriptionKey.isBlank() ->
                 throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid subscriptionKey")

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -4,7 +4,6 @@ package com.rakuten.tech.mobile.miniapp
  * This represents the configuration settings for the Mini App SDK.
  * @property baseUrl Base URL used for retrieving a Mini App.
  * @property rasProjectId Project ID for the Platform API.
- * @property rasAppId App ID for the Platform API (Deprecated).
  * @property subscriptionKey Subscription Key for the Platform API.
  * @property hostAppVersionId Version of the host app, used to determine feature compatibility for Mini App.
  * @property hostAppUserAgentInfo User Agent information from Host App.
@@ -12,14 +11,31 @@ package com.rakuten.tech.mobile.miniapp
  */
 data class MiniAppSdkConfig(
     val baseUrl: String,
-    var rasProjectId: String,
-    @Deprecated("Use rasProjectId") var rasAppId: String,
+    val rasProjectId: String,
     val subscriptionKey: String,
     val hostAppVersionId: String,
     val hostAppUserAgentInfo: String,
     val isTestMode: Boolean
 ) {
-    internal var projectOrAppId = ""
+    internal val key = "$baseUrl-$isTestMode-$rasProjectId-$subscriptionKey-$hostAppVersionId"
+
+    @Deprecated("Use rasProjectId instead of rasAppId")
+    constructor(
+        baseUrl: String,
+        rasAppId: String,
+        rasProjectId: String = rasAppId,
+        subscriptionKey: String,
+        hostAppVersionId: String,
+        hostAppUserAgentInfo: String,
+        isTestMode: Boolean
+    ) : this(
+        baseUrl = baseUrl,
+        rasProjectId = rasProjectId,
+        subscriptionKey = subscriptionKey,
+        hostAppVersionId = hostAppVersionId,
+        hostAppUserAgentInfo = hostAppUserAgentInfo,
+        isTestMode = isTestMode
+    )
 
     init {
         when {
@@ -29,18 +45,10 @@ data class MiniAppSdkConfig(
                 throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid subscriptionKey")
             hostAppVersionId.isBlank() ->
                 throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid hostAppVersionId")
-            rasProjectId.isBlank() && rasAppId.isBlank() ->
-                throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid either rasProjectId or rasAppId")
-            rasProjectId.isNotBlank() && rasAppId.isNotBlank() ->
-                projectOrAppId = rasProjectId // Project ID has the first priority
-            rasProjectId.isBlank() && rasAppId.isNotBlank() ->
-                projectOrAppId = rasAppId
-            rasProjectId.isNotBlank() && rasAppId.isBlank() ->
-                projectOrAppId = rasProjectId
+            rasProjectId.isBlank() ->
+                throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid rasProjectId")
         }
     }
-
-    internal val key = "$baseUrl-$isTestMode-$projectOrAppId-$subscriptionKey-$hostAppVersionId"
 }
 
 private fun isBaseUrlValid(url: String) = url.startsWith("https://")

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -51,7 +51,11 @@ class MiniappSdkInitializer : ContentProvider() {
          * App Id assigned to host App.
          **/
         @MetaData(key = "com.rakuten.tech.mobile.ras.AppId")
+        @Deprecated("Use rasProjectId()")
         fun rasAppId(): String
+
+        @MetaData(key = "com.rakuten.tech.mobile.ras.ProjectId")
+        fun rasProjectId(): String
 
         /**
          * Subscription Key for the registered host app.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -70,12 +70,14 @@ class MiniappSdkInitializer : ContentProvider() {
     override fun onCreate(): Boolean {
         val context = context ?: return false
         val manifestConfig = createAppManifestConfig(context)
+        val backwardCompatibleHostId = if (manifestConfig.rasProjectId().isEmpty())
+            manifestConfig.rasAppId() else manifestConfig.rasProjectId()
 
         MiniApp.init(
             context = context,
             miniAppSdkConfig = MiniAppSdkConfig(
                 baseUrl = manifestConfig.baseUrl(),
-                rasProjectId = manifestConfig.rasProjectId(),
+                rasProjectId = backwardCompatibleHostId,
                 rasAppId = manifestConfig.rasAppId(),
                 subscriptionKey = manifestConfig.subscriptionKey(),
                 hostAppVersionId = manifestConfig.hostAppVersion(),

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -50,10 +50,13 @@ class MiniappSdkInitializer : ContentProvider() {
         /**
          * App Id assigned to host App.
          **/
-        @MetaData(key = "com.rakuten.tech.mobile.ras.AppId")
         @Deprecated("Use rasProjectId()")
+        @MetaData(key = "com.rakuten.tech.mobile.ras.AppId")
         fun rasAppId(): String
 
+        /**
+         * Project Id assigned to host App.
+         **/
         @MetaData(key = "com.rakuten.tech.mobile.ras.ProjectId")
         fun rasProjectId(): String
 
@@ -73,6 +76,7 @@ class MiniappSdkInitializer : ContentProvider() {
             miniAppSdkConfig = MiniAppSdkConfig(
                 baseUrl = manifestConfig.baseUrl(),
                 rasProjectId = manifestConfig.rasProjectId(),
+                rasAppId = manifestConfig.rasAppId(),
                 subscriptionKey = manifestConfig.subscriptionKey(),
                 hostAppVersionId = manifestConfig.hostAppVersion(),
                 hostAppUserAgentInfo = manifestConfig.hostAppUserAgentInfo(),

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -72,7 +72,7 @@ class MiniappSdkInitializer : ContentProvider() {
             context = context,
             miniAppSdkConfig = MiniAppSdkConfig(
                 baseUrl = manifestConfig.baseUrl(),
-                rasAppId = manifestConfig.rasAppId(),
+                rasProjectId = manifestConfig.rasProjectId(),
                 subscriptionKey = manifestConfig.subscriptionKey(),
                 hostAppVersionId = manifestConfig.hostAppVersion(),
                 hostAppUserAgentInfo = manifestConfig.hostAppUserAgentInfo(),

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -77,7 +77,7 @@ internal class RealMiniApp(
     @VisibleForTesting
     internal fun createApiClient(newConfig: MiniAppSdkConfig) = ApiClient(
         baseUrl = newConfig.baseUrl,
-        rasProjectOrAppId = newConfig.projectOrAppId,
+        rasProjectId = newConfig.rasProjectId,
         subscriptionKey = newConfig.subscriptionKey,
         hostAppVersionId = newConfig.hostAppVersionId,
         isTestMode = newConfig.isTestMode

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -77,7 +77,7 @@ internal class RealMiniApp(
     @VisibleForTesting
     internal fun createApiClient(newConfig: MiniAppSdkConfig) = ApiClient(
         baseUrl = newConfig.baseUrl,
-        rasProjectId = newConfig.rasProjectId,
+        rasProjectOrAppId = newConfig.projectOrAppId,
         subscriptionKey = newConfig.subscriptionKey,
         hostAppVersionId = newConfig.hostAppVersionId,
         isTestMode = newConfig.isTestMode

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -77,7 +77,7 @@ internal class RealMiniApp(
     @VisibleForTesting
     internal fun createApiClient(newConfig: MiniAppSdkConfig) = ApiClient(
         baseUrl = newConfig.baseUrl,
-        rasAppId = newConfig.rasAppId,
+        rasProjectId = newConfig.rasProjectId,
         subscriptionKey = newConfig.subscriptionKey,
         hostAppVersionId = newConfig.hostAppVersionId,
         isTestMode = newConfig.isTestMode

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -22,7 +22,7 @@ internal class ApiClient @VisibleForTesting constructor(
     retrofit: Retrofit,
     private val isTestMode: Boolean,
     private val hostAppVersionId: String,
-    private val hostAppId: String,
+    private val hostProjectId: String,
     private val appInfoApi: AppInfoApi = retrofit.create(AppInfoApi::class.java),
     private val downloadApi: DownloadApi = retrofit.create(DownloadApi::class.java),
     private val manifestApi: ManifestApi = retrofit.create(ManifestApi::class.java),
@@ -31,19 +31,19 @@ internal class ApiClient @VisibleForTesting constructor(
 
     constructor(
         baseUrl: String,
-        rasAppId: String,
+        rasProjectId: String,
         subscriptionKey: String,
         hostAppVersionId: String,
         isTestMode: Boolean = false
     ) : this(
         retrofit = createRetrofitClient(
             baseUrl = baseUrl,
-            rasAppId = rasAppId,
+            rasProjectId = rasProjectId,
             subscriptionKey = subscriptionKey
         ),
         isTestMode = isTestMode,
         hostAppVersionId = hostAppVersionId,
-        hostAppId = rasAppId
+        hostProjectId = rasProjectId
     )
 
     private val testPath = if (isTestMode) "test" else ""
@@ -51,7 +51,7 @@ internal class ApiClient @VisibleForTesting constructor(
     @Throws(MiniAppSdkException::class)
     suspend fun list(): List<MiniAppInfo> {
         val request = appInfoApi.list(
-            hostAppId = hostAppId,
+            hostAppId = hostProjectId,
             hostAppVersionId = hostAppVersionId,
             testPath = testPath)
         return requestExecutor.executeRequest(request)
@@ -60,7 +60,7 @@ internal class ApiClient @VisibleForTesting constructor(
     @Throws(MiniAppSdkException::class)
     suspend fun fetchInfo(appId: String): MiniAppInfo {
         val request = appInfoApi.fetchInfo(
-            hostAppId = hostAppId,
+            hostAppId = hostProjectId,
             hostAppVersionId = hostAppVersionId,
             miniAppId = appId,
             testPath = testPath)
@@ -75,7 +75,7 @@ internal class ApiClient @VisibleForTesting constructor(
 
     suspend fun fetchFileList(miniAppId: String, versionId: String): ManifestEntity {
         val request = manifestApi.fetchFileListFromManifest(
-            hostAppId = hostAppId,
+            hostAppId = hostProjectId,
             miniAppId = miniAppId,
             versionId = versionId,
             hostAppVersionId = hostAppVersionId,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -22,7 +22,7 @@ internal class ApiClient @VisibleForTesting constructor(
     retrofit: Retrofit,
     private val isTestMode: Boolean,
     private val hostAppVersionId: String,
-    private val hostProjectId: String,
+    private val hostProjectOrAppId: String,
     private val appInfoApi: AppInfoApi = retrofit.create(AppInfoApi::class.java),
     private val downloadApi: DownloadApi = retrofit.create(DownloadApi::class.java),
     private val manifestApi: ManifestApi = retrofit.create(ManifestApi::class.java),
@@ -31,19 +31,19 @@ internal class ApiClient @VisibleForTesting constructor(
 
     constructor(
         baseUrl: String,
-        rasProjectId: String,
+        rasProjectOrAppId: String,
         subscriptionKey: String,
         hostAppVersionId: String,
         isTestMode: Boolean = false
     ) : this(
         retrofit = createRetrofitClient(
             baseUrl = baseUrl,
-            rasProjectId = rasProjectId,
+            rasProjectOrAppId = rasProjectOrAppId,
             subscriptionKey = subscriptionKey
         ),
         isTestMode = isTestMode,
         hostAppVersionId = hostAppVersionId,
-        hostProjectId = rasProjectId
+        hostProjectOrAppId = rasProjectOrAppId
     )
 
     private val testPath = if (isTestMode) "test" else ""
@@ -51,7 +51,7 @@ internal class ApiClient @VisibleForTesting constructor(
     @Throws(MiniAppSdkException::class)
     suspend fun list(): List<MiniAppInfo> {
         val request = appInfoApi.list(
-            hostAppId = hostProjectId,
+            hostAppId = hostProjectOrAppId,
             hostAppVersionId = hostAppVersionId,
             testPath = testPath)
         return requestExecutor.executeRequest(request)
@@ -60,7 +60,7 @@ internal class ApiClient @VisibleForTesting constructor(
     @Throws(MiniAppSdkException::class)
     suspend fun fetchInfo(appId: String): MiniAppInfo {
         val request = appInfoApi.fetchInfo(
-            hostAppId = hostProjectId,
+            hostAppId = hostProjectOrAppId,
             hostAppVersionId = hostAppVersionId,
             miniAppId = appId,
             testPath = testPath)
@@ -75,7 +75,7 @@ internal class ApiClient @VisibleForTesting constructor(
 
     suspend fun fetchFileList(miniAppId: String, versionId: String): ManifestEntity {
         val request = manifestApi.fetchFileListFromManifest(
-            hostAppId = hostProjectId,
+            hostAppId = hostProjectOrAppId,
             miniAppId = miniAppId,
             versionId = versionId,
             hostAppVersionId = hostAppVersionId,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -22,7 +22,7 @@ internal class ApiClient @VisibleForTesting constructor(
     retrofit: Retrofit,
     private val isTestMode: Boolean,
     private val hostAppVersionId: String,
-    private val hostProjectOrAppId: String,
+    private val hostProjectId: String,
     private val appInfoApi: AppInfoApi = retrofit.create(AppInfoApi::class.java),
     private val downloadApi: DownloadApi = retrofit.create(DownloadApi::class.java),
     private val manifestApi: ManifestApi = retrofit.create(ManifestApi::class.java),
@@ -31,19 +31,19 @@ internal class ApiClient @VisibleForTesting constructor(
 
     constructor(
         baseUrl: String,
-        rasProjectOrAppId: String,
+        rasProjectId: String,
         subscriptionKey: String,
         hostAppVersionId: String,
         isTestMode: Boolean = false
     ) : this(
         retrofit = createRetrofitClient(
             baseUrl = baseUrl,
-            rasProjectOrAppId = rasProjectOrAppId,
+            rasProjectId = rasProjectId,
             subscriptionKey = subscriptionKey
         ),
         isTestMode = isTestMode,
         hostAppVersionId = hostAppVersionId,
-        hostProjectOrAppId = rasProjectOrAppId
+        hostProjectId = rasProjectId
     )
 
     private val testPath = if (isTestMode) "test" else ""
@@ -51,7 +51,7 @@ internal class ApiClient @VisibleForTesting constructor(
     @Throws(MiniAppSdkException::class)
     suspend fun list(): List<MiniAppInfo> {
         val request = appInfoApi.list(
-            hostAppId = hostProjectOrAppId,
+            hostAppId = hostProjectId,
             hostAppVersionId = hostAppVersionId,
             testPath = testPath)
         return requestExecutor.executeRequest(request)
@@ -60,7 +60,7 @@ internal class ApiClient @VisibleForTesting constructor(
     @Throws(MiniAppSdkException::class)
     suspend fun fetchInfo(appId: String): MiniAppInfo {
         val request = appInfoApi.fetchInfo(
-            hostAppId = hostProjectOrAppId,
+            hostAppId = hostProjectId,
             hostAppVersionId = hostAppVersionId,
             miniAppId = appId,
             testPath = testPath)
@@ -75,7 +75,7 @@ internal class ApiClient @VisibleForTesting constructor(
 
     suspend fun fetchFileList(miniAppId: String, versionId: String): ManifestEntity {
         val request = manifestApi.fetchFileListFromManifest(
-            hostAppId = hostProjectOrAppId,
+            hostAppId = hostProjectId,
             miniAppId = miniAppId,
             versionId = versionId,
             hostAppVersionId = hostAppVersionId,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtils.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtils.kt
@@ -12,12 +12,12 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 internal fun createRetrofitClient(
     baseUrl: String,
-    rasAppId: String,
+    rasProjectId: String,
     subscriptionKey: String
 ) = createRetrofitClient(
     baseUrl = baseUrl,
     headers = RasSdkHeaders(
-        appId = rasAppId,
+        appId = rasProjectId,
         subscriptionKey = subscriptionKey,
         sdkName = "MiniApp",
         sdkVersion = BuildConfig.VERSION_NAME

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtils.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtils.kt
@@ -12,12 +12,12 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 internal fun createRetrofitClient(
     baseUrl: String,
-    rasProjectOrAppId: String,
+    rasProjectId: String,
     subscriptionKey: String
 ) = createRetrofitClient(
     baseUrl = baseUrl,
     headers = RasSdkHeaders(
-        appId = rasProjectOrAppId,
+        appId = rasProjectId,
         subscriptionKey = subscriptionKey,
         sdkName = "MiniApp",
         sdkVersion = BuildConfig.VERSION_NAME

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtils.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtils.kt
@@ -12,12 +12,12 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 internal fun createRetrofitClient(
     baseUrl: String,
-    rasProjectId: String,
+    rasProjectOrAppId: String,
     subscriptionKey: String
 ) = createRetrofitClient(
     baseUrl = baseUrl,
     headers = RasSdkHeaders(
-        appId = rasProjectId,
+        appId = rasProjectOrAppId,
         subscriptionKey = subscriptionKey,
         sdkName = "MiniApp",
         sdkVersion = BuildConfig.VERSION_NAME

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfigSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfigSpec.kt
@@ -6,10 +6,41 @@ import org.junit.Test
 class MiniAppSdkConfigSpec {
 
     @Test
-    fun `the key pattern should match the defined scheme`() {
+    fun `the key pattern should match the defined scheme when both project and app id has value`() {
         val config = MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
             isTestMode = true,
+            rasProjectId = TEST_HA_ID_PROJECT,
+            rasAppId = TEST_HA_ID_APP,
+            subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
+            hostAppVersionId = TEST_HA_ID_VERSION,
+            hostAppUserAgentInfo = TEST_HA_NAME
+        )
+        config.key shouldEqual "${config.baseUrl}-${config.isTestMode}" +
+                "-${config.rasProjectId}-${config.subscriptionKey}-${config.hostAppVersionId}"
+    }
+
+    @Test
+    fun `the key pattern should match the defined scheme when only project id has value`() {
+        val config = MiniAppSdkConfig(
+            baseUrl = TEST_URL_HTTPS_2,
+            isTestMode = true,
+            rasProjectId = TEST_HA_ID_PROJECT,
+            rasAppId = " ",
+            subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
+            hostAppVersionId = TEST_HA_ID_VERSION,
+            hostAppUserAgentInfo = TEST_HA_NAME
+        )
+        config.key shouldEqual "${config.baseUrl}-${config.isTestMode}" +
+                "-${config.rasProjectId}-${config.subscriptionKey}-${config.hostAppVersionId}"
+    }
+
+    @Test
+    fun `the key pattern should match the defined scheme when only app id has value`() {
+        val config = MiniAppSdkConfig(
+            baseUrl = TEST_URL_HTTPS_2,
+            isTestMode = true,
+            rasProjectId = " ",
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION,
@@ -24,6 +55,7 @@ class MiniAppSdkConfigSpec {
         MiniAppSdkConfig(
             baseUrl = "http://www.example.com/1",
             isTestMode = false,
+            rasProjectId = TEST_HA_ID_PROJECT,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION,
@@ -36,6 +68,7 @@ class MiniAppSdkConfigSpec {
         MiniAppSdkConfig(
             baseUrl = " ",
             isTestMode = true,
+            rasProjectId = TEST_HA_ID_PROJECT,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION,
@@ -44,10 +77,11 @@ class MiniAppSdkConfigSpec {
     }
 
     @Test(expected = MiniAppSdkException::class)
-    fun `should throw exception when rasAppId is blank`() {
+    fun `should throw exception when both projectId and rasAppId is blank`() {
         MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
             isTestMode = true,
+            rasProjectId = " ",
             rasAppId = " ",
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION,
@@ -60,6 +94,7 @@ class MiniAppSdkConfigSpec {
         MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
             isTestMode = true,
+            rasProjectId = TEST_HA_ID_PROJECT,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = " ",
             hostAppVersionId = TEST_HA_ID_VERSION,
@@ -72,6 +107,7 @@ class MiniAppSdkConfigSpec {
         MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
             isTestMode = true,
+            rasProjectId = TEST_HA_ID_PROJECT,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = " ",

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfigSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfigSpec.kt
@@ -20,7 +20,7 @@ class MiniAppSdkConfigSpec {
     }
 
     @Test
-    fun `the key pattern should match the defined scheme when both project and app id has value`() {
+    fun `the key pattern should match the defined scheme when both project and app id have value`() {
         val config = MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
             isTestMode = true,
@@ -74,7 +74,7 @@ class MiniAppSdkConfigSpec {
     }
 
     @Test(expected = MiniAppSdkException::class)
-    fun `should throw exception when both projectId is blank`() {
+    fun `should throw exception when projectId is blank`() {
         MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
             isTestMode = true,
@@ -86,7 +86,7 @@ class MiniAppSdkConfigSpec {
     }
 
     @Test(expected = MiniAppSdkException::class)
-    fun `should throw exception when both projectId and rasAppId is blank`() {
+    fun `should throw exception when both projectId and rasAppId are blank`() {
         MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
             isTestMode = true,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfigSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfigSpec.kt
@@ -6,6 +6,20 @@ import org.junit.Test
 class MiniAppSdkConfigSpec {
 
     @Test
+    fun `the key pattern should match the defined scheme`() {
+        val config = MiniAppSdkConfig(
+            baseUrl = TEST_URL_HTTPS_2,
+            isTestMode = true,
+            rasProjectId = TEST_HA_ID_PROJECT,
+            subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
+            hostAppVersionId = TEST_HA_ID_VERSION,
+            hostAppUserAgentInfo = TEST_HA_NAME
+        )
+        config.key shouldEqual "${config.baseUrl}-${config.isTestMode}" +
+                "-${config.rasProjectId}-${config.subscriptionKey}-${config.hostAppVersionId}"
+    }
+
+    @Test
     fun `the key pattern should match the defined scheme when both project and app id has value`() {
         val config = MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
@@ -35,28 +49,12 @@ class MiniAppSdkConfigSpec {
                 "-${config.rasProjectId}-${config.subscriptionKey}-${config.hostAppVersionId}"
     }
 
-    @Test
-    fun `the key pattern should match the defined scheme when only app id has value`() {
-        val config = MiniAppSdkConfig(
-            baseUrl = TEST_URL_HTTPS_2,
-            isTestMode = true,
-            rasProjectId = " ",
-            rasAppId = TEST_HA_ID_APP,
-            subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
-            hostAppVersionId = TEST_HA_ID_VERSION,
-            hostAppUserAgentInfo = TEST_HA_NAME
-        )
-        config.key shouldEqual "${config.baseUrl}-${config.isTestMode}" +
-                "-${config.rasAppId}-${config.subscriptionKey}-${config.hostAppVersionId}"
-    }
-
     @Test(expected = MiniAppSdkException::class)
     fun `should throw exception when api url is not https`() {
         MiniAppSdkConfig(
             baseUrl = "http://www.example.com/1",
             isTestMode = false,
             rasProjectId = TEST_HA_ID_PROJECT,
-            rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION,
             hostAppUserAgentInfo = TEST_HA_NAME
@@ -69,7 +67,18 @@ class MiniAppSdkConfigSpec {
             baseUrl = " ",
             isTestMode = true,
             rasProjectId = TEST_HA_ID_PROJECT,
-            rasAppId = TEST_HA_ID_APP,
+            subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
+            hostAppVersionId = TEST_HA_ID_VERSION,
+            hostAppUserAgentInfo = TEST_HA_NAME
+        )
+    }
+
+    @Test(expected = MiniAppSdkException::class)
+    fun `should throw exception when both projectId is blank`() {
+        MiniAppSdkConfig(
+            baseUrl = TEST_URL_HTTPS_2,
+            isTestMode = true,
+            rasProjectId = " ",
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION,
             hostAppUserAgentInfo = TEST_HA_NAME
@@ -95,7 +104,6 @@ class MiniAppSdkConfigSpec {
             baseUrl = TEST_URL_HTTPS_2,
             isTestMode = true,
             rasProjectId = TEST_HA_ID_PROJECT,
-            rasAppId = TEST_HA_ID_APP,
             subscriptionKey = " ",
             hostAppVersionId = TEST_HA_ID_VERSION,
             hostAppUserAgentInfo = TEST_HA_NAME
@@ -108,7 +116,6 @@ class MiniAppSdkConfigSpec {
             baseUrl = TEST_URL_HTTPS_2,
             isTestMode = true,
             rasProjectId = TEST_HA_ID_PROJECT,
-            rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = " ",
             hostAppUserAgentInfo = TEST_HA_NAME

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -123,7 +123,6 @@ class RealMiniAppSpec {
             baseUrl = TEST_URL_HTTPS_2,
             isTestMode = true,
             rasProjectId = TEST_HA_ID_PROJECT,
-            rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION,
             hostAppUserAgentInfo = TEST_HA_NAME

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -122,6 +122,7 @@ class RealMiniAppSpec {
         val miniAppSdkConfig = MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
             isTestMode = true,
+            rasProjectId = TEST_HA_ID_PROJECT,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
@@ -21,6 +21,7 @@ internal const val TEST_MA_VERSION_ID = "test_vid"
 
 internal const val TEST_HA_NAME = "test_hostapp_name"
 internal const val TEST_HA_ID_VERSION = "test_version"
+internal const val TEST_HA_ID_PROJECT = "test_project_id"
 internal const val TEST_HA_ID_APP = "test_hostapp_id"
 internal const val TEST_HA_SUBSCRIPTION_KEY = "test_subscription_key"
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
@@ -127,7 +127,7 @@ open class ApiClientSpec {
         When calling mockRetrofitClient.create(ManifestApi::class.java) itReturns mockManifestApi
         When calling mockRetrofitClient.create(DownloadApi::class.java) itReturns mockDownloadApi
 
-        ApiClient(mockRetrofitClient, false, TEST_HA_ID_APP, TEST_HA_ID_VERSION).downloadFile(TEST_URL_FILE)
+        ApiClient(mockRetrofitClient, false, TEST_HA_ID_PROJECT, TEST_HA_ID_VERSION).downloadFile(TEST_URL_FILE)
     }
 
     @Test
@@ -135,7 +135,7 @@ open class ApiClientSpec {
         AppInfo.instance = mock()
         ApiClient(
             baseUrl = TEST_URL_HTTPS_2,
-            rasAppId = TEST_HA_ID_APP,
+            rasProjectOrAppId = TEST_HA_ID_PROJECT,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION
         )
@@ -152,7 +152,7 @@ open class ApiClientSpec {
 
     private fun createApiClient(
         retrofit: Retrofit = mockRetrofitClient,
-        hostAppId: String = TEST_HA_ID_APP,
+        hostProjectOrAppId: String = TEST_HA_ID_PROJECT,
         hostAppVersionId: String = TEST_HA_ID_VERSION,
         requestExecutor: RetrofitRequestExecutor = mockRequestExecutor,
         appInfoApi: AppInfoApi = mockAppInfoApi,
@@ -161,7 +161,7 @@ open class ApiClientSpec {
     ) = ApiClient(
         retrofit = retrofit,
         isTestMode = false,
-        hostAppId = hostAppId,
+        hostProjectOrAppId = hostProjectOrAppId,
         hostAppVersionId = hostAppVersionId,
         requestExecutor = requestExecutor,
         appInfoApi = appInfoApi,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
@@ -135,7 +135,7 @@ open class ApiClientSpec {
         AppInfo.instance = mock()
         ApiClient(
             baseUrl = TEST_URL_HTTPS_2,
-            rasProjectOrAppId = TEST_HA_ID_PROJECT,
+            rasProjectId = TEST_HA_ID_PROJECT,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION
         )
@@ -152,7 +152,7 @@ open class ApiClientSpec {
 
     private fun createApiClient(
         retrofit: Retrofit = mockRetrofitClient,
-        hostProjectOrAppId: String = TEST_HA_ID_PROJECT,
+        hostProjectId: String = TEST_HA_ID_PROJECT,
         hostAppVersionId: String = TEST_HA_ID_VERSION,
         requestExecutor: RetrofitRequestExecutor = mockRequestExecutor,
         appInfoApi: AppInfoApi = mockAppInfoApi,
@@ -161,7 +161,7 @@ open class ApiClientSpec {
     ) = ApiClient(
         retrofit = retrofit,
         isTestMode = false,
-        hostProjectOrAppId = hostProjectOrAppId,
+        hostProjectId = hostProjectId,
         hostAppVersionId = hostAppVersionId,
         requestExecutor = requestExecutor,
         appInfoApi = appInfoApi,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/AppInfoApiSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/AppInfoApiSpec.kt
@@ -62,7 +62,7 @@ class AppInfoApiRequestSpec : AppInfoApiSpec() {
     fun `should fetch mini apps for the provided host app version in test mode`() {
         mockServer.enqueue(createResponse())
         retrofit.create(AppInfoApi::class.java)
-            .list(hostAppId = TEST_HA_ID_APP, hostAppVersionId = TEST_HA_ID_VERSION, testPath = "test")
+            .list(hostAppId = TEST_HA_ID_PROJECT, hostAppVersionId = TEST_HA_ID_VERSION, testPath = "test")
             .execute()
         val request = mockServer.takeRequest()
 
@@ -73,7 +73,7 @@ class AppInfoApiRequestSpec : AppInfoApiSpec() {
     private fun executeListingCallByRetrofit() {
         mockServer.enqueue(createResponse())
         retrofit.create(AppInfoApi::class.java)
-            .list(hostAppId = TEST_HA_ID_APP, hostAppVersionId = TEST_HA_ID_VERSION)
+            .list(hostAppId = TEST_HA_ID_PROJECT, hostAppVersionId = TEST_HA_ID_VERSION)
             .execute()
     }
 }
@@ -87,7 +87,7 @@ class AppInfoApiResponseSpec : AppInfoApiSpec() {
         mockServer.enqueue(createResponse())
 
         miniAppInfo = retrofit.create(AppInfoApi::class.java)
-            .list(hostAppId = TEST_HA_ID_APP, hostAppVersionId = TEST_HA_ID_VERSION)
+            .list(hostAppId = TEST_HA_ID_PROJECT, hostAppVersionId = TEST_HA_ID_VERSION)
             .execute().body()!![0]
     }
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiSpec.kt
@@ -62,7 +62,7 @@ class ManifestApiRequestSpec : ManifestApiSpec() {
         mockServer.enqueue(createResponse())
         retrofit.create(ManifestApi::class.java)
             .fetchFileListFromManifest(
-                hostAppId = TEST_HA_ID_APP,
+                hostAppId = TEST_HA_ID_PROJECT,
                 miniAppId = TEST_ID_MINIAPP,
                 versionId = TEST_ID_MINIAPP_VERSION,
                 hostAppVersionId = TEST_HA_ID_VERSION,
@@ -75,7 +75,7 @@ class ManifestApiRequestSpec : ManifestApiSpec() {
         mockServer.enqueue(createResponse())
         retrofit.create(ManifestApi::class.java)
             .fetchFileListFromManifest(
-                hostAppId = TEST_HA_ID_APP,
+                hostAppId = TEST_HA_ID_PROJECT,
                 miniAppId = TEST_ID_MINIAPP,
                 versionId = TEST_ID_MINIAPP_VERSION,
                 hostAppVersionId = TEST_HA_ID_VERSION
@@ -92,7 +92,7 @@ class ManifestApiResponseSpec : ManifestApiSpec() {
         mockServer.enqueue(createResponse())
         manifestEntity = retrofit.create(ManifestApi::class.java)
             .fetchFileListFromManifest(
-                hostAppId = TEST_HA_ID_APP,
+                hostAppId = TEST_HA_ID_PROJECT,
                 miniAppId = TEST_ID_MINIAPP,
                 versionId = TEST_ID_MINIAPP_VERSION,
                 hostAppVersionId = TEST_HA_ID_VERSION

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
@@ -55,7 +55,7 @@ open class RetrofitRequestExecutorSpec private constructor(
         AppInfo.instance = mock()
         val retrofit = createRetrofitClient(
             baseUrl = TEST_URL_HTTPS_2,
-            rasAppId = TEST_HA_ID_APP,
+            rasProjectOrAppId = TEST_HA_ID_PROJECT,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY
         )
         return Mockito.spy(RetrofitRequestExecutor(retrofit))

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
@@ -55,7 +55,7 @@ open class RetrofitRequestExecutorSpec private constructor(
         AppInfo.instance = mock()
         val retrofit = createRetrofitClient(
             baseUrl = TEST_URL_HTTPS_2,
-            rasProjectOrAppId = TEST_HA_ID_PROJECT,
+            rasProjectId = TEST_HA_ID_PROJECT,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY
         )
         return Mockito.spy(RetrofitRequestExecutor(retrofit))

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -38,7 +38,7 @@ android {
             isTestMode              : property("IS_TEST_MODE") ?: false,
             hostAppUserAgentInfo    : property("HOST_APP_UA_INFO") ?: "MiniApp Demo App/$project.version",
             hostAppVersion          : property("HOST_APP_VERSION") ?: "test-host-app-version",
-            appId                   : property("HOST_APP_ID") ?: "test-host-app-id",
+            projectId               : property("HOST_PROJECT_ID") ?: "test-host-project-id",
             subscriptionKey         : property("HOST_APP_SUBSCRIPTION_KEY") ?: "test-subs-key",
             adMobAppId              : property("ADMOB_APP_ID") ?: ""
     ]
@@ -47,7 +47,7 @@ android {
             isTestMode              : property("PROD_IS_TEST_MODE") ?: false,
             hostAppUserAgentInfo    : property("HOST_APP_PROD_UA_INFO") ?: "MiniApp Demo App/$project.version",
             hostAppVersion          : property("HOST_APP_PROD_VERSION") ?: "test-host-app-version",
-            appId                   : property("HOST_APP_PROD_ID") ?: "test-host-app-id",
+            projectId               : property("HOST_PROJECT_PROD_ID") ?: "test-host-project-id",
             subscriptionKey         : property("HOST_APP_PROD_SUBSCRIPTION_KEY") ?: "test-subs-key",
             adMobAppId              : property("PROD_ADMOB_APP_ID") ?: ""
     ]

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -70,8 +70,8 @@
             android:name="com.rakuten.tech.mobile.miniapp.HostAppUserAgentInfo"
             android:value="${hostAppUserAgentInfo}" />
         <meta-data
-            android:name="com.rakuten.tech.mobile.ras.AppId"
-            android:value="${appId}" />
+          android:name="com.rakuten.tech.mobile.ras.ProjectId"
+          android:value="${projectId}" />
         <meta-data
             android:name="com.rakuten.tech.mobile.ras.ProjectSubscriptionKey"
             android:value="${subscriptionKey}" />

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -90,6 +90,7 @@ class AppSettings private constructor(context: Context) {
         get() = MiniAppSdkConfig(
             baseUrl = baseUrl,
             rasProjectId = projectId,
+            rasAppId = projectId, // rasAppId is deprecated
             subscriptionKey = subscriptionKey,
             hostAppVersionId = hostAppVersionId,
             // no update for hostAppUserAgentInfo because SDK does not allow changing it at runtime

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -21,10 +21,10 @@ class AppSettings private constructor(context: Context) {
             cache.isTestMode = isTestMode
         }
 
-    var appId: String
-        get() = cache.appId ?: manifestConfig.rasProjectId()
-        set(appId) {
-            cache.appId = appId
+    var projectId: String
+        get() = cache.projectId ?: manifestConfig.rasProjectId()
+        set(projectId) {
+            cache.projectId = projectId
         }
 
     var subscriptionKey: String
@@ -89,7 +89,7 @@ class AppSettings private constructor(context: Context) {
     val miniAppSettings: MiniAppSdkConfig
         get() = MiniAppSdkConfig(
             baseUrl = baseUrl,
-            rasAppId = appId,
+            rasProjectId = projectId,
             subscriptionKey = subscriptionKey,
             hostAppVersionId = hostAppVersionId,
             // no update for hostAppUserAgentInfo because SDK does not allow changing it at runtime
@@ -122,7 +122,7 @@ private class Settings(context: Context) {
                 null
         set(isTestMode) = prefs.edit().putBoolean(IS_TEST_MODE, isTestMode!!).apply()
 
-    var appId: String?
+    var projectId: String?
         get() = prefs.getString(APP_ID, null)
         set(appId) = prefs.edit().putString(APP_ID, appId).apply()
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -90,7 +90,6 @@ class AppSettings private constructor(context: Context) {
         get() = MiniAppSdkConfig(
             baseUrl = baseUrl,
             rasProjectId = projectId,
-            rasAppId = projectId, // rasAppId is deprecated
             subscriptionKey = subscriptionKey,
             hostAppVersionId = hostAppVersionId,
             // no update for hostAppUserAgentInfo because SDK does not allow changing it at runtime

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -22,7 +22,7 @@ class AppSettings private constructor(context: Context) {
         }
 
     var appId: String
-        get() = cache.appId ?: manifestConfig.rasAppId()
+        get() = cache.appId ?: manifestConfig.rasProjectId()
         set(appId) {
             cache.appId = appId
         }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
@@ -86,7 +86,7 @@ class SettingsMenuActivity : BaseActivity() {
         settingsProgressDialog.show()
 
         updateSettings(
-            binding.editAppId.text.toString(),
+            binding.editProjectId.text.toString(),
             binding.editSubscriptionKey.text.toString(),
             binding.switchTestMode.isChecked
         )
@@ -100,11 +100,11 @@ class SettingsMenuActivity : BaseActivity() {
 
     private fun renderAppSettingsScreen() {
         binding.textInfo.text = createBuildInfo()
-        binding.editAppId.setText(settings.appId)
+        binding.editProjectId.setText(settings.projectId)
         binding.editSubscriptionKey.setText(settings.subscriptionKey)
         binding.switchTestMode.isChecked = settings.isTestMode
 
-        binding.editAppId.addTextChangedListener(settingsTextWatcher)
+        binding.editProjectId.addTextChangedListener(settingsTextWatcher)
         binding.editSubscriptionKey.addTextChangedListener(settingsTextWatcher)
 
         binding.buttonProfile.setOnClickListener {
@@ -131,14 +131,14 @@ class SettingsMenuActivity : BaseActivity() {
     }
 
     private fun validateInputIDs() {
-        val isAppIdInvalid = binding.editAppId.text.toString().isInvalidUuid()
+        val isAppIdInvalid = binding.editProjectId.text.toString().isInvalidUuid()
 
-        saveViewEnabled = !(isInputEmpty(binding.editAppId)
+        saveViewEnabled = !(isInputEmpty(binding.editProjectId)
                 || isInputEmpty(binding.editSubscriptionKey)
                 || isAppIdInvalid)
 
-        if (isInputEmpty(binding.editAppId) || isAppIdInvalid) {
-            binding.editAppId.error = getString(R.string.error_invalid_input)
+        if (isInputEmpty(binding.editProjectId) || isAppIdInvalid) {
+            binding.editProjectId.error = getString(R.string.error_invalid_input)
         }
 
         if (isInputEmpty(binding.editSubscriptionKey)) {
@@ -146,11 +146,11 @@ class SettingsMenuActivity : BaseActivity() {
         }
     }
 
-    private fun updateSettings(appId: String, subscriptionKey: String, isTestMode: Boolean) {
-        val appIdHolder = settings.appId
+    private fun updateSettings(projectId: String, subscriptionKey: String, isTestMode: Boolean) {
+        val appIdHolder = settings.projectId
         val subscriptionKeyHolder = settings.subscriptionKey
         val isTestModeHolder = settings.isTestMode
-        settings.appId = appId
+        settings.projectId = projectId
         settings.subscriptionKey = subscriptionKey
         settings.isTestMode = isTestMode
 
@@ -163,7 +163,7 @@ class SettingsMenuActivity : BaseActivity() {
                     navigateToPreviousScreen()
                 }
             } catch (error: MiniAppSdkException) {
-                settings.appId = appIdHolder
+                settings.projectId = appIdHolder
                 settings.subscriptionKey = subscriptionKeyHolder
                 settings.isTestMode = isTestModeHolder
                 runOnUiThread {

--- a/testapp/src/main/res/layout/settings_menu_activity.xml
+++ b/testapp/src/main/res/layout/settings_menu_activity.xml
@@ -48,10 +48,10 @@
             android:layout_margin="@dimen/small_8">
 
           <androidx.appcompat.widget.AppCompatEditText
-              android:id="@+id/editAppId"
+              android:id="@+id/editProjectId"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
-              android:hint="@string/hint_host_app_id"
+              android:hint="@string/hint_host_project_id"
               android:imeOptions="actionDone"
               android:inputType="text" />
         </com.google.android.material.textfield.TextInputLayout>

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -29,7 +29,7 @@
     <string name="action_contacts">Contacts</string>
     <string name="action_custom_permissions">Permissions</string>
 
-    <string name="hint_host_app_id">Host App ID</string>
+    <string name="hint_host_project_id">Host Project ID</string>
     <string name="hint_subscription_key">Subscription Key</string>
 
     <string name="error_empty">Required</string>
@@ -37,5 +37,5 @@
 
     <string name="message_empty_miniapps">There is no Mini App found!</string>
 
-    <string name="tut_setting">This is the first time you launch the MiniApp Demo application on this device. You need to provide your own Host App ID and Subscription Key from &lt;font color="#BF0000">&lt;b>Rakuten&lt;/b>&lt;/font> &lt;b>App Studio&lt;/b></string>
+    <string name="tut_setting">This is the first time you launch the MiniApp Demo application on this device. You need to provide your own Host Project ID and Subscription Key from &lt;font color="#BF0000">&lt;b>Rakuten&lt;/b>&lt;/font> &lt;b>App Studio&lt;/b></string>
 </resources>


### PR DESCRIPTION
# Description
- Added `MiniAppSdkConfig.rasProjectId`
- Deprecated `MiniAppSdkConfig.rasAppId`
- Use Project ID in sample app

## Links
- MINI-2039

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
