### PR TITLE
refactor error messages with project id when `MiniAppNotFoundException` exception

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -36,7 +36,7 @@ abstract class MiniApp internal constructor() {
      * @param appId mini app id.
      * @param miniAppMessageBridge the interface for communicating between host app & mini app.
      * @param miniAppNavigator allow host app to handle specific urls such as external link.
-     * @throws [MiniAppNotFoundException] when the specified mini app ID does not exist on the server
+     * @throws [MiniAppNotFoundException] when the specified project ID does not have any mini app exist on the server.
      * @throws [MiniAppHasNoPublishedVersionException] when the specified mini app ID exists on the
      * server but has no published versions
      * @throws [MiniAppSdkException] when there is any other issue during fetching,
@@ -56,7 +56,7 @@ abstract class MiniApp internal constructor() {
      * @param appInfo metadata of a mini app.
      * @param miniAppMessageBridge the interface for communicating between host app & mini app.
      * @param miniAppNavigator allow host app to handle specific urls such as external link.
-     * @throws [MiniAppNotFoundException] when the specified mini app ID does not exist on the server
+     * @throws [MiniAppNotFoundException] when the specified project ID does not have any mini app exist on the server.
      * @throws [MiniAppHasNoPublishedVersionException] when the specified mini app ID exists on the
      * server but has no published versions
      * @throws [MiniAppSdkException] when there is any other issue during fetching,
@@ -72,7 +72,7 @@ abstract class MiniApp internal constructor() {
     /**
      * Fetches meta data information of a mini app.
      * @return [MiniAppInfo] for the provided appId of a mini app
-     * @throws [MiniAppNotFoundException] when the specified mini app ID does not exist on the server
+     * @throws [MiniAppNotFoundException] when the specified project ID does not have any mini app exist on the server.
      * @throws [MiniAppHasNoPublishedVersionException] when the specified mini app ID exists on the
      * server but has no published versions
      * @throws [MiniAppSdkException] when fetching fails from the BE server for any other reason.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
@@ -22,11 +22,11 @@ class MiniAppHasNoPublishedVersionException(appId: String) :
     MiniAppSdkException("Server returned no published version info for the provided Mini App Id: $appId")
 
 /**
- * Exception which is thrown when the provided mini app ID
- * does not exist on the server.
+ * Exception which is thrown when the provided project ID
+ * does not have any mini app exist on the server.
  */
 class MiniAppNotFoundException(serverMessage: String) :
-    MiniAppSdkException("$serverMessage: Server returned no mini app for the provided Mini App ID.")
+    MiniAppSdkException("$serverMessage: Server returned no mini app for the provided project ID.")
 
 /**
  * Exception which is thrown when HostApp doesn't implement requestCustomPermissions interface.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -111,7 +111,7 @@ internal class RetrofitRequestExecutor(
         }
     }
 
-    @Throws(MiniAppSdkException::class)
+    @Throws(MiniAppSdkException::class, MiniAppNotFoundException::class)
     @Suppress("MagicNumber", "ThrowsCount")
     private fun <T> exceptionForHttpError(response: Response<T>): MiniAppSdkException {
         // Error body shouldn't be null if request wasn't successful

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
@@ -55,7 +55,7 @@ class MiniAppDisplayViewModel constructor(
                 is MiniAppHasNoPublishedVersionException ->
                     _errorData.postValue("No published versions for the provided Mini App ID.")
                 is MiniAppNotFoundException ->
-                    _errorData.postValue("No Mini App found for the provided Mini App ID.")
+                    _errorData.postValue("No Mini App found for the provided Project ID.")
                 else -> _errorData.postValue(e.message)
             }
         } finally {


### PR DESCRIPTION
# Description
Refactor messages with specifying project id when `MiniAppNotFoundException` exception. 

## Links
MINI-2175

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
