### PR TITLE
api: support preview mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 **Sample App**
 - **Change:** Update setting of external webview.
-- **Change:** Adopted Preview Mode in sample app.
+- **Change:** Use `isPreviewMode` in sample app. "Preview Mode" switch in the settings screen is visible now.
 
 ### 2.5.0 (2020-11-13)
 **SDK**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **SDK**
 - **Feature:** Mini App can call media execution play/pause programmatically.
 - **Change:** Added the default implementation for external link handler. Using [custom tab](https://developers.google.com/web/android/custom-tabs).
-- **Change:** Adopted Preview Mode to get the miniapps.  
+- **Change:** `isTestMode` has been deprecated and replaced with `isPreviewMode` to adopt the Preview mode.  
 
 **Sample App**
 - **Change:** Update setting of external webview.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **SDK**
 - **Feature:** Mini App can call media execution play/pause programmatically.
 - **Change:** Added the default implementation for external link handler. Using [custom tab](https://developers.google.com/web/android/custom-tabs).
-- **Change:** `isTestMode` has been deprecated and replaced with `isPreviewMode` to adopt the Preview mode.  
+- **Change:** `isTestMode` has been deprecated and replaced with `isPreviewMode` to adopt the Preview mode. See [this](miniapp/USERGUIDE.md#2-configure-sdk-settings-in-androidmanifestxml).
 
 **Sample App**
 - **Change:** Update setting of external webview.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 **SDK**
 - **Feature:** Mini App can call media execution play/pause programmatically.
 - **Change:** Added the default implementation for external link handler. Using [custom tab](https://developers.google.com/web/android/custom-tabs).
+- **Change:** Adopted Preview Mode to get the miniapps.  
 
 **Sample App**
 - **Change:** Update setting of external webview.
+- **Change:** Adopted Preview Mode in sample app.
 
 ### 2.5.0 (2020-11-13)
 **SDK**

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -58,6 +58,11 @@ In your `AndroidManifest.xml`:
             android:name="com.rakuten.tech.mobile.miniapp.BaseUrl"
             android:value="https://www.example.com" />
 
+        <!-- Preview Mode used for retrieving the Mini Apps -->
+        <meta-data
+            android:name="com.rakuten.tech.mobile.miniapp.IsPreviewMode"
+            android:value="${isPreviewMode}" />
+
         <!-- App ID for the Platform API -->
         <meta-data
             android:name="com.rakuten.tech.mobile.ras.AppId"

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -58,7 +58,7 @@ In your `AndroidManifest.xml`:
             android:name="com.rakuten.tech.mobile.miniapp.BaseUrl"
             android:value="https://www.example.com" />
 
-        <!-- Preview Mode used for retrieving the Mini Apps -->
+        <!-- Preview mode used for retrieving the Mini Apps -->
         <meta-data
             android:name="com.rakuten.tech.mobile.miniapp.IsPreviewMode"
             android:value="${isPreviewMode}" />

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -38,6 +38,7 @@ The SDK is configured via manifest meta-data, the configurable values are:
 |------------------------------|---------|--------------------------------------------------------|----------- |--------- |
 | Base URL                     | String  | `com.rakuten.tech.mobile.miniapp.BaseUrl`              | ❌         | 🚫        |
 | App ID                       | String  | `com.rakuten.tech.mobile.ras.AppId`                    | ❌         | 🚫        |
+| Is Preview Mode              | Boolean | `com.rakuten.tech.mobile.miniapp.IsPreviewMode`        | ❌         | 🚫        |
 | RAS Project Subscription Key | String  | `com.rakuten.tech.mobile.ras.ProjectSubscriptionKey`   | ❌         | 🚫        |
 | Host App Version             | String  | `com.rakuten.tech.mobile.miniapp.HostAppVersion`       | ❌         | 🚫        |
 | Host App User Agent Info     | String  | `com.rakuten.tech.mobile.miniapp.HostAppUserAgentInfo` | ✅         | 🚫        |

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -114,7 +114,7 @@ abstract class MiniApp internal constructor() {
                 rasAppId = miniAppSdkConfig.rasAppId,
                 subscriptionKey = miniAppSdkConfig.subscriptionKey,
                 hostAppVersionId = miniAppSdkConfig.hostAppVersionId,
-                isTestMode = miniAppSdkConfig.isTestMode
+                isPreviewMode = miniAppSdkConfig.isPreviewMode
             )
             val apiClientRepository = ApiClientRepository().apply {
                 registerApiClient(defaultConfig.key, apiClient)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -1,7 +1,5 @@
 package com.rakuten.tech.mobile.miniapp
 
-import android.util.Log
-
 /**
  * This represents the configuration settings for the Mini App SDK.
  * @property baseUrl Base URL used for retrieving a Mini App.
@@ -40,8 +38,6 @@ data class MiniAppSdkConfig(
     )
 
     init {
-        Log.d("AAAAA",""+isPreviewMode)
-
         when {
             !isBaseUrlValid(baseUrl) ->
                 throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid baseUrl")

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -1,5 +1,7 @@
 package com.rakuten.tech.mobile.miniapp
 
+import android.util.Log
+
 /**
  * This represents the configuration settings for the Mini App SDK.
  * @property baseUrl Base URL used for retrieving a Mini App.
@@ -38,6 +40,8 @@ data class MiniAppSdkConfig(
     )
 
     init {
+        Log.d("AAAAA",""+isPreviewMode)
+
         when {
             !isBaseUrlValid(baseUrl) ->
                 throw sdkExceptionForInvalidArguments("MiniAppSdkConfig with invalid baseUrl")

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -7,7 +7,7 @@ package com.rakuten.tech.mobile.miniapp
  * @property subscriptionKey Subscription Key for the Platform API.
  * @property hostAppVersionId Version of the host app, used to determine feature compatibility for Mini App.
  * @property hostAppUserAgentInfo User Agent information from Host App.
- * @property isTestMode Whether the sdk is making use of the Test API Endpoints for under "Testing" mini apps.
+ * @property isPreviewMode Whether the sdk wants to use the API Endpoints under "Preview" mode.
  */
 data class MiniAppSdkConfig(
     val baseUrl: String,
@@ -15,9 +15,27 @@ data class MiniAppSdkConfig(
     val subscriptionKey: String,
     val hostAppVersionId: String,
     val hostAppUserAgentInfo: String,
-    val isTestMode: Boolean
+    val isPreviewMode: Boolean
 ) {
-    internal val key = "$baseUrl-$isTestMode-$rasAppId-$subscriptionKey-$hostAppVersionId"
+    internal val key = "$baseUrl-$isPreviewMode-$rasAppId-$subscriptionKey-$hostAppVersionId"
+
+    @Deprecated("Use isPreviewMode instead of isTestMode")
+    constructor(
+        baseUrl: String,
+        rasAppId: String,
+        subscriptionKey: String,
+        hostAppVersionId: String,
+        hostAppUserAgentInfo: String,
+        isTestMode: Boolean,
+        isPreviewMode: Boolean = isTestMode
+    ) : this(
+        baseUrl = baseUrl,
+        rasAppId = rasAppId,
+        subscriptionKey = subscriptionKey,
+        hostAppVersionId = hostAppVersionId,
+        hostAppUserAgentInfo = hostAppUserAgentInfo,
+        isPreviewMode = isPreviewMode
+    )
 
     init {
         when {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -7,7 +7,7 @@ package com.rakuten.tech.mobile.miniapp
  * @property subscriptionKey Subscription Key for the Platform API.
  * @property hostAppVersionId Version of the host app, used to determine feature compatibility for Mini App.
  * @property hostAppUserAgentInfo User Agent information from Host App.
- * @property isPreviewMode Whether the sdk wants to use the API Endpoints under "Preview" mode.
+ * @property isPreviewMode Whether the host app wants to use the API Endpoints under "Preview" mode.
  */
 data class MiniAppSdkConfig(
     val baseUrl: String,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -28,6 +28,12 @@ class MiniappSdkInitializer : ContentProvider() {
         fun baseUrl(): String
 
         /**
+         * Whether the sdk is running in Preview mode.
+         **/
+        @MetaData(key = "com.rakuten.tech.mobile.miniapp.IsPreviewMode")
+        fun isPreviewMode(): Boolean
+
+        /**
          * Whether the sdk is running in Testing mode.
          **/
         @MetaData(key = "com.rakuten.tech.mobile.miniapp.IsTestMode")
@@ -72,7 +78,7 @@ class MiniappSdkInitializer : ContentProvider() {
                 subscriptionKey = manifestConfig.subscriptionKey(),
                 hostAppVersionId = manifestConfig.hostAppVersion(),
                 hostAppUserAgentInfo = manifestConfig.hostAppUserAgentInfo(),
-                isTestMode = manifestConfig.isTestMode()
+                isTestMode = manifestConfig.isPreviewMode()
             )
         )
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -78,7 +78,7 @@ class MiniappSdkInitializer : ContentProvider() {
                 subscriptionKey = manifestConfig.subscriptionKey(),
                 hostAppVersionId = manifestConfig.hostAppVersion(),
                 hostAppUserAgentInfo = manifestConfig.hostAppUserAgentInfo(),
-                isTestMode = manifestConfig.isPreviewMode()
+                isTestMode = manifestConfig.isPreviewMode() || manifestConfig.isTestMode()
             )
         )
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -80,6 +80,6 @@ internal class RealMiniApp(
         rasAppId = newConfig.rasAppId,
         subscriptionKey = newConfig.subscriptionKey,
         hostAppVersionId = newConfig.hostAppVersionId,
-        isTestMode = newConfig.isTestMode
+        isPreviewMode = newConfig.isPreviewMode
     )
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -1,6 +1,5 @@
 package com.rakuten.tech.mobile.miniapp.api
 
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.google.gson.annotations.SerializedName
 import com.rakuten.tech.mobile.miniapp.MiniAppHasNoPublishedVersionException
@@ -104,7 +103,6 @@ internal class RetrofitRequestExecutor(
         when {
             response.isSuccessful -> {
                 // Body shouldn't be null if request was successful
-                Log.d("AAAA",""+response.body().toString())
                 response.body() ?: throw sdkExceptionForInternalServerError()
             }
             else -> throw exceptionForHttpError<T>(response)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.miniapp.api
 
+import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.google.gson.annotations.SerializedName
 import com.rakuten.tech.mobile.miniapp.MiniAppHasNoPublishedVersionException
@@ -20,7 +21,7 @@ import java.net.UnknownHostException
 
 internal class ApiClient @VisibleForTesting constructor(
     retrofit: Retrofit,
-    private val isTestMode: Boolean,
+    private val isPreviewMode: Boolean,
     private val hostAppVersionId: String,
     private val hostAppId: String,
     private val appInfoApi: AppInfoApi = retrofit.create(AppInfoApi::class.java),
@@ -34,19 +35,19 @@ internal class ApiClient @VisibleForTesting constructor(
         rasAppId: String,
         subscriptionKey: String,
         hostAppVersionId: String,
-        isTestMode: Boolean = false
+        isPreviewMode: Boolean = false
     ) : this(
         retrofit = createRetrofitClient(
             baseUrl = baseUrl,
             rasAppId = rasAppId,
             subscriptionKey = subscriptionKey
         ),
-        isTestMode = isTestMode,
+        isPreviewMode = isPreviewMode,
         hostAppVersionId = hostAppVersionId,
         hostAppId = rasAppId
     )
 
-    private val testPath = if (isTestMode) "test" else ""
+    private val testPath = if (isPreviewMode) "preview" else ""
 
     @Throws(MiniAppSdkException::class)
     suspend fun list(): List<MiniAppInfo> {
@@ -103,6 +104,7 @@ internal class RetrofitRequestExecutor(
         when {
             response.isSuccessful -> {
                 // Body shouldn't be null if request was successful
+                Log.d("AAAA",""+response.body().toString())
                 response.body() ?: throw sdkExceptionForInternalServerError()
             }
             else -> throw exceptionForHttpError<T>(response)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfigSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfigSpec.kt
@@ -9,13 +9,13 @@ class MiniAppSdkConfigSpec {
     fun `the key pattern should match the defined scheme`() {
         val config = MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
-            isTestMode = true,
+            isPreviewMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION,
             hostAppUserAgentInfo = TEST_HA_NAME
         )
-        config.key shouldEqual "${config.baseUrl}-${config.isTestMode}" +
+        config.key shouldEqual "${config.baseUrl}-${config.isPreviewMode}" +
                 "-${config.rasAppId}-${config.subscriptionKey}-${config.hostAppVersionId}"
     }
 
@@ -23,7 +23,7 @@ class MiniAppSdkConfigSpec {
     fun `should throw exception when api url is not https`() {
         MiniAppSdkConfig(
             baseUrl = "http://www.example.com/1",
-            isTestMode = false,
+            isPreviewMode = false,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION,
@@ -35,7 +35,7 @@ class MiniAppSdkConfigSpec {
     fun `should throw exception when api url is blank`() {
         MiniAppSdkConfig(
             baseUrl = " ",
-            isTestMode = true,
+            isPreviewMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION,
@@ -47,7 +47,7 @@ class MiniAppSdkConfigSpec {
     fun `should throw exception when rasAppId is blank`() {
         MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
-            isTestMode = true,
+            isPreviewMode = true,
             rasAppId = " ",
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION,
@@ -59,7 +59,7 @@ class MiniAppSdkConfigSpec {
     fun `should throw exception when subscriptionKey is blank`() {
         MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
-            isTestMode = true,
+            isPreviewMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = " ",
             hostAppVersionId = TEST_HA_ID_VERSION,
@@ -71,7 +71,7 @@ class MiniAppSdkConfigSpec {
     fun `should throw exception when hostAppVersionId is blank`() {
         MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
-            isTestMode = true,
+            isPreviewMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = " ",

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -121,7 +121,7 @@ class RealMiniAppSpec {
         val miniApp = Mockito.spy(realMiniApp)
         val miniAppSdkConfig = MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,
-            isTestMode = true,
+            isPreviewMode = true,
             rasAppId = TEST_HA_ID_APP,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY,
             hostAppVersionId = TEST_HA_ID_VERSION,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
@@ -160,7 +160,7 @@ open class ApiClientSpec {
         downloadApi: DownloadApi = mockDownloadApi
     ) = ApiClient(
         retrofit = retrofit,
-        isTestMode = false,
+        isPreviewMode = false,
         hostAppId = hostAppId,
         hostAppVersionId = hostAppVersionId,
         requestExecutor = requestExecutor,

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -35,7 +35,7 @@ android {
     def appName = "Mini App Sample"
     def stagingManifestPlaceholders = [
             baseUrl                 : property("MINIAPP_SERVER_BASE_URL") ?: "https://www.example.com/",
-            isPreviewMode           : property("IS_PREVIEW_MODE") ?: false,
+            isPreviewMode           : property("IS_PREVIEW_MODE") ?: true,
             hostAppUserAgentInfo    : property("HOST_APP_UA_INFO") ?: "MiniApp Demo App/$project.version",
             hostAppVersion          : property("HOST_APP_VERSION") ?: "test-host-app-version",
             appId                   : property("HOST_APP_ID") ?: "test-host-app-id",
@@ -44,7 +44,7 @@ android {
     ]
     def prodManifestPlaceholders = [
             baseUrl                 : property("MINIAPP_PROD_SERVER_BASE_URL") ?: "https://www.example.com/",
-            isPreviewMode           : property("PROD_IS_PREVIEW_MODE") ?: false,
+            isPreviewMode           : property("PROD_IS_PREVIEW_MODE") ?: true,
             hostAppUserAgentInfo    : property("HOST_APP_PROD_UA_INFO") ?: "MiniApp Demo App/$project.version",
             hostAppVersion          : property("HOST_APP_PROD_VERSION") ?: "test-host-app-version",
             appId                   : property("HOST_APP_PROD_ID") ?: "test-host-app-id",

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -35,7 +35,7 @@ android {
     def appName = "Mini App Sample"
     def stagingManifestPlaceholders = [
             baseUrl                 : property("MINIAPP_SERVER_BASE_URL") ?: "https://www.example.com/",
-            isTestMode              : property("IS_TEST_MODE") ?: false,
+            isPreviewMode           : property("IS_PREVIEW_MODE") ?: false,
             hostAppUserAgentInfo    : property("HOST_APP_UA_INFO") ?: "MiniApp Demo App/$project.version",
             hostAppVersion          : property("HOST_APP_VERSION") ?: "test-host-app-version",
             appId                   : property("HOST_APP_ID") ?: "test-host-app-id",
@@ -44,7 +44,7 @@ android {
     ]
     def prodManifestPlaceholders = [
             baseUrl                 : property("MINIAPP_PROD_SERVER_BASE_URL") ?: "https://www.example.com/",
-            isTestMode              : property("PROD_IS_TEST_MODE") ?: false,
+            isPreviewMode           : property("PROD_IS_PREVIEW_MODE") ?: false,
             hostAppUserAgentInfo    : property("HOST_APP_PROD_UA_INFO") ?: "MiniApp Demo App/$project.version",
             hostAppVersion          : property("HOST_APP_PROD_VERSION") ?: "test-host-app-version",
             appId                   : property("HOST_APP_PROD_ID") ?: "test-host-app-id",

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -61,8 +61,8 @@
             android:name="com.rakuten.tech.mobile.miniapp.BaseUrl"
             android:value="${baseUrl}" />
         <meta-data
-            android:name="com.rakuten.tech.mobile.miniapp.IsTestMode"
-            android:value="${isTestMode}" />
+            android:name="com.rakuten.tech.mobile.miniapp.IsPreviewMode"
+            android:value="${isPreviewMode}" />
         <meta-data
             android:name="com.rakuten.tech.mobile.miniapp.HostAppVersion"
             android:value="${hostAppVersion}" />

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/MiniAppListStore.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/MiniAppListStore.kt
@@ -23,7 +23,7 @@ class MiniAppListStore private constructor(context: Context) {
         Context.MODE_PRIVATE
     )
     private val gson = Gson()
-    private val MINI_APP_LIST = "mini_app_list" + "_is_test_${AppSettings.instance.isTestMode}"
+    private val MINI_APP_LIST = "mini_app_list" + "_is_test_${AppSettings.instance.isPreviewMode}"
 
     fun saveMiniAppList(list: List<MiniAppInfo>): Boolean = when {
         list.isEmpty() -> false

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -117,7 +117,7 @@ private class Settings(context: Context) {
     var isPreviewMode: Boolean?
         get() =
             if (prefs.contains(IS_PREVIEW_MODE))
-                prefs.getBoolean(IS_PREVIEW_MODE, false)
+                prefs.getBoolean(IS_PREVIEW_MODE, true)
             else
                 null
         set(isPreviewMode) = prefs.edit().putBoolean(IS_PREVIEW_MODE, isPreviewMode!!).apply()

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -15,10 +15,10 @@ class AppSettings private constructor(context: Context) {
     private val manifestConfig = AppManifestConfig(context)
     private val cache = Settings(context)
 
-    var isTestMode: Boolean
-        get() = cache.isTestMode ?: manifestConfig.isTestMode()
-        set(isTestMode) {
-            cache.isTestMode = isTestMode
+    var isPreviewMode: Boolean
+        get() = cache.isPreviewMode ?: manifestConfig.isPreviewMode()
+        set(isPreviewMode) {
+            cache.isPreviewMode = isPreviewMode
         }
 
     var appId: String
@@ -94,7 +94,7 @@ class AppSettings private constructor(context: Context) {
             hostAppVersionId = hostAppVersionId,
             // no update for hostAppUserAgentInfo because SDK does not allow changing it at runtime
             hostAppUserAgentInfo = manifestConfig.hostAppUserAgentInfo(),
-            isTestMode = isTestMode
+            isPreviewMode = isPreviewMode
         )
 
     companion object {
@@ -114,13 +114,13 @@ private class Settings(context: Context) {
         Context.MODE_PRIVATE
     )
 
-    var isTestMode: Boolean?
+    var isPreviewMode: Boolean?
         get() =
-            if (prefs.contains(IS_TEST_MODE))
-                prefs.getBoolean(IS_TEST_MODE, false)
+            if (prefs.contains(IS_PREVIEW_MODE))
+                prefs.getBoolean(IS_PREVIEW_MODE, false)
             else
                 null
-        set(isTestMode) = prefs.edit().putBoolean(IS_TEST_MODE, isTestMode!!).apply()
+        set(isPreviewMode) = prefs.edit().putBoolean(IS_PREVIEW_MODE, isPreviewMode!!).apply()
 
     var appId: String?
         get() = prefs.getString(APP_ID, null)
@@ -169,7 +169,7 @@ private class Settings(context: Context) {
         get() = prefs.contains(CONTACT_NAMES)
 
     companion object {
-        private const val IS_TEST_MODE = "is_test_mode"
+        private const val IS_PREVIEW_MODE = "is_preview_mode"
         private const val APP_ID = "app_id"
         private const val SUBSCRIPTION_KEY = "subscription_key"
         private const val UNIQUE_ID = "unique_id"

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
@@ -88,7 +88,7 @@ class SettingsMenuActivity : BaseActivity() {
         updateSettings(
             binding.editAppId.text.toString(),
             binding.editSubscriptionKey.text.toString(),
-            binding.switchTestMode.isChecked
+            binding.switchPreviewMode.isChecked
         )
     }
 
@@ -102,7 +102,7 @@ class SettingsMenuActivity : BaseActivity() {
         binding.textInfo.text = createBuildInfo()
         binding.editAppId.setText(settings.appId)
         binding.editSubscriptionKey.setText(settings.subscriptionKey)
-        binding.switchTestMode.isChecked = settings.isTestMode
+        binding.switchPreviewMode.isChecked = settings.isPreviewMode
 
         binding.editAppId.addTextChangedListener(settingsTextWatcher)
         binding.editSubscriptionKey.addTextChangedListener(settingsTextWatcher)
@@ -146,13 +146,13 @@ class SettingsMenuActivity : BaseActivity() {
         }
     }
 
-    private fun updateSettings(appId: String, subscriptionKey: String, isTestMode: Boolean) {
+    private fun updateSettings(appId: String, subscriptionKey: String, isPreviewMode: Boolean) {
         val appIdHolder = settings.appId
         val subscriptionKeyHolder = settings.subscriptionKey
-        val isTestModeHolder = settings.isTestMode
+        val isPreviewModeHolder = settings.isPreviewMode
         settings.appId = appId
         settings.subscriptionKey = subscriptionKey
-        settings.isTestMode = isTestMode
+        settings.isPreviewMode = isPreviewMode
 
         launch {
             try {
@@ -165,7 +165,7 @@ class SettingsMenuActivity : BaseActivity() {
             } catch (error: MiniAppSdkException) {
                 settings.appId = appIdHolder
                 settings.subscriptionKey = subscriptionKeyHolder
-                settings.isTestMode = isTestModeHolder
+                settings.isPreviewMode = isPreviewModeHolder
                 runOnUiThread {
                     settingsProgressDialog.cancel()
                     showNormalDialog(this@SettingsMenuActivity, error.message.toString())

--- a/testapp/src/main/res/layout/settings_menu_activity.xml
+++ b/testapp/src/main/res/layout/settings_menu_activity.xml
@@ -23,6 +23,24 @@
           android:layout_height="wrap_content"
           android:orientation="vertical">
 
+        <RelativeLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:padding="@dimen/medium_16"
+          android:foreground="?attr/selectableItemBackground">
+
+          <com.google.android.material.switchmaterial.SwitchMaterial
+            android:id="@+id/switchPreviewMode"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/lb_preview_mode" />
+        </RelativeLayout>
+
+        <View
+          android:layout_width="match_parent"
+          android:layout_height="@dimen/horizontal_divider_height"
+          android:background="@color/bg_section" />
+
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/textInfo"
             android:layout_width="match_parent"
@@ -187,14 +205,6 @@
             android:layout_width="match_parent"
             android:layout_height="@dimen/horizontal_divider_height"
             android:background="@color/bg_section" />
-
-        <com.google.android.material.switchmaterial.SwitchMaterial
-            android:id="@+id/switchPreviewMode"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/small_12"
-            android:text="@string/lb_preview_mode"
-            android:visibility="gone" />
 
       </LinearLayout>
 

--- a/testapp/src/main/res/layout/settings_menu_activity.xml
+++ b/testapp/src/main/res/layout/settings_menu_activity.xml
@@ -189,11 +189,11 @@
             android:background="@color/bg_section" />
 
         <com.google.android.material.switchmaterial.SwitchMaterial
-            android:id="@+id/switchTestMode"
+            android:id="@+id/switchPreviewMode"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/small_12"
-            android:text="@string/lb_test_mode"
+            android:text="@string/lb_preview_mode"
             android:visibility="gone" />
 
       </LinearLayout>

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
     <string name="lb_description">Description</string>
     <string name="lb_app_id">App ID</string>
     <string name="lb_app_settings">App Settings</string>
-    <string name="lb_test_mode">Test Mode</string>
+    <string name="lb_preview_mode">Preview Mode</string>
     <string name="lb_ras">RAS</string>
     <string name="lb_user_details">User Details</string>
     <string name="lb_access_token">Access Token</string>


### PR DESCRIPTION
# Description
- Deprecated the "isTestMode" in `MiniAppSdkConfig`
- Added "isPreviewMode" support in `MiniAppSdkConfig`
- Change the API endpoint for "isPreviewMode" from "test" to "preview"
- Add "isPreviewMode" to user guide and changelog.
- Adopt Preview Mode in sample app. "Preview Mode" switch in sample app settings is visible now.

## Links
- MINI-2141

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
