### PR TITLE
api: remove hostapp version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 **SDK**
 - **Feature:** Mini App can call media execution play/pause programmatically.
 - **Change:** Added the default implementation for external link handler. Using [custom tab](https://developers.google.com/web/android/custom-tabs).
-- **Removed:** The SDK setting `Host App Version` has been removed. There is no usage of it.
 - **Change:** `isTestMode` has been deprecated and replaced with `isPreviewMode` to adopt the Preview mode. See [this](miniapp/USERGUIDE.md#2-configure-sdk-settings-in-androidmanifestxml).
 
 **Sample App**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **SDK**
 - **Feature:** Mini App can call media execution play/pause programmatically.
 - **Change:** Added the default implementation for external link handler. Using [custom tab](https://developers.google.com/web/android/custom-tabs).
+- **Removed:** The SDK setting `Host App Version` has been removed. There is no usage of it.
 
 **Sample App**
 - **Change:** Update setting of external webview.

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -43,7 +43,6 @@ The SDK is configured via manifest meta-data, the configurable values are:
 
 **Note:**  
 * We don't currently host a public API, so you will need to provide your own Base URL for API requests.
-* All meta-data values must be string values, including the value for `com.rakuten.tech.mobile.miniapp.HostAppVersion`. For example it could be set to the string value `1.0.0`, but if you need to use a number value such as `1.0` or `1`, then you must declare the value in your string resources (`res/values/strings.xml`) and reference the string ID in the manifest, for example `@string/app_version`.
 * The host app info is the string which is appended to user-agent of webview. It should be a meaningful keyword such as host app name to differentiate other host apps.
 
 In your `AndroidManifest.xml`:
@@ -66,11 +65,6 @@ In your `AndroidManifest.xml`:
         <meta-data
             android:name="com.rakuten.tech.mobile.ras.ProjectSubscriptionKey"
             android:value="your_subscription_key" />
-
-        <!-- Version of your app - used to determine feature compatibility for Mini App -->
-        <meta-data
-            android:name="com.rakuten.tech.mobile.miniapp.HostAppVersion"
-            android:value="your_app_version" />
 
         <!-- Optional User Agent Information relating to the host app -->
         <meta-data

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -39,7 +39,6 @@ The SDK is configured via manifest meta-data, the configurable values are:
 | Base URL                     | String  | `com.rakuten.tech.mobile.miniapp.BaseUrl`              | ❌         | 🚫        |
 | App ID                       | String  | `com.rakuten.tech.mobile.ras.AppId`                    | ❌         | 🚫        |
 | RAS Project Subscription Key | String  | `com.rakuten.tech.mobile.ras.ProjectSubscriptionKey`   | ❌         | 🚫        |
-| Host App Version             | String  | `com.rakuten.tech.mobile.miniapp.HostAppVersion`       | ❌         | 🚫        |
 | Host App User Agent Info     | String  | `com.rakuten.tech.mobile.miniapp.HostAppUserAgentInfo` | ✅         | 🚫        |
 
 **Note:**  

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -113,7 +113,6 @@ abstract class MiniApp internal constructor() {
                 baseUrl = miniAppSdkConfig.baseUrl,
                 rasAppId = miniAppSdkConfig.rasAppId,
                 subscriptionKey = miniAppSdkConfig.subscriptionKey,
-                hostAppVersionId = miniAppSdkConfig.hostAppVersionId,
                 isTestMode = miniAppSdkConfig.isTestMode
             )
             val apiClientRepository = ApiClientRepository().apply {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -5,7 +5,6 @@ package com.rakuten.tech.mobile.miniapp
  * @property baseUrl Base URL used for retrieving a Mini App.
  * @property rasAppId App ID for the Platform API.
  * @property subscriptionKey Subscription Key for the Platform API.
- * @property hostAppVersionId Version of the host app, used to determine feature compatibility for Mini App.
  * @property hostAppUserAgentInfo User Agent information from Host App.
  * @property isTestMode Whether the sdk is making use of the Test API Endpoints for under "Testing" mini apps.
  */

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -5,6 +5,7 @@ package com.rakuten.tech.mobile.miniapp
  * @property baseUrl Base URL used for retrieving a Mini App.
  * @property rasAppId App ID for the Platform API.
  * @property subscriptionKey Subscription Key for the Platform API.
+ * @property hostAppVersionId Version of the host app, used to determine feature compatibility for Mini App.
  * @property hostAppUserAgentInfo User Agent information from Host App.
  * @property isPreviewMode Whether the host app wants to use the API Endpoints under "Preview" mode.
  */
@@ -12,10 +13,29 @@ data class MiniAppSdkConfig(
     val baseUrl: String,
     val rasAppId: String,
     val subscriptionKey: String,
+    val hostAppVersionId: String = "",
     val hostAppUserAgentInfo: String,
     val isPreviewMode: Boolean
 ) {
     internal val key = "$baseUrl-$isPreviewMode-$rasAppId-$subscriptionKey"
+
+    @Deprecated("Use isPreviewMode instead of isTestMode")
+    constructor(
+        baseUrl: String,
+        rasAppId: String,
+        subscriptionKey: String,
+        hostAppVersionId: String = "",
+        hostAppUserAgentInfo: String,
+        isTestMode: Boolean,
+        isPreviewMode: Boolean = isTestMode
+    ) : this(
+        baseUrl = baseUrl,
+        rasAppId = rasAppId,
+        subscriptionKey = subscriptionKey,
+        hostAppVersionId = hostAppVersionId,
+        hostAppUserAgentInfo = hostAppUserAgentInfo,
+        isPreviewMode = isPreviewMode
+    )
 
     init {
         when {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -13,11 +13,10 @@ data class MiniAppSdkConfig(
     val baseUrl: String,
     val rasAppId: String,
     val subscriptionKey: String,
-    val hostAppVersionId: String,
     val hostAppUserAgentInfo: String,
     val isTestMode: Boolean
 ) {
-    internal val key = "$baseUrl-$isTestMode-$rasAppId-$subscriptionKey-$hostAppVersionId"
+    internal val key = "$baseUrl-$isTestMode-$rasAppId-$subscriptionKey"
 
     init {
         when {
@@ -27,8 +26,6 @@ data class MiniAppSdkConfig(
                 throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid rasAppId")
             subscriptionKey.isBlank() ->
                 throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid subscriptionKey")
-            hostAppVersionId.isBlank() ->
-                throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid hostAppVersionId")
         }
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -71,7 +71,7 @@ class MiniappSdkInitializer : ContentProvider() {
                 rasAppId = manifestConfig.rasAppId(),
                 subscriptionKey = manifestConfig.subscriptionKey(),
                 hostAppUserAgentInfo = manifestConfig.hostAppUserAgentInfo(),
-                isTestMode = manifestConfig.isPreviewMode() || manifestConfig.isTestMode()
+                isPreviewMode = manifestConfig.isPreviewMode() || manifestConfig.isTestMode()
             )
         )
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -78,7 +78,6 @@ class MiniappSdkInitializer : ContentProvider() {
             miniAppSdkConfig = MiniAppSdkConfig(
                 baseUrl = manifestConfig.baseUrl(),
                 rasProjectId = backwardCompatibleHostId,
-                rasAppId = manifestConfig.rasAppId(),
                 subscriptionKey = manifestConfig.subscriptionKey(),
                 hostAppUserAgentInfo = manifestConfig.hostAppUserAgentInfo(),
                 isPreviewMode = manifestConfig.isPreviewMode() || manifestConfig.isTestMode()

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -70,7 +70,6 @@ class MiniappSdkInitializer : ContentProvider() {
                 baseUrl = manifestConfig.baseUrl(),
                 rasAppId = manifestConfig.rasAppId(),
                 subscriptionKey = manifestConfig.subscriptionKey(),
-                hostAppVersionId = manifestConfig.hostAppVersion(),
                 hostAppUserAgentInfo = manifestConfig.hostAppUserAgentInfo(),
                 isTestMode = manifestConfig.isTestMode()
             )

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -34,12 +34,6 @@ class MiniappSdkInitializer : ContentProvider() {
         fun isTestMode(): Boolean
 
         /**
-         * Host app version for the mini app backend.
-         **/
-        @MetaData(key = "com.rakuten.tech.mobile.miniapp.HostAppVersion")
-        fun hostAppVersion(): String
-
-        /**
          * This user agent specific info will be appended to the default user-agent.
          * It should be meaningful e.g. host-app-name/version.
          * @see [link][https://developer.chrome.com/multidevice/user-agent] for more information.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -79,7 +79,6 @@ internal class RealMiniApp(
         baseUrl = newConfig.baseUrl,
         rasAppId = newConfig.rasAppId,
         subscriptionKey = newConfig.subscriptionKey,
-        hostAppVersionId = newConfig.hostAppVersionId,
         isTestMode = newConfig.isTestMode
     )
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -21,7 +21,6 @@ import java.net.UnknownHostException
 internal class ApiClient @VisibleForTesting constructor(
     retrofit: Retrofit,
     private val isTestMode: Boolean,
-    private val hostAppVersionId: String,
     private val hostAppId: String,
     private val appInfoApi: AppInfoApi = retrofit.create(AppInfoApi::class.java),
     private val downloadApi: DownloadApi = retrofit.create(DownloadApi::class.java),
@@ -33,7 +32,6 @@ internal class ApiClient @VisibleForTesting constructor(
         baseUrl: String,
         rasAppId: String,
         subscriptionKey: String,
-        hostAppVersionId: String,
         isTestMode: Boolean = false
     ) : this(
         retrofit = createRetrofitClient(
@@ -42,7 +40,6 @@ internal class ApiClient @VisibleForTesting constructor(
             subscriptionKey = subscriptionKey
         ),
         isTestMode = isTestMode,
-        hostAppVersionId = hostAppVersionId,
         hostAppId = rasAppId
     )
 
@@ -52,7 +49,6 @@ internal class ApiClient @VisibleForTesting constructor(
     suspend fun list(): List<MiniAppInfo> {
         val request = appInfoApi.list(
             hostAppId = hostAppId,
-            hostAppVersionId = hostAppVersionId,
             testPath = testPath)
         return requestExecutor.executeRequest(request)
     }
@@ -61,7 +57,6 @@ internal class ApiClient @VisibleForTesting constructor(
     suspend fun fetchInfo(appId: String): MiniAppInfo {
         val request = appInfoApi.fetchInfo(
             hostAppId = hostAppId,
-            hostAppVersionId = hostAppVersionId,
             miniAppId = appId,
             testPath = testPath)
         val info = requestExecutor.executeRequest(request)
@@ -78,7 +73,6 @@ internal class ApiClient @VisibleForTesting constructor(
             hostAppId = hostAppId,
             miniAppId = miniAppId,
             versionId = versionId,
-            hostAppVersionId = hostAppVersionId,
             testPath = testPath
         )
         return requestExecutor.executeRequest(request)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/AppInfoApi.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/AppInfoApi.kt
@@ -11,15 +11,13 @@ internal interface AppInfoApi {
     @GET("host/{hostappId}/miniapps/{testPath}")
     fun list(
         @Path("hostappId") hostAppId: String,
-        @Path("testPath") testPath: String = "",
-        @Query("hostVersion") hostAppVersionId: String
+        @Path("testPath") testPath: String = ""
     ): Call<List<MiniAppInfo>>
 
     @GET("host/{hostappId}/miniapps/{testPath}")
     fun fetchInfo(
         @Path("hostappId") hostAppId: String,
         @Path("testPath") testPath: String = "",
-        @Query("hostVersion") hostAppVersionId: String,
         @Query("miniAppId") miniAppId: String
     ): Call<List<MiniAppInfo>>
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ManifestApi.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ManifestApi.kt
@@ -4,7 +4,6 @@ import com.google.gson.annotations.SerializedName
 import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Path
-import retrofit2.http.Query
 
 internal interface ManifestApi {
     // double slash is okay
@@ -13,8 +12,7 @@ internal interface ManifestApi {
         @Path("hostappId") hostAppId: String,
         @Path("miniappId") miniAppId: String,
         @Path("versionId") versionId: String,
-        @Path("testPath") testPath: String = "",
-        @Query("hostVersion") hostAppVersionId: String
+        @Path("testPath") testPath: String = ""
     ): Call<ManifestEntity>
 }
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfigSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfigSpec.kt
@@ -12,11 +12,10 @@ class MiniAppSdkConfigSpec {
             isTestMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
-            hostAppVersionId = TEST_HA_ID_VERSION,
             hostAppUserAgentInfo = TEST_HA_NAME
         )
         config.key shouldEqual "${config.baseUrl}-${config.isTestMode}" +
-                "-${config.rasAppId}-${config.subscriptionKey}-${config.hostAppVersionId}"
+                "-${config.rasAppId}-${config.subscriptionKey}"
     }
 
     @Test(expected = MiniAppSdkException::class)
@@ -26,7 +25,6 @@ class MiniAppSdkConfigSpec {
             isTestMode = false,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
-            hostAppVersionId = TEST_HA_ID_VERSION,
             hostAppUserAgentInfo = TEST_HA_NAME
         )
     }
@@ -38,7 +36,6 @@ class MiniAppSdkConfigSpec {
             isTestMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
-            hostAppVersionId = TEST_HA_ID_VERSION,
             hostAppUserAgentInfo = TEST_HA_NAME
         )
     }
@@ -50,7 +47,6 @@ class MiniAppSdkConfigSpec {
             isTestMode = true,
             rasAppId = " ",
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
-            hostAppVersionId = TEST_HA_ID_VERSION,
             hostAppUserAgentInfo = TEST_HA_NAME
         )
     }
@@ -62,19 +58,6 @@ class MiniAppSdkConfigSpec {
             isTestMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = " ",
-            hostAppVersionId = TEST_HA_ID_VERSION,
-            hostAppUserAgentInfo = TEST_HA_NAME
-        )
-    }
-
-    @Test(expected = MiniAppSdkException::class)
-    fun `should throw exception when hostAppVersionId is blank`() {
-        MiniAppSdkConfig(
-            baseUrl = TEST_URL_HTTPS_2,
-            isTestMode = true,
-            rasAppId = TEST_HA_ID_APP,
-            subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
-            hostAppVersionId = " ",
             hostAppUserAgentInfo = TEST_HA_NAME
         )
     }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -124,7 +124,6 @@ class RealMiniAppSpec {
             isTestMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
-            hostAppVersionId = TEST_HA_ID_VERSION,
             hostAppUserAgentInfo = TEST_HA_NAME
         )
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -124,7 +124,7 @@ class RealMiniAppSpec {
             isTestMode = true,
             rasProjectId = TEST_HA_ID_PROJECT,
             isPreviewMode = true,
-            rasAppId = TEST_HA_ID_APP,
+            rasAppId = TEST_HA_ID_PROJECT,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppUserAgentInfo = TEST_HA_NAME
         )

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
@@ -20,7 +20,6 @@ internal const val TEST_MA_VERSION_TAG = "test_vtag"
 internal const val TEST_MA_VERSION_ID = "test_vid"
 
 internal const val TEST_HA_NAME = "test_hostapp_name"
-internal const val TEST_HA_ID_VERSION = "test_version"
 internal const val TEST_HA_ID_APP = "test_hostapp_id"
 internal const val TEST_HA_SUBSCRIPTION_KEY = "test_subscription_key"
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
@@ -34,7 +34,7 @@ open class ApiClientSpec {
     fun `should fetch the list of mini apps`() = runBlockingTest {
         val mockCall: Call<List<MiniAppInfo>> = mock()
 
-        When calling mockAppInfoApi.list(any(), any(), any()) itReturns mockCall
+        When calling mockAppInfoApi.list(any(), any()) itReturns mockCall
         When calling mockRequestExecutor.executeRequest(mockCall) itReturns listOf(miniAppInfo)
 
         val apiClient = createApiClient(appInfoApi = mockAppInfoApi)
@@ -48,7 +48,7 @@ open class ApiClientSpec {
         val mockCall: Call<ManifestEntity> = mock()
         When calling
                 mockManifestApi
-                    .fetchFileListFromManifest(any(), any(), any(), any(), any()) itReturns mockCall
+                    .fetchFileListFromManifest(any(), any(), any(), any()) itReturns mockCall
         When calling
                 mockRequestExecutor
                     .executeRequest(mockCall) itReturns ManifestEntity(fileList)
@@ -82,7 +82,7 @@ open class ApiClientSpec {
     fun `should fetch meta data for a mini app for a given appId`() = runBlockingTest {
         val mockCall: Call<List<MiniAppInfo>> = mock()
 
-        When calling mockAppInfoApi.fetchInfo(any(), any(), any(), any()) itReturns mockCall
+        When calling mockAppInfoApi.fetchInfo(any(), any(), any()) itReturns mockCall
         When calling mockRequestExecutor.executeRequest(mockCall) itReturns listOf(miniAppInfo)
 
         val apiClient = createApiClient(appInfoApi = mockAppInfoApi)
@@ -95,7 +95,7 @@ open class ApiClientSpec {
         val secondItem = miniAppInfo.copy()
         val resultList = listOf(miniAppInfo, secondItem)
 
-        When calling mockAppInfoApi.fetchInfo(any(), any(), any(), any()) itReturns mockCall
+        When calling mockAppInfoApi.fetchInfo(any(), any(), any()) itReturns mockCall
         When calling mockRequestExecutor.executeRequest(mockCall) itReturns resultList
 
         val apiClient = createApiClient(appInfoApi = mockAppInfoApi)
@@ -107,7 +107,7 @@ open class ApiClientSpec {
             runBlockingTest {
         val mockCall: Call<List<MiniAppInfo>> = mock()
 
-        When calling mockAppInfoApi.fetchInfo(any(), any(), any(), any()) itReturns mockCall
+        When calling mockAppInfoApi.fetchInfo(any(), any(), any()) itReturns mockCall
         When calling mockRequestExecutor.executeRequest(mockCall) itReturns emptyList()
 
         val apiClient = createApiClient(appInfoApi = mockAppInfoApi)
@@ -127,7 +127,7 @@ open class ApiClientSpec {
         When calling mockRetrofitClient.create(ManifestApi::class.java) itReturns mockManifestApi
         When calling mockRetrofitClient.create(DownloadApi::class.java) itReturns mockDownloadApi
 
-        ApiClient(mockRetrofitClient, false, TEST_HA_ID_APP, TEST_HA_ID_VERSION).downloadFile(TEST_URL_FILE)
+        ApiClient(mockRetrofitClient, false, TEST_HA_ID_APP).downloadFile(TEST_URL_FILE)
     }
 
     @Test
@@ -136,8 +136,7 @@ open class ApiClientSpec {
         ApiClient(
             baseUrl = TEST_URL_HTTPS_2,
             rasAppId = TEST_HA_ID_APP,
-            subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
-            hostAppVersionId = TEST_HA_ID_VERSION
+            subscriptionKey = TEST_HA_SUBSCRIPTION_KEY
         )
     }
 
@@ -162,7 +161,6 @@ open class ApiClientSpec {
         retrofit = retrofit,
         isTestMode = false,
         hostAppId = hostAppId,
-        hostAppVersionId = hostAppVersionId,
         requestExecutor = requestExecutor,
         appInfoApi = appInfoApi,
         manifestApi = manifestApi,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
@@ -152,7 +152,6 @@ open class ApiClientSpec {
     private fun createApiClient(
         retrofit: Retrofit = mockRetrofitClient,
         hostAppId: String = TEST_HA_ID_APP,
-        hostAppVersionId: String = TEST_HA_ID_VERSION,
         requestExecutor: RetrofitRequestExecutor = mockRequestExecutor,
         appInfoApi: AppInfoApi = mockAppInfoApi,
         manifestApi: ManifestApi = mockManifestApi,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/AppInfoApiSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/AppInfoApiSpec.kt
@@ -62,7 +62,7 @@ class AppInfoApiRequestSpec : AppInfoApiSpec() {
     fun `should fetch mini apps for the provided host app version in test mode`() {
         mockServer.enqueue(createResponse())
         retrofit.create(AppInfoApi::class.java)
-            .list(hostAppId = TEST_HA_ID_APP, hostAppVersionId = TEST_HA_ID_VERSION, testPath = "test")
+            .list(hostAppId = TEST_HA_ID_APP, testPath = "test")
             .execute()
         val request = mockServer.takeRequest()
 
@@ -73,7 +73,7 @@ class AppInfoApiRequestSpec : AppInfoApiSpec() {
     private fun executeListingCallByRetrofit() {
         mockServer.enqueue(createResponse())
         retrofit.create(AppInfoApi::class.java)
-            .list(hostAppId = TEST_HA_ID_APP, hostAppVersionId = TEST_HA_ID_VERSION)
+            .list(hostAppId = TEST_HA_ID_APP)
             .execute()
     }
 }
@@ -87,7 +87,7 @@ class AppInfoApiResponseSpec : AppInfoApiSpec() {
         mockServer.enqueue(createResponse())
 
         miniAppInfo = retrofit.create(AppInfoApi::class.java)
-            .list(hostAppId = TEST_HA_ID_APP, hostAppVersionId = TEST_HA_ID_VERSION)
+            .list(hostAppId = TEST_HA_ID_APP)
             .execute().body()!![0]
     }
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/AppInfoApiSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/AppInfoApiSpec.kt
@@ -55,19 +55,6 @@ class AppInfoApiRequestSpec : AppInfoApiSpec() {
         val requestUrl = mockServer.takeRequest().requestUrl!!
 
         requestUrl.encodedPath shouldEndWith "miniapps/"
-        requestUrl.encodedQuery.toString() shouldContain "hostVersion=$TEST_HA_ID_VERSION"
-    }
-
-    @Test
-    fun `should fetch mini apps for the provided host app version in test mode`() {
-        mockServer.enqueue(createResponse())
-        retrofit.create(AppInfoApi::class.java)
-            .list(hostAppId = TEST_HA_ID_APP, testPath = "test")
-            .execute()
-        val request = mockServer.takeRequest()
-
-        request.requestUrl!!.encodedPath shouldEndWith "miniapps/test"
-        request.path!! shouldContain "test_version"
     }
 
     private fun executeListingCallByRetrofit() {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiSpec.kt
@@ -65,7 +65,6 @@ class ManifestApiRequestSpec : ManifestApiSpec() {
                 hostAppId = TEST_HA_ID_APP,
                 miniAppId = TEST_ID_MINIAPP,
                 versionId = TEST_ID_MINIAPP_VERSION,
-                hostAppVersionId = TEST_HA_ID_VERSION,
                 testPath = "test"
             ).execute()
         mockServer.takeRequest().path!! shouldContain "test"
@@ -77,8 +76,7 @@ class ManifestApiRequestSpec : ManifestApiSpec() {
             .fetchFileListFromManifest(
                 hostAppId = TEST_HA_ID_APP,
                 miniAppId = TEST_ID_MINIAPP,
-                versionId = TEST_ID_MINIAPP_VERSION,
-                hostAppVersionId = TEST_HA_ID_VERSION
+                versionId = TEST_ID_MINIAPP_VERSION
             ).execute()
     }
 }
@@ -94,8 +92,7 @@ class ManifestApiResponseSpec : ManifestApiSpec() {
             .fetchFileListFromManifest(
                 hostAppId = TEST_HA_ID_APP,
                 miniAppId = TEST_ID_MINIAPP,
-                versionId = TEST_ID_MINIAPP_VERSION,
-                hostAppVersionId = TEST_HA_ID_VERSION
+                versionId = TEST_ID_MINIAPP_VERSION
             )
             .execute().body()!!
     }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiSpec.kt
@@ -47,7 +47,6 @@ class ManifestApiRequestSpec : ManifestApiSpec() {
         executeManifestCallByRetrofit()
         val requestUrl = mockServer.takeRequest().requestUrl!!
         requestUrl.encodedPath shouldEndWith "manifest"
-        requestUrl.encodedQuery.toString() shouldContain "hostVersion=$TEST_HA_ID_VERSION"
     }
 
     @Test

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -37,7 +37,6 @@ android {
             baseUrl                 : property("MINIAPP_SERVER_BASE_URL") ?: "https://www.example.com/",
             isTestMode              : property("IS_TEST_MODE") ?: false,
             hostAppUserAgentInfo    : property("HOST_APP_UA_INFO") ?: "MiniApp Demo App/$project.version",
-            hostAppVersion          : property("HOST_APP_VERSION") ?: "test-host-app-version",
             appId                   : property("HOST_APP_ID") ?: "test-host-app-id",
             subscriptionKey         : property("HOST_APP_SUBSCRIPTION_KEY") ?: "test-subs-key",
             adMobAppId              : property("ADMOB_APP_ID") ?: ""
@@ -46,7 +45,6 @@ android {
             baseUrl                 : property("MINIAPP_PROD_SERVER_BASE_URL") ?: "https://www.example.com/",
             isTestMode              : property("PROD_IS_TEST_MODE") ?: false,
             hostAppUserAgentInfo    : property("HOST_APP_PROD_UA_INFO") ?: "MiniApp Demo App/$project.version",
-            hostAppVersion          : property("HOST_APP_PROD_VERSION") ?: "test-host-app-version",
             appId                   : property("HOST_APP_PROD_ID") ?: "test-host-app-id",
             subscriptionKey         : property("HOST_APP_PROD_SUBSCRIPTION_KEY") ?: "test-subs-key",
             adMobAppId              : property("PROD_ADMOB_APP_ID") ?: ""

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -64,9 +64,6 @@
             android:name="com.rakuten.tech.mobile.miniapp.IsTestMode"
             android:value="${isTestMode}" />
         <meta-data
-            android:name="com.rakuten.tech.mobile.miniapp.HostAppVersion"
-            android:value="${hostAppVersion}" />
-        <meta-data
             android:name="com.rakuten.tech.mobile.miniapp.HostAppUserAgentInfo"
             android:value="${hostAppUserAgentInfo}" />
         <meta-data

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -84,14 +84,11 @@ class AppSettings private constructor(context: Context) {
 
     val baseUrl = manifestConfig.baseUrl()
 
-    val hostAppVersionId = manifestConfig.hostAppVersion()
-
     val miniAppSettings: MiniAppSdkConfig
         get() = MiniAppSdkConfig(
             baseUrl = baseUrl,
             rasAppId = appId,
             subscriptionKey = subscriptionKey,
-            hostAppVersionId = hostAppVersionId,
             // no update for hostAppUserAgentInfo because SDK does not allow changing it at runtime
             hostAppUserAgentInfo = manifestConfig.hostAppUserAgentInfo(),
             isTestMode = isTestMode


### PR DESCRIPTION
# Description
There is no usage of hostapp version so this PR removes it in sdk and sample app.

## Links
MINI-2028

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
