### PR TITLE
make sdk initializer compatible for both isTestMode and isPreviewMode

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -88,7 +88,8 @@ class MiniappSdkInitializer : ContentProvider() {
                 subscriptionKey = manifestConfig.subscriptionKey(),
                 hostAppVersionId = manifestConfig.hostAppVersion(),
                 hostAppUserAgentInfo = manifestConfig.hostAppUserAgentInfo(),
-                isTestMode = manifestConfig.isPreviewMode() || manifestConfig.isTestMode()
+                isPreviewMode = manifestConfig.isPreviewMode(),
+                isTestMode = manifestConfig.isTestMode()
             )
         )
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -7,7 +7,8 @@ import com.google.gson.reflect.TypeToken
 import com.rakuten.tech.mobile.miniapp.AppManifestConfig
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkConfig
 import com.rakuten.tech.mobile.miniapp.js.userinfo.TokenData
-import java.util.*
+import java.util.Date
+import java.util.UUID
 import kotlin.collections.ArrayList
 
 class AppSettings private constructor(context: Context) {


### PR DESCRIPTION
# Description
In the last [preview mode pr](https://github.com/rakutentech/android-miniapp/pull/201), we were not passing value from `MiniappSdkInitializer` for `isPreviewMode` via secondary constructor of `MiniAppSdkConfig`.  So, if HostApp does have both `isPreviewMode` and `isTestMode` in their configuration, then SDK prioritizes `isTestMode` which is unexpected. This PR aims to fix this issue.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
