### PR TITLE
refactor: get preview miniapp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **SDK**
 - **Feature:** Mini App can call media execution play/pause programmatically.
-- **Feature:** Added `MiniApp#create(info: MiniAppInfo, miniAppMessageBridge: MiniAppMessageBridge, miniAppNavigator: MiniAppNavigator? = null)`.
+- **Feature:** Added `MiniApp#create(appInfo: MiniAppInfo, miniAppMessageBridge: MiniAppMessageBridge, miniAppNavigator: MiniAppNavigator? = null)`.
 - **Change:** Added the default implementation for external link handler. Using [custom tab](https://developers.google.com/web/android/custom-tabs).
 - **Change:** `isTestMode` has been deprecated and replaced with `isPreviewMode` to adopt the Preview mode. See [this](miniapp/USERGUIDE.md#2-configure-sdk-settings-in-androidmanifestxml).
 - **Change:** `com.rakuten.tech.mobile.ras.AppId` has been deprecated, use `com.rakuten.tech.mobile.ras.ProjectId` instead. See [this](miniapp/USERGUIDE.md#2-configure-sdk-settings-in-androidmanifestxml).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **SDK**
 - **Feature:** Mini App can call media execution play/pause programmatically.
+- **Feature:** Added `MiniApp#create(info: MiniAppInfo, miniAppMessageBridge: MiniAppMessageBridge, miniAppNavigator: MiniAppNavigator? = null)`.
 - **Change:** Added the default implementation for external link handler. Using [custom tab](https://developers.google.com/web/android/custom-tabs).
 - **Change:** `isTestMode` has been deprecated and replaced with `isPreviewMode` to adopt the Preview mode. See [this](miniapp/USERGUIDE.md#2-configure-sdk-settings-in-androidmanifestxml).
 - **Change:** `com.rakuten.tech.mobile.ras.AppId` has been deprecated, use `com.rakuten.tech.mobile.ras.ProjectId` instead. See [this](miniapp/USERGUIDE.md#2-configure-sdk-settings-in-androidmanifestxml).

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -209,7 +209,7 @@ miniAppMessageBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)
 
 ### #5 Create and display a Mini App
 
-Calling `MiniApp.create` with a Mini App ID object will download the latest version of the Mini App if it has not yet been downloaded. A view will then be returned which will display the Mini App.
+Calling `MiniApp.create` with a Mini App ID or `MiniAppInfo` object will download the latest version of the Mini App if it has not yet been downloaded. A view will then be returned which will display the Mini App.
 
 ```kotlin
 class MiniAppActivity : Activity(), CoroutineScope {
@@ -224,6 +224,7 @@ class MiniAppActivity : Activity(), CoroutineScope {
         launch {
             try {
                 val miniAppDisplay = withContext(Dispatchers.IO) {
+                    // MINI_APP_ID can be replaced with MiniAppInfo.
                     MiniApp.instance().create("MINI_APP_ID", miniAppMessageBridge)
                 }
                 val miniAppView = miniAppDisplay.getMiniAppView(this@MiniAppActivity)

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -209,7 +209,7 @@ miniAppMessageBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)
 
 ### #5 Create and display a Mini App
 
-Calling `MiniApp.create` with a Mini App ID or `MiniAppInfo` object will download the latest version of the Mini App if it has not yet been downloaded. A view will then be returned which will display the Mini App.
+Calling `MiniApp.create` with a Mini App ID object will download the latest version of the Mini App if it has not yet been downloaded. A view will then be returned which will display the Mini App.
 
 ```kotlin
 class MiniAppActivity : Activity(), CoroutineScope {
@@ -224,7 +224,6 @@ class MiniAppActivity : Activity(), CoroutineScope {
         launch {
             try {
                 val miniAppDisplay = withContext(Dispatchers.IO) {
-                    // MINI_APP_ID can be replaced with MiniAppInfo.
                     MiniApp.instance().create("MINI_APP_ID", miniAppMessageBridge)
                 }
                 val miniAppView = miniAppDisplay.getMiniAppView(this@MiniAppActivity)
@@ -246,6 +245,9 @@ class MiniAppActivity : Activity(), CoroutineScope {
 You can handle each exception type differently if you would like different behavior for different cases.
 For example you may wish to display a different error message when the server contains no published versions of a mini app.
 See the full list of exceptions in the [API docs](api/com.rakuten.tech.mobile.miniapp/-mini-app/create.html).
+
+**Note:** Preview Mode
+In preview mode, you can have multiple versions of single miniapp so you can load the specific version with MiniAppInfo object by using `MiniApp.instance().create(MINI_APP_INFO, miniAppMessageBridge)`.
 
 ## Advanced
 
@@ -306,6 +308,7 @@ miniAppNavigator = object : MiniAppNavigator {
 
 - Create mini app display
 Using `MiniApp.instance().create("MINI_APP_ID", miniAppMessageBridge, miniAppNavigator)`.
+In preview mode, using `MiniApp.instance().create(MINI_APP_INFO, miniAppMessageBridge, miniAppNavigator)`.
 
 - Return URL result to mini app view.
 Some mini apps are loaded their services with external url but in the end that external url will

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -50,7 +50,8 @@ abstract class MiniApp internal constructor() {
     ): MiniAppDisplay
 
     /**
-     * Creates a mini app.
+     * Creates a mini app using the mini app ID and version specified in [MiniAppInfo].
+     * This should only be used in "Preview Mode".
      * The mini app is downloaded, saved and provides a [MiniAppDisplay] when successful.
      * @param info metadata of a mini app.
      * @param miniAppMessageBridge the interface for communicating between host app & mini app.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -50,6 +50,25 @@ abstract class MiniApp internal constructor() {
     ): MiniAppDisplay
 
     /**
+     * Creates a mini app.
+     * The mini app is downloaded, saved and provides a [MiniAppDisplay] when successful.
+     * @param info metadata of a mini app.
+     * @param miniAppMessageBridge the interface for communicating between host app & mini app.
+     * @param miniAppNavigator allow host app to handle specific urls such as external link.
+     * @throws [MiniAppNotFoundException] when the specified mini app ID does not exist on the server
+     * @throws [MiniAppHasNoPublishedVersionException] when the specified mini app ID exists on the
+     * server but has no published versions
+     * @throws [MiniAppSdkException] when there is any other issue during fetching,
+     * downloading or creating the view.
+     */
+    @Throws(MiniAppNotFoundException::class, MiniAppHasNoPublishedVersionException::class, MiniAppSdkException::class)
+    abstract suspend fun create(
+        appInfo: MiniAppInfo,
+        miniAppMessageBridge: MiniAppMessageBridge,
+        miniAppNavigator: MiniAppNavigator? = null
+    ): MiniAppDisplay
+
+    /**
      * Fetches meta data information of a mini app.
      * @return [MiniAppInfo] for the provided appId of a mini app
      * @throws [MiniAppNotFoundException] when the specified mini app ID does not exist on the server

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -53,7 +53,7 @@ abstract class MiniApp internal constructor() {
      * Creates a mini app using the mini app ID and version specified in [MiniAppInfo].
      * This should only be used in "Preview Mode".
      * The mini app is downloaded, saved and provides a [MiniAppDisplay] when successful.
-     * @param info metadata of a mini app.
+     * @param appInfo metadata of a mini app.
      * @param miniAppMessageBridge the interface for communicating between host app & mini app.
      * @param miniAppNavigator allow host app to handle specific urls such as external link.
      * @throws [MiniAppNotFoundException] when the specified mini app ID does not exist on the server

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.Job
 import java.io.File
 
-@Suppress("SwallowedException")
+@Suppress("SwallowedException", "TooManyFunctions")
 internal class MiniAppDownloader(
     private val storage: MiniAppStorage,
     private var apiClient: ApiClient,
@@ -28,7 +28,7 @@ internal class MiniAppDownloader(
         val miniAppInfo = apiClient.fetchInfo(appId)
         onGetMiniApp(miniAppInfo)
     } catch (netError: MiniAppNetException) {
-       onNetworkError(miniAppStatus.getDownloadedMiniApp(appId))
+        onNetworkError(miniAppStatus.getDownloadedMiniApp(appId))
     }
 
     suspend fun getMiniApp(miniAppInfo: MiniAppInfo): Pair<String, MiniAppInfo> = try {
@@ -67,21 +67,22 @@ internal class MiniAppDownloader(
         miniAppStatus.saveDownloadedMiniApp(miniAppInfo)
     }
 
-    private fun retrieveDownloadedVersionPath(miniAppInfo: MiniAppInfo): String? {
+    fun retrieveDownloadedVersionPath(miniAppInfo: MiniAppInfo): String? {
         val versionPath = storage.getMiniAppVersionPath(miniAppInfo.id, miniAppInfo.version.versionId)
 
         if (miniAppStatus.isVersionDownloaded(miniAppInfo.id, miniAppInfo.version.versionId, versionPath)) {
-            return if (verifier.verify(miniAppInfo.version.versionId, File(versionPath))) {
+            return if (verifier.verify(miniAppInfo.version.versionId, File(versionPath)))
                 versionPath
-            } else {
-                Log.e(TAG, "Failed to verify the hash of the cached files. " +
-                        "The files will be deleted and the Mini App re-downloaded.")
+            else {
+                Log.e(
+                    TAG, "Failed to verify the hash of the cached files. " +
+                            "The files will be deleted and the Mini App re-downloaded."
+                )
                 storage.removeApp(miniAppInfo.id)
                 miniAppStatus.setVersionDownloaded(miniAppInfo.id, miniAppInfo.version.versionId, false)
                 null
             }
         }
-
         return null
     }
 
@@ -98,7 +99,10 @@ internal class MiniAppDownloader(
     ) = apiClient.fetchFileList(appId, versionId)
 
     @SuppressWarnings("LongMethod")
-    private suspend fun downloadMiniApp(miniAppInfo: MiniAppInfo, manifest: ManifestEntity): String {
+    private suspend fun downloadMiniApp(
+        miniAppInfo: MiniAppInfo,
+        manifest: ManifestEntity
+    ): String {
         val appId = miniAppInfo.id
         val versionId = miniAppInfo.version.versionId
         val baseSavePath = storage.getMiniAppVersionPath(appId, versionId)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -67,7 +67,7 @@ internal class MiniAppDownloader(
         miniAppStatus.saveDownloadedMiniApp(miniAppInfo)
     }
 
-    fun retrieveDownloadedVersionPath(miniAppInfo: MiniAppInfo): String? {
+    private fun retrieveDownloadedVersionPath(miniAppInfo: MiniAppInfo): String? {
         val versionPath = storage.getMiniAppVersionPath(miniAppInfo.id, miniAppInfo.version.versionId)
 
         if (miniAppStatus.isVersionDownloaded(miniAppInfo.id, miniAppInfo.version.versionId, versionPath)) {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.Job
 import java.io.File
 
+@Suppress("SwallowedException")
 internal class MiniAppDownloader(
     private val storage: MiniAppStorage,
     private var apiClient: ApiClient,
@@ -23,29 +24,38 @@ internal class MiniAppDownloader(
     private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : UpdatableApiClient {
 
-    @Suppress("SwallowedException", "LongMethod")
-    suspend fun getMiniApp(appId: String, appInfo: MiniAppInfo?): Pair<String, MiniAppInfo> {
-        try {
-            val miniAppInfo = appInfo ?: apiClient.fetchInfo(appId)
+    suspend fun getMiniApp(appId: String): Pair<String, MiniAppInfo> = try {
+        val miniAppInfo = apiClient.fetchInfo(appId)
+        onGetMiniApp(miniAppInfo)
+    } catch (netError: MiniAppNetException) {
+       onNetworkError(miniAppStatus.getDownloadedMiniApp(appId))
+    }
+
+    suspend fun getMiniApp(miniAppInfo: MiniAppInfo): Pair<String, MiniAppInfo> = try {
+        onGetMiniApp(miniAppInfo)
+    } catch (netError: MiniAppNetException) {
+        onNetworkError(miniAppInfo)
+    }
+
+    private suspend fun onGetMiniApp(miniAppInfo: MiniAppInfo): Pair<String, MiniAppInfo> {
+        val downloadedVersionPath = retrieveDownloadedVersionPath(miniAppInfo)
+
+        return if (downloadedVersionPath == null) {
+            val versionPath = startDownload(miniAppInfo)
+            verifier.storeHashAsync(miniAppInfo.version.versionId, File(versionPath))
+            storeDownloadedMiniApp(miniAppInfo)
+
+            Pair(versionPath, miniAppInfo)
+        } else {
+            Pair(downloadedVersionPath, miniAppInfo)
+        }
+    }
+
+    private fun onNetworkError(miniAppInfo: MiniAppInfo?): Pair<String, MiniAppInfo> {
+        if (miniAppInfo != null) {
             val downloadedVersionPath = retrieveDownloadedVersionPath(miniAppInfo)
-
-            return if (downloadedVersionPath == null) {
-                val versionPath = startDownload(miniAppInfo)
-                verifier.storeHashAsync(miniAppInfo.id, File(versionPath))
-                storeDownloadedMiniApp(miniAppInfo)
-
-                Pair(versionPath, miniAppInfo)
-            } else {
-                Pair(downloadedVersionPath, miniAppInfo)
-            }
-        } catch (netError: MiniAppNetException) {
-            // load local if possible when offline
-            val miniAppInfo = appInfo ?: miniAppStatus.getDownloadedMiniApp(appId)
-            if (miniAppInfo != null) {
-                val downloadedVersionPath = retrieveDownloadedVersionPath(miniAppInfo)
-                if (downloadedVersionPath !== null) {
-                    return Pair(downloadedVersionPath, miniAppInfo)
-                }
+            if (downloadedVersionPath !== null) {
+                return Pair(downloadedVersionPath, miniAppInfo)
             }
         }
         // cannot load miniapp from server
@@ -61,7 +71,7 @@ internal class MiniAppDownloader(
         val versionPath = storage.getMiniAppVersionPath(miniAppInfo.id, miniAppInfo.version.versionId)
 
         if (miniAppStatus.isVersionDownloaded(miniAppInfo.id, miniAppInfo.version.versionId, versionPath)) {
-            return if (verifier.verify(miniAppInfo.id, File(versionPath))) {
+            return if (verifier.verify(miniAppInfo.version.versionId, File(versionPath))) {
                 versionPath
             } else {
                 Log.e(TAG, "Failed to verify the hash of the cached files. " +
@@ -98,8 +108,10 @@ internal class MiniAppDownloader(
                     val response = apiClient.downloadFile(file)
                     storage.saveFile(file, baseSavePath, response.byteStream())
                 }
-                withContext(coroutineDispatcher) {
-                    launch(Job()) { storage.removeOutdatedVersionApp(appId, versionId) }
+                if (!apiClient.isPreviewMode) {
+                    withContext(coroutineDispatcher) {
+                        launch(Job()) { storage.removeVersions(appId, versionId) }
+                    }
                 }
                 return baseSavePath
             }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -24,9 +24,9 @@ internal class MiniAppDownloader(
 ) : UpdatableApiClient {
 
     @Suppress("SwallowedException", "LongMethod")
-    suspend fun getMiniApp(appId: String): Pair<String, MiniAppInfo> {
+    suspend fun getMiniApp(appId: String, appInfo: MiniAppInfo?): Pair<String, MiniAppInfo> {
         try {
-            val miniAppInfo = apiClient.fetchInfo(appId)
+            val miniAppInfo = appInfo ?: apiClient.fetchInfo(appId)
             val downloadedVersionPath = retrieveDownloadedVersionPath(miniAppInfo)
 
             return if (downloadedVersionPath == null) {
@@ -40,7 +40,7 @@ internal class MiniAppDownloader(
             }
         } catch (netError: MiniAppNetException) {
             // load local if possible when offline
-            val miniAppInfo = miniAppStatus.getDownloadedMiniApp(appId)
+            val miniAppInfo = appInfo ?: miniAppStatus.getDownloadedMiniApp(appId)
             if (miniAppInfo != null) {
                 val downloadedVersionPath = retrieveDownloadedVersionPath(miniAppInfo)
                 if (downloadedVersionPath !== null) {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -41,32 +41,28 @@ internal class RealMiniApp(
         appId: String,
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator?
-    ): MiniAppDisplay = executingCreate(
-        miniAppId = appId,
-        miniAppMessageBridge = miniAppMessageBridge,
-        miniAppNavigator = miniAppNavigator
-    )
+    ): MiniAppDisplay = when {
+        appId.isBlank() -> throw sdkExceptionForInvalidArguments()
+        else -> {
+            val (basePath, miniAppInfo) = miniAppDownloader.getMiniApp(appId)
+            displayer.createMiniAppDisplay(
+                basePath,
+                miniAppInfo,
+                miniAppMessageBridge,
+                miniAppNavigator,
+                miniAppCustomPermissionCache
+            )
+        }
+    }
 
     override suspend fun create(
         appInfo: MiniAppInfo,
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator?
-    ): MiniAppDisplay = executingCreate(
-        appInfo = appInfo,
-        miniAppId = appInfo.id,
-        miniAppMessageBridge = miniAppMessageBridge,
-        miniAppNavigator = miniAppNavigator
-    )
-
-    private suspend fun executingCreate(
-        appInfo: MiniAppInfo? = null,
-        miniAppId: String,
-        miniAppMessageBridge: MiniAppMessageBridge,
-        miniAppNavigator: MiniAppNavigator?
     ): MiniAppDisplay = when {
-        miniAppId.isBlank() -> throw sdkExceptionForInvalidArguments()
+        appInfo.id.isBlank() -> throw sdkExceptionForInvalidArguments()
         else -> {
-            val (basePath, miniAppInfo) = miniAppDownloader.getMiniApp(miniAppId, appInfo)
+            val (basePath, miniAppInfo) = miniAppDownloader.getMiniApp(appInfo)
             displayer.createMiniAppDisplay(
                 basePath,
                 miniAppInfo,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -41,16 +41,32 @@ internal class RealMiniApp(
         appId: String,
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator?
-    ): MiniAppDisplay = executingCreate(appId, miniAppMessageBridge, miniAppNavigator)
+    ): MiniAppDisplay = executingCreate(
+        miniAppId = appId,
+        miniAppMessageBridge = miniAppMessageBridge,
+        miniAppNavigator = miniAppNavigator
+    )
+
+    override suspend fun create(
+        appInfo: MiniAppInfo,
+        miniAppMessageBridge: MiniAppMessageBridge,
+        miniAppNavigator: MiniAppNavigator?
+    ): MiniAppDisplay = executingCreate(
+        appInfo = appInfo,
+        miniAppId = appInfo.id,
+        miniAppMessageBridge = miniAppMessageBridge,
+        miniAppNavigator = miniAppNavigator
+    )
 
     private suspend fun executingCreate(
+        appInfo: MiniAppInfo? = null,
         miniAppId: String,
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator?
     ): MiniAppDisplay = when {
         miniAppId.isBlank() -> throw sdkExceptionForInvalidArguments()
         else -> {
-            val (basePath, miniAppInfo) = miniAppDownloader.getMiniApp(miniAppId)
+            val (basePath, miniAppInfo) = miniAppDownloader.getMiniApp(miniAppId, appInfo)
             displayer.createMiniAppDisplay(
                 basePath,
                 miniAppInfo,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -68,6 +68,7 @@ internal class ApiClient @VisibleForTesting constructor(
         }
     }
 
+    @Throws(MiniAppSdkException::class)
     suspend fun fetchFileList(miniAppId: String, versionId: String): ManifestEntity {
         val request = manifestApi.fetchFileListFromManifest(
             hostAppId = hostProjectId,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -20,7 +20,7 @@ import java.net.UnknownHostException
 
 internal class ApiClient @VisibleForTesting constructor(
     retrofit: Retrofit,
-    private val isPreviewMode: Boolean,
+    internal val isPreviewMode: Boolean,
     private val hostProjectId: String,
     private val appInfoApi: AppInfoApi = retrofit.create(AppInfoApi::class.java),
     private val downloadApi: DownloadApi = retrofit.create(DownloadApi::class.java),

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorage.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorage.kt
@@ -58,17 +58,12 @@ internal class MiniAppStorage(
         deleteDirectory(parentFile)
     }
 
-    @Suppress("LongMethod")
-    suspend fun removeOutdatedVersionApp(
-        appId: String,
-        latestVersionId: String,
-        appPath: String = getMiniAppPath(appId)
-    ) {
+    suspend fun removeVersions(appId: String, exclusiveVersionId: String, appPath: String = getMiniAppPath(appId)) {
         val parentFile = File(appPath)
         if (parentFile.isDirectory && parentFile.listFiles() != null) {
             flow {
                 parentFile.listFiles()?.forEach { file ->
-                    if (!file.absolutePath.endsWith(latestVersionId))
+                    if (!file.absolutePath.endsWith(exclusiveVersionId))
                         emit(file)
                 }
             }.collect { file -> deleteDirectory(file) }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
@@ -262,21 +262,19 @@ class MiniAppDownloaderSpec {
         }
 
     @Test(expected = MiniAppSdkException::class)
-    fun `should throw exception when cannot get miniapp`() =
-        runBlockingTest {
-            When calling miniAppStatus.isVersionDownloaded(
-                TEST_ID_MINIAPP,
-                TEST_ID_MINIAPP_VERSION,
-                TEST_BASE_PATH
-            ) itReturns false
-            When calling storage.getMiniAppVersionPath(
-                TEST_ID_MINIAPP,
-                TEST_ID_MINIAPP_VERSION
-            ) itReturns TEST_BASE_PATH
-            When calling apiClient.fetchInfo(TEST_ID_MINIAPP) doThrow MiniAppNetException(TEST_ERROR_MSG)
+    fun `should throw exception when cannot get miniapp by id from server`() = runBlockingTest {
+        When calling apiClient.fetchInfo(TEST_ID_MINIAPP) doThrow MiniAppNetException(TEST_ERROR_MSG)
 
-            downloader.getMiniApp(TEST_ID_MINIAPP)
-        }
+        downloader.getMiniApp(TEST_ID_MINIAPP)
+    }
+
+    @Test(expected = MiniAppSdkException::class)
+    fun `should throw exception when cannot get miniapp by MiniAppInfo from server`() = runBlockingTest {
+        When calling apiClient.fetchFileList(TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION) doThrow
+                MiniAppNetException(TEST_ERROR_MSG)
+
+        downloader.getMiniApp(testMiniApp)
+    }
 
     @Test
     fun `getDownloadedMiniAppList should get values from miniAppStatus`() {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
@@ -131,7 +131,7 @@ class MiniAppDownloaderSpec {
         }
 
     @Test
-    fun `should execute old file deletion after downloading new version`() {
+    fun `should execute old file deletion after downloading new version when in host mode`() {
         runBlockingTest {
             When calling storage.getMiniAppVersionPath(
                 TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION) itReturns TEST_BASE_PATH
@@ -144,6 +144,9 @@ class MiniAppDownloaderSpec {
             setupValidManifestResponse(downloader, apiClient)
             setupLatestMiniAppInfoResponse(apiClient, TEST_ID_MINIAPP, TEST_ID_MINIAPP_VERSION)
 
+            downloader.getMiniApp(TEST_ID_MINIAPP)
+
+            When calling apiClient.isPreviewMode itReturns true
             downloader.getMiniApp(TEST_ID_MINIAPP)
 
             verify(storage, times(1)).removeVersions(
@@ -240,6 +243,7 @@ class MiniAppDownloaderSpec {
             When calling apiClient.fetchInfo(TEST_ID_MINIAPP) doThrow MiniAppNetException(TEST_ERROR_MSG)
 
             downloader.getMiniApp(TEST_ID_MINIAPP).first shouldBe TEST_BASE_PATH
+            downloader.getMiniApp(testMiniApp).first shouldBe TEST_BASE_PATH
         }
 
     @Test(expected = MiniAppSdkException::class)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
@@ -146,7 +146,7 @@ class MiniAppDownloaderSpec {
 
             downloader.getMiniApp(TEST_ID_MINIAPP)
 
-            verify(storage, times(1)).removeOutdatedVersionApp(
+            verify(storage, times(1)).removeVersions(
                 TEST_ID_MINIAPP,
                 TEST_ID_MINIAPP_VERSION
             )
@@ -166,7 +166,7 @@ class MiniAppDownloaderSpec {
 
             downloader.getMiniApp(TEST_ID_MINIAPP)
 
-            verify(storage, times(1)).removeOutdatedVersionApp(
+            verify(storage, times(1)).removeVersions(
                 TEST_ID_MINIAPP,
                 TEST_ID_MINIAPP_VERSION
             )

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -64,6 +64,12 @@ class RealMiniAppSpec {
         realMiniApp.create(" ", miniAppMessageBridge)
     }
 
+    @Test(expected = MiniAppSdkException::class)
+    fun `should throw exception when id of MiniAppInfo is blank`() = runBlockingTest {
+        val testMiniAppInfo = TEST_MA.copy(id = "")
+        realMiniApp.create(testMiniAppInfo, miniAppMessageBridge)
+    }
+
     @Test
     fun `should invoke from MiniAppDownloader and Displayer when calling create miniapp`() =
         runBlockingTest {
@@ -81,10 +87,10 @@ class RealMiniAppSpec {
     fun `should create mini app display with correct passing external navigator`() =
         runBlockingTest {
             val getMiniAppResult = Pair(TEST_BASE_PATH, TEST_MA)
-            When calling miniAppDownloader.getMiniApp(TEST_MA_ID) itReturns getMiniAppResult
-            realMiniApp.create(TEST_MA_ID, miniAppMessageBridge, miniAppNavigator)
+            When calling miniAppDownloader.getMiniApp(TEST_MA) itReturns getMiniAppResult
+            realMiniApp.create(TEST_MA, miniAppMessageBridge, miniAppNavigator)
 
-            verify(miniAppDownloader, times(1)).getMiniApp(TEST_MA_ID)
+            verify(miniAppDownloader, times(1)).getMiniApp(TEST_MA)
             verify(displayer, times(1))
                 .createMiniAppDisplay(getMiniAppResult.first, getMiniAppResult.second,
                     miniAppMessageBridge, miniAppNavigator, miniAppCustomPermissionCache)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
@@ -34,7 +34,6 @@ internal const val VALID_FILE_URL_PATH =
         .plus("ver-6181004c-a6aa-4eda-b145-a5ff73fc4ad0/a/b/index.html")
 internal const val INVALID_FILE_URL_PATH = "https://78d85043-d04f-486a-8212-bf2601cb63a2/js"
 
-internal const val TEST_CUSTOM_PERMISSION_RESULT = "{\"rakuten.miniapp.user.USER_NAME\":\"DENIED\"}"
 internal const val TEST_USER_NAME = "test_user_name"
 internal const val TEST_PROFILE_PHOTO = "data:image/png;base64,encodedValue"
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageSpec.kt
@@ -62,7 +62,7 @@ class MiniAppStorageSpec {
         val oldFile2 = tempFolder.newFile()
         val latestPackage = tempFolder.newFolder(TEST_ID_MINIAPP_VERSION)
 
-        miniAppStorage.removeOutdatedVersionApp(
+        miniAppStorage.removeVersions(
             TEST_ID_MINIAPP,
             TEST_ID_MINIAPP_VERSION,
             tempFolder.root.path)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -107,20 +107,13 @@ class MiniAppDisplayActivity : BaseActivity() {
                 }
             }
 
-            if (appInfo == null)
-                viewModel.obtainMiniAppDisplay(
-                    this@MiniAppDisplayActivity,
-                    appId,
-                    miniAppMessageBridge,
-                    miniAppNavigator
-                )
-            else
-                viewModel.obtainMiniAppDisplay(
-                    this@MiniAppDisplayActivity,
-                    appId,
-                    miniAppMessageBridge,
-                    miniAppNavigator
-                )
+            viewModel.obtainMiniAppDisplay(
+                this@MiniAppDisplayActivity,
+                appInfo,
+                appId,
+                miniAppMessageBridge,
+                miniAppNavigator
+            )
         }
     }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -31,7 +31,6 @@ import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
 
 class MiniAppDisplayActivity : BaseActivity() {
 
-    private lateinit var appId: String
     private lateinit var miniAppMessageBridge: MiniAppMessageBridge
     private lateinit var miniAppNavigator: MiniAppNavigator
     private var miniappPermissionCallback: (isGranted: Boolean) -> Unit = {}
@@ -72,9 +71,8 @@ class MiniAppDisplayActivity : BaseActivity() {
         showBackIcon()
 
         if (intent.hasExtra(miniAppTag) || intent.hasExtra(appIdTag)) {
-            appId = intent.getStringExtra(appIdTag) ?: ""
-            if (appId.isEmpty())
-                appId = intent.getParcelableExtra<MiniAppInfo>(miniAppTag)!!.id
+            val appId = intent.getStringExtra(appIdTag) ?: intent.getParcelableExtra<MiniAppInfo>(miniAppTag)!!.id
+            val appInfo = intent.getParcelableExtra<MiniAppInfo>(miniAppTag)
 
             binding = DataBindingUtil.setContentView(this, R.layout.mini_app_display_activity)
 
@@ -109,12 +107,20 @@ class MiniAppDisplayActivity : BaseActivity() {
                 }
             }
 
-            viewModel.obtainMiniAppDisplay(
-                this@MiniAppDisplayActivity,
-                appId,
-                miniAppMessageBridge,
-                miniAppNavigator
-            )
+            if (appInfo == null)
+                viewModel.obtainMiniAppDisplay(
+                    this@MiniAppDisplayActivity,
+                    appId,
+                    miniAppMessageBridge,
+                    miniAppNavigator
+                )
+            else
+                viewModel.obtainMiniAppDisplay(
+                    this@MiniAppDisplayActivity,
+                    appId,
+                    miniAppMessageBridge,
+                    miniAppNavigator
+                )
         }
     }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
@@ -36,13 +36,17 @@ class MiniAppDisplayViewModel constructor(
 
     fun obtainMiniAppDisplay(
         context: Context,
+        appInfo: MiniAppInfo?,
         appId: String,
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator
     ) = viewModelScope.launch(Dispatchers.IO) {
         try {
             _isLoading.postValue(true)
-            miniAppDisplay = miniapp.create(appId, miniAppMessageBridge, miniAppNavigator)
+            miniAppDisplay = if (appInfo != null)
+                miniapp.create(appInfo, miniAppMessageBridge, miniAppNavigator)
+            else
+                miniapp.create(appId, miniAppMessageBridge, miniAppNavigator)
             hostLifeCycle?.addObserver(miniAppDisplay)
             _miniAppView.postValue(miniAppDisplay.getMiniAppView(context))
         } catch (e: MiniAppSdkException) {


### PR DESCRIPTION
# Description
Currently cannot load all versions of miniapp in preview mode. The cause is we made get miniapp by MiniAppInfo deprecated. This PR:

- Fix getting miniapp in preview
- Update miniapp cache in preview mode
- Change security validation of hashcheck. Using miniapp version id.

## Links
This fix is required to move MINI-235 into QA.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
