### PR TITLE
fix: miniapp item display with different version names

### DIFF
--- a/testapp/src/main/res/layout/item_list_miniapp.xml
+++ b/testapp/src/main/res/layout/item_list_miniapp.xml
@@ -48,7 +48,7 @@
             app:layout_constraintTop_toTopOf="parent">
 
             <TextView
-                android:id="@+id/tv_lb_version"
+                android:id="@+id/tv_app_name"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/small_8"
@@ -56,16 +56,31 @@
                 android:gravity="start"
                 android:textColor="@android:color/black"
                 android:textSize="@dimen/text_medium_14"
-                android:text="@{@string/lb_version + `: `}"
+                android:text="@{miniapp.displayName}"
+                android:singleLine="true"
+                android:ellipsize="end"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
+                tools:text="Name of the Mini App" />
+
+            <TextView
+                android:id="@+id/tv_lb_version"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:alpha="0.6"
+                android:gravity="start"
+                android:textColor="@android:color/black"
+                android:textSize="@dimen/text_medium_14"
+                android:text="@{@string/lb_version + `: `}"
+                app:layout_constraintTop_toBottomOf="@+id/tv_app_name"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 tools:text="Version: " />
 
             <TextView
                 android:id="@+id/tv_version"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/small_8"
                 android:alpha="0.6"
                 android:textColor="@android:color/black"
                 android:textSize="@dimen/text_medium_14"
@@ -75,7 +90,7 @@
                 android:marqueeRepeatLimit="marquee_forever"
                 app:layout_constraintStart_toEndOf="@id/tv_lb_version"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintTop_toTopOf="@id/tv_lb_version"
                 tools:text="9ab14a68-e8f9-4216-a6df-2c3b06f3c7f7" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/testapp/src/main/res/layout/item_list_miniapp.xml
+++ b/testapp/src/main/res/layout/item_list_miniapp.xml
@@ -60,6 +60,7 @@
                 android:singleLine="true"
                 android:ellipsize="end"
                 app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 tools:text="Name of the Mini App" />
 

--- a/testapp/src/main/res/layout/item_section_miniapp.xml
+++ b/testapp/src/main/res/layout/item_section_miniapp.xml
@@ -18,7 +18,7 @@
         android:layout_height="wrap_content">
 
         <TextView
-            android:id="@+id/tv_app_name"
+            android:id="@+id/tv_app_id"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:ellipsize="end"
@@ -27,9 +27,10 @@
             android:paddingStart="@dimen/medium_16"
             android:paddingEnd="@dimen/medium_16"
             android:singleLine="true"
-            android:text="@{miniapp.displayName}"
+            android:text="@{miniapp.id}"
             android:textColor="@android:color/black"
             android:textSize="@dimen/text_medium_14"
+            android:marqueeRepeatLimit="marquee_forever"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
# Description
Display app id in header and add version name in each item.

## Links
MINI-2174

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
