### PR TITLE
feat: add an option to load mini app by url (MINI-1981)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ $ ./gradlew assembleRelease
 ## How to Test the Sample App
 
 We currently don't provide an API for public use, so you must provide your own API.
+Alternatively you can launch your MiniApp on a local sever and then use 'Load by URL' option in the Sample App.
 
 ## Writing and generating documentation
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -70,6 +70,23 @@ abstract class MiniApp internal constructor() {
     ): MiniAppDisplay
 
     /**
+     * Creates a mini app using provided url.
+     * Mini app is NOT downloaded and cached in local, its content are read directly from the url.
+     * This should only be used for previewing a mini app from a local server.
+     * @param appUrl a HTTP url containing Mini App content.
+     * @param miniAppMessageBridge the interface for communicating between host app & mini app.
+     * @param miniAppNavigator allow host app to handle specific urls such as external link.
+     * @throws [MiniAppNotFoundException] when the specified Mini App URL cannot be reached.
+     * @throws [MiniAppSdkException] when there is any other issue during loading or creating the view.
+     */
+    @Throws(MiniAppNotFoundException::class, MiniAppSdkException::class)
+    abstract suspend fun createWithUrl(
+        appUrl: String,
+        miniAppMessageBridge: MiniAppMessageBridge,
+        miniAppNavigator: MiniAppNavigator? = null
+    ): MiniAppDisplay
+
+    /**
      * Fetches meta data information of a mini app.
      * @return [MiniAppInfo] for the provided appId of a mini app
      * @throws [MiniAppNotFoundException] when the specified project ID does not have any mini app exist on the server.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppInfo.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppInfo.kt
@@ -18,7 +18,11 @@ data class MiniAppInfo(
     @SerializedName("displayName") val displayName: String,
     @SerializedName("icon") val icon: String,
     @SerializedName("version") val version: Version
-) : Parcelable
+) : Parcelable {
+    companion object {
+        internal fun empty() = MiniAppInfo("", "", "", Version("", ""))
+    }
+}
 
 /**
  * This represents a version entity of a Mini App.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppScheme.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppScheme.kt
@@ -4,13 +4,36 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.net.toUri
 
-internal class MiniAppScheme(miniAppId: String) {
+internal class MiniAppScheme private constructor(miniAppId: String) {
 
     val miniAppDomain = "mscheme.$miniAppId"
     val miniAppCustomScheme = "$miniAppDomain://"
     val miniAppCustomDomain = "https://$miniAppDomain/"
+    var appUrl: String? = null
+        private set
 
-    fun isMiniAppUrl(url: String) = url.startsWith(miniAppCustomDomain) || url.startsWith(miniAppCustomScheme)
+    companion object {
+        fun schemeWithAppId(miniAppId: String) = MiniAppScheme(miniAppId)
+
+        fun schemeWithCustomUrl(appUrl: String): MiniAppScheme {
+            val scheme = MiniAppScheme("")
+            scheme.appUrl = appUrl
+            return scheme
+        }
+    }
+
+    fun isMiniAppUrl(url: String): Boolean {
+        return if (appUrl?.isNotEmpty() == true) {
+            val miniAppUri = appUrl!!.toUri()
+            if (miniAppUri.host?.isNotEmpty() == true) {
+                miniAppUri.host.equals(url.toUri().host)
+            } else {
+                false
+            }
+        } else {
+            url.startsWith(miniAppCustomDomain) || url.startsWith(miniAppCustomScheme)
+        }
+    }
 
     internal fun openPhoneDialer(context: Context, url: String) = Intent(Intent.ACTION_DIAL).let {
         it.data = url.toUri()

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -4,10 +4,10 @@ import androidx.annotation.VisibleForTesting
 import com.rakuten.tech.mobile.miniapp.api.ApiClient
 import com.rakuten.tech.mobile.miniapp.api.ApiClientRepository
 import com.rakuten.tech.mobile.miniapp.display.Displayer
-import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermission
-import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermission
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 
 internal class RealMiniApp(
     private val apiClientRepository: ApiClientRepository,
@@ -66,6 +66,23 @@ internal class RealMiniApp(
             displayer.createMiniAppDisplay(
                 basePath,
                 miniAppInfo,
+                miniAppMessageBridge,
+                miniAppNavigator,
+                miniAppCustomPermissionCache
+            )
+        }
+    }
+
+    override suspend fun createWithUrl(
+        appUrl: String,
+        miniAppMessageBridge: MiniAppMessageBridge,
+        miniAppNavigator: MiniAppNavigator?
+    ): MiniAppDisplay = when {
+        appUrl.isBlank() -> throw sdkExceptionForInvalidArguments()
+        else -> {
+            miniAppDownloader.validateHttpAppUrl(appUrl)
+            displayer.createMiniAppDisplay(
+                appUrl,
                 miniAppMessageBridge,
                 miniAppNavigator,
                 miniAppCustomPermissionCache

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
@@ -24,4 +24,18 @@ internal class Displayer(private val context: Context, private val hostAppUserAg
         hostAppUserAgentInfo = hostAppUserAgentInfo,
         miniAppCustomPermissionCache = miniAppCustomPermissionCache
     )
+
+    fun createMiniAppDisplay(
+        appUrl: String,
+        miniAppMessageBridge: MiniAppMessageBridge,
+        miniAppNavigator: MiniAppNavigator?,
+        miniAppCustomPermissionCache: MiniAppCustomPermissionCache
+    ): MiniAppDisplay = RealMiniAppDisplay(
+        context = context,
+        appUrl = appUrl,
+        miniAppMessageBridge = miniAppMessageBridge,
+        miniAppNavigator = miniAppNavigator,
+        hostAppUserAgentInfo = hostAppUserAgentInfo,
+        miniAppCustomPermissionCache = miniAppCustomPermissionCache
+    )
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
@@ -1,0 +1,45 @@
+package com.rakuten.tech.mobile.miniapp.display
+
+import android.content.Context
+import com.rakuten.tech.mobile.miniapp.MiniAppInfo
+import com.rakuten.tech.mobile.miniapp.MiniAppScheme
+import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
+import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
+import java.util.*
+
+internal class MiniAppHttpWebView(
+    context: Context,
+    miniAppTitle: String,
+    val appUrl: String,
+    miniAppMessageBridge: MiniAppMessageBridge,
+    miniAppNavigator: MiniAppNavigator?,
+    hostAppUserAgentInfo: String,
+    miniAppWebChromeClient: MiniAppWebChromeClient = MiniAppWebChromeClient(context, miniAppTitle),
+    miniAppCustomPermissionCache: MiniAppCustomPermissionCache
+) : MiniAppWebView(
+    context,
+    "",
+    MiniAppInfo.empty(),
+    miniAppMessageBridge,
+    miniAppNavigator,
+    hostAppUserAgentInfo,
+    miniAppWebChromeClient,
+    miniAppCustomPermissionCache
+) {
+    init {
+        miniAppScheme = MiniAppScheme.schemeWithCustomUrl(appUrl)
+        miniAppId = UUID.randomUUID().toString() // some id is needed to handle custom permissions
+        commonInit()
+    }
+
+    override fun getMiniAppWebViewClient(): MiniAppWebViewClient = MiniAppWebViewClient(
+        context,
+        null,
+        miniAppNavigator!!,
+        externalResultHandler,
+        miniAppScheme
+    )
+
+    override fun getLoadUrl(): String = appUrl
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
@@ -1,12 +1,13 @@
 package com.rakuten.tech.mobile.miniapp.display
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.MiniAppScheme
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
-import java.util.*
+import java.util.UUID
 
 internal class MiniAppHttpWebView(
     context: Context,
@@ -42,4 +43,14 @@ internal class MiniAppHttpWebView(
     )
 
     override fun getLoadUrl(): String = appUrl
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        miniAppCustomPermissionCache.removeId(miniAppId)
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun callOnDetached() {
+        onDetachedFromWindow()
+    }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
@@ -11,13 +11,12 @@ import android.webkit.WebChromeClient
 import android.webkit.WebView
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
-import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.js.DialogType
 import java.io.BufferedReader
 
 internal class MiniAppWebChromeClient(
-    val context: Context,
-    val miniAppInfo: MiniAppInfo
+    private val context: Context,
+    private val miniAppTitle: String
 ) : WebChromeClient() {
 
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
@@ -53,7 +52,7 @@ internal class MiniAppWebChromeClient(
             message = message,
             result = result as JsResult,
             dialogType = DialogType.ALERT,
-            miniAppInfo = miniAppInfo
+            miniAppTitle = miniAppTitle
         )
 
     override fun onJsConfirm(
@@ -67,7 +66,7 @@ internal class MiniAppWebChromeClient(
             message = message,
             result = result as JsResult,
             dialogType = DialogType.CONFIRM,
-            miniAppInfo = miniAppInfo
+            miniAppTitle = miniAppTitle
         )
 
     override fun onJsPrompt(
@@ -82,7 +81,7 @@ internal class MiniAppWebChromeClient(
         defaultValue = defaultValue,
         result = result,
         dialogType = DialogType.PROMPT,
-        miniAppInfo = miniAppInfo
+        miniAppTitle = miniAppTitle
     )
 
     @VisibleForTesting

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
@@ -14,14 +14,14 @@ import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 
 internal class MiniAppWebViewClient(
     private val context: Context,
-    @VisibleForTesting internal val loader: WebViewAssetLoader,
+    @VisibleForTesting internal val loader: WebViewAssetLoader?,
     private val miniAppNavigator: MiniAppNavigator,
     private val externalResultHandler: ExternalResultHandler,
     private val miniAppScheme: MiniAppScheme
 ) : WebViewClient() {
 
     override fun shouldInterceptRequest(view: WebView, request: WebResourceRequest): WebResourceResponse? {
-        val response = loader.shouldInterceptRequest(request.url)
+        val response = loader?.shouldInterceptRequest(request.url)
         interceptMimeType(response, request)
         return response
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
@@ -29,8 +29,29 @@ internal class RealMiniAppDisplay(
     val miniAppCustomPermissionCache: MiniAppCustomPermissionCache
 ) : MiniAppDisplay {
 
+    var appUrl: String? = null
+        private set
     @VisibleForTesting
     internal var miniAppWebView: MiniAppWebView? = null
+
+    constructor(
+        context: Context,
+        appUrl: String,
+        miniAppMessageBridge: MiniAppMessageBridge,
+        miniAppNavigator: MiniAppNavigator?,
+        hostAppUserAgentInfo: String,
+        miniAppCustomPermissionCache: MiniAppCustomPermissionCache
+    ) : this(
+        context,
+        "",
+        MiniAppInfo.empty(),
+        miniAppMessageBridge,
+        miniAppNavigator,
+        hostAppUserAgentInfo,
+        miniAppCustomPermissionCache
+    ) {
+        this.appUrl = appUrl
+    }
 
     // Returns the view only when context type is legit else throw back error
     // Activity context needs to be used here, to prevent issues, where some native elements are
@@ -68,17 +89,31 @@ internal class RealMiniAppDisplay(
         }
     } else false
 
+    @Suppress("LongMethod")
     private suspend fun provideMiniAppWebView(context: Context): MiniAppWebView =
         miniAppWebView ?: withContext(Dispatchers.Main) {
-            miniAppWebView = MiniAppWebView(
-                context = context,
-                basePath = basePath,
-                miniAppInfo = miniAppInfo,
-                miniAppMessageBridge = miniAppMessageBridge,
-                miniAppNavigator = miniAppNavigator,
-                hostAppUserAgentInfo = hostAppUserAgentInfo,
-                miniAppCustomPermissionCache = miniAppCustomPermissionCache
-            )
+            if (appUrl != null) {
+                miniAppWebView = MiniAppHttpWebView(
+                    context = context,
+                    miniAppTitle = "Mini app",
+                    appUrl = appUrl!!,
+                    miniAppMessageBridge = miniAppMessageBridge,
+                    miniAppNavigator = miniAppNavigator,
+                    hostAppUserAgentInfo = hostAppUserAgentInfo,
+                    miniAppCustomPermissionCache = miniAppCustomPermissionCache
+                )
+            } else {
+                miniAppWebView = MiniAppWebView(
+                    context = context,
+                    basePath = basePath,
+                    miniAppInfo = miniAppInfo,
+                    miniAppMessageBridge = miniAppMessageBridge,
+                    miniAppNavigator = miniAppNavigator,
+                    hostAppUserAgentInfo = hostAppUserAgentInfo,
+                    miniAppCustomPermissionCache = miniAppCustomPermissionCache
+                )
+            }
+
             miniAppWebView!!
         }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/WebViewDialog.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/WebViewDialog.kt
@@ -7,7 +7,6 @@ import android.webkit.JsPromptResult
 import android.webkit.JsResult
 import android.widget.EditText
 import android.widget.FrameLayout
-import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.js.DialogType
 
 @Suppress("LongParameterList", "LongMethod")
@@ -17,10 +16,10 @@ internal fun onShowDialog(
     defaultValue: String? = "",
     result: JsResult?,
     dialogType: DialogType,
-    miniAppInfo: MiniAppInfo
+    miniAppTitle: String
 ): Boolean {
     val dialogBuilder = AlertDialog.Builder(context)
-        .setTitle(miniAppInfo.displayName)
+        .setTitle(miniAppTitle)
         .setMessage(message)
 
     if (dialogType != DialogType.ALERT)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -7,7 +7,6 @@ import androidx.annotation.VisibleForTesting
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.rakuten.tech.mobile.miniapp.CustomPermissionsNotImplementedException
-import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.ads.AdMobDisplayer
 import com.rakuten.tech.mobile.miniapp.ads.MiniAppAdDisplayer
 import com.rakuten.tech.mobile.miniapp.display.WebViewListener
@@ -28,7 +27,7 @@ abstract class MiniAppMessageBridge {
     private lateinit var customPermissionCache: MiniAppCustomPermissionCache
     private lateinit var customPermissionBridgeDispatcher: CustomPermissionBridgeDispatcher
     private lateinit var customPermissionWindow: MiniAppCustomPermissionWindow
-    private lateinit var miniAppInfo: MiniAppInfo
+    private lateinit var miniAppId: String
     private lateinit var activity: Activity
     private lateinit var userInfoBridgeDispatcher: UserInfoBridgeDispatcher
     private val adBridgeDispatcher = AdBridgeDispatcher()
@@ -40,16 +39,16 @@ abstract class MiniAppMessageBridge {
         activity: Activity,
         webViewListener: WebViewListener,
         customPermissionCache: MiniAppCustomPermissionCache,
-        miniAppInfo: MiniAppInfo
+        miniAppId: String
     ) {
         this.activity = activity
-        this.miniAppInfo = miniAppInfo
+        this.miniAppId = miniAppId
         this.bridgeExecutor = createBridgeExecutor(webViewListener)
         this.customPermissionCache = customPermissionCache
         this.customPermissionBridgeDispatcher = CustomPermissionBridgeDispatcher(
             bridgeExecutor,
             customPermissionCache,
-            miniAppInfo.id
+            miniAppId
         )
         this.customPermissionWindow = MiniAppCustomPermissionWindow(
             activity,
@@ -60,7 +59,7 @@ abstract class MiniAppMessageBridge {
         adBridgeDispatcher.setBridgeExecutor(bridgeExecutor)
 
         if (this::userInfoBridgeDispatcher.isInitialized)
-            this.userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, miniAppInfo.id)
+            this.userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, miniAppId)
         else this.userInfoBridgeDispatcher = object : UserInfoBridgeDispatcher() {}
 
         miniAppViewInitialized = true
@@ -146,7 +145,7 @@ abstract class MiniAppMessageBridge {
     fun setUserInfoBridgeDispatcher(bridgeDispatcher: UserInfoBridgeDispatcher) {
         userInfoBridgeDispatcher = bridgeDispatcher
         if (miniAppViewInitialized)
-            userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, miniAppInfo.id)
+            userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, miniAppId)
     }
 
     private fun onGetUniqueId(callbackObj: CallbackObj) {
@@ -193,7 +192,7 @@ abstract class MiniAppMessageBridge {
                     )
                 }
             } catch (e: CustomPermissionsNotImplementedException) {
-                customPermissionWindow.displayPermissions(miniAppInfo.id, deniedPermissions)
+                customPermissionWindow.displayPermissions(miniAppId, deniedPermissions)
             } catch (e: Exception) {
                 customPermissionBridgeDispatcher.postCustomPermissionError(e.message.toString())
             }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/navigator/MiniAppExternalUrlLoader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/navigator/MiniAppExternalUrlLoader.kt
@@ -7,17 +7,49 @@ import com.rakuten.tech.mobile.miniapp.MiniAppScheme
 /**
  * This support the scenario that external loader redirect to url which is only supported in mini app view,
  * close the external loader and emit that url to mini app view by [ExternalResultHandler.emitResult].
- * @param miniAppId The id of loading mini app.
- * @param activity The Activity contains webview. Pass the activity if you want to auto finish
- * the Activity with current external loading url as result data.
  **/
-class MiniAppExternalUrlLoader(miniAppId: String, private val activity: Activity? = null) {
+class MiniAppExternalUrlLoader private constructor(
+    private val activity: Activity?
+) {
 
     companion object {
         const val returnUrlTag = "return_url_tag"
+
+        /**
+         * Creates new MiniAppExternalUrlLoader.
+         * @param miniAppId The id of loading mini app.
+         * @param activity The Activity contains webview. Pass the activity if you want to auto finish
+         * the Activity with current external loading url as result data.
+         **/
+        fun loaderWithId(miniAppId: String, activity: Activity? = null): MiniAppExternalUrlLoader {
+            val loader = MiniAppExternalUrlLoader(activity)
+            loader.miniAppId = miniAppId
+            return loader
+        }
+
+        /**
+         * Creates new MiniAppExternalUrlLoader.
+         * This should only be used for previewing a mini app from a local server.
+         * @param customAppUrl The url that was used to load the Mini App.
+         * @param activity The Activity contains webview. Pass the activity if you want to auto finish
+         * the Activity with current external loading url as result data.
+         **/
+        fun loaderWithUrl(customAppUrl: String, activity: Activity? = null): MiniAppExternalUrlLoader {
+            val loader = MiniAppExternalUrlLoader(activity)
+            loader.customAppUrl = customAppUrl
+            return loader
+        }
     }
 
-    private val miniAppScheme = MiniAppScheme(miniAppId)
+    private var miniAppId = ""
+    private var customAppUrl: String? = null
+    private val miniAppScheme: MiniAppScheme by lazy {
+        if (customAppUrl != null) {
+            MiniAppScheme.schemeWithCustomUrl(customAppUrl!!)
+        } else {
+            MiniAppScheme.schemeWithAppId(miniAppId)
+        }
+    }
 
     /**
      * Determine to close the external loader.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
@@ -96,6 +96,10 @@ internal class MiniAppCustomPermissionCache(context: Context) {
         applyStoringPermissions(MiniAppCustomPermission(miniAppId, allPermissions))
     }
 
+    fun removeId(miniAppId: String) {
+        prefs.edit().remove(miniAppId).apply()
+    }
+
     @SuppressWarnings("PrintStackTrace")
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun applyStoringPermissions(miniAppCustomPermission: MiniAppCustomPermission) {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
@@ -14,6 +14,7 @@ internal const val TEST_URL_HTTPS_2 = "https://www.example.com/2/"
 internal const val TEST_PHONE_URI = "tel:123456"
 
 internal const val TEST_MA_ID = "test_id"
+internal const val TEST_MA_URL = "https://miniapp"
 internal const val TEST_MA_DISPLAY_NAME = "test_name"
 internal const val TEST_MA_ICON = "test_icon"
 internal const val TEST_MA_VERSION_TAG = "test_vtag"

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerSpec.kt
@@ -8,6 +8,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
 import com.rakuten.tech.mobile.miniapp.TEST_HA_NAME
 import com.rakuten.tech.mobile.miniapp.TEST_MA
+import com.rakuten.tech.mobile.miniapp.TEST_MA_URL
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import org.amshove.kluent.shouldBeInstanceOf
 import org.junit.Before
@@ -28,19 +29,31 @@ class DisplayerSpec {
     @Test
     fun `for a given base path createMiniAppDisplay returns an implementer of MiniAppDisplay`() {
         val obtainedDisplay = getMiniAppDisplay()
+        val obtainedDisplayUrl = getMiniAppDisplayUrl()
         obtainedDisplay shouldBeInstanceOf RealMiniAppDisplay::class
+        obtainedDisplayUrl shouldBeInstanceOf RealMiniAppDisplay::class
     }
 
     @Test
     fun `for a given base path createMiniAppDisplay returns an implementer of LifecycleObserver`() {
         val obtainedDisplay = getMiniAppDisplay()
+        val obtainedDisplayUrl = getMiniAppDisplayUrl()
         obtainedDisplay shouldBeInstanceOf LifecycleObserver::class
+        obtainedDisplayUrl shouldBeInstanceOf LifecycleObserver::class
     }
 
     private fun getMiniAppDisplay(): MiniAppDisplay =
         Displayer(context, TEST_HA_NAME).createMiniAppDisplay(
             basePath = context.filesDir.path,
             miniAppInfo = TEST_MA,
+            miniAppMessageBridge = miniAppMessageBridge,
+            miniAppNavigator = mock(),
+            miniAppCustomPermissionCache = mock()
+        )
+
+    private fun getMiniAppDisplayUrl(): MiniAppDisplay =
+        Displayer(context, TEST_HA_NAME).createMiniAppDisplay(
+            appUrl = TEST_MA_URL,
             miniAppMessageBridge = miniAppMessageBridge,
             miniAppNavigator = mock(),
             miniAppCustomPermissionCache = mock()

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -51,7 +51,7 @@ open class BaseWebViewSpec {
         activityScenario.onActivity { activity ->
             context = activity
             basePath = context.filesDir.path
-            webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA))
+            webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA.displayName))
 
             miniAppWebView = MiniAppWebView(
                 context,
@@ -222,7 +222,7 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
 @RunWith(AndroidJUnit4::class)
 class MiniAppWebClientSpec : BaseWebViewSpec() {
     private val externalResultHandler: ExternalResultHandler = spy()
-    private val miniAppScheme = Mockito.spy(MiniAppScheme(TEST_MA_ID))
+    private val miniAppScheme = Mockito.spy(MiniAppScheme.schemeWithAppId(TEST_MA_ID))
 
     @Test
     fun `for a WebViewClient, it should be MiniAppWebViewClient`() {
@@ -231,7 +231,7 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
 
     @Test
     fun `should intercept request with WebViewAssetLoader`() {
-        val webAssetLoader: WebViewAssetLoader =
+        val webAssetLoader: WebViewAssetLoader? =
             Mockito.spy((miniAppWebView.webViewClient as MiniAppWebViewClient).loader)
         val webViewClient = MiniAppWebViewClient(context, webAssetLoader, miniAppNavigator,
             externalResultHandler, miniAppScheme)
@@ -239,13 +239,13 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
 
         webViewClient.shouldInterceptRequest(miniAppWebView, webResourceRequest)
 
-        verify(webAssetLoader, times(1))
+        verify(webAssetLoader!!, times(1))
             .shouldInterceptRequest(webResourceRequest.url)
     }
 
     @Test
     fun `should redirect to custom domain when only loading with custom scheme`() {
-        val webAssetLoader: WebViewAssetLoader = (miniAppWebView.webViewClient as MiniAppWebViewClient).loader
+        val webAssetLoader: WebViewAssetLoader? = (miniAppWebView.webViewClient as MiniAppWebViewClient).loader
         val customDomain = "https://mscheme.${miniAppWebView.miniAppInfo.id}/"
         val webViewClient = Mockito.spy(MiniAppWebViewClient(context, webAssetLoader, miniAppNavigator,
             externalResultHandler, miniAppScheme))
@@ -261,7 +261,7 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
 
     @Test
     fun `should open phone dialer when there is telephone scheme`() {
-        val webAssetLoader: WebViewAssetLoader = (miniAppWebView.webViewClient as MiniAppWebViewClient).loader
+        val webAssetLoader: WebViewAssetLoader? = (miniAppWebView.webViewClient as MiniAppWebViewClient).loader
         val webViewClient = Mockito.spy(MiniAppWebViewClient(context, webAssetLoader, miniAppNavigator,
             externalResultHandler, miniAppScheme))
         val displayer = Mockito.spy(miniAppWebView)
@@ -290,7 +290,7 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
             miniAppCustomPermissionCache = miniAppCustomPermissionCache
         ))
         val miniAppNavigator = Mockito.spy(displayer.miniAppNavigator)
-        val webAssetLoader: WebViewAssetLoader = (displayer.webViewClient as MiniAppWebViewClient).loader
+        val webAssetLoader: WebViewAssetLoader? = (displayer.webViewClient as MiniAppWebViewClient).loader
         val webViewClient = Mockito.spy(MiniAppWebViewClient(context, webAssetLoader, miniAppNavigator!!,
             externalResultHandler, miniAppScheme))
 
@@ -306,7 +306,7 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
 
     @Test
     fun `should open external url loader when there is the config for navigation`() {
-        val webAssetLoader: WebViewAssetLoader = (miniAppWebView.webViewClient as MiniAppWebViewClient).loader
+        val webAssetLoader: WebViewAssetLoader? = (miniAppWebView.webViewClient as MiniAppWebViewClient).loader
         val webViewClient = Mockito.spy(MiniAppWebViewClient(context, webAssetLoader, miniAppNavigator,
             externalResultHandler, miniAppScheme))
         val displayer = Mockito.spy(miniAppWebView)
@@ -365,7 +365,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
 
     @Test
     fun `bridge js should be null when js asset is inaccessible`() {
-        val webClient = MiniAppWebChromeClient(mock(), mock())
+        val webClient = MiniAppWebChromeClient(mock(), "title")
         webClient.bridgeJs shouldBe null
     }
 
@@ -399,7 +399,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
     @Test
     fun `should close custom view when exit`() {
         val context = getApplicationContext<Context>()
-        webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA))
+        webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA.displayName))
         webChromeClient.onShowCustomView(null, mock())
         webChromeClient.customView = mock()
         webChromeClient.onShowCustomView(mock(), mock())
@@ -409,7 +409,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
 
     @Test
     fun `should execute custom view flow without error`() {
-        val webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA))
+        val webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA.displayName))
 
         webChromeClient.onShowCustomView(View(context), mock())
         webChromeClient.updateControls()
@@ -419,7 +419,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
 
     @Test
     fun `should exit fullscreen when destroy miniapp view`() {
-        val webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA))
+        val webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA.displayName))
         webChromeClient.onShowCustomView(View(context), mock())
         webChromeClient.onWebViewDetach()
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -29,6 +29,7 @@ import org.amshove.kluent.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito
 import java.io.ByteArrayInputStream
 import kotlin.test.assertTrue
@@ -46,7 +47,7 @@ open class BaseWebViewSpec {
 
     @Suppress("LongMethod")
     @Before
-    fun setup() {
+    open fun setup() {
         activityScenario = ActivityScenario.launch(TestActivity::class.java)
         activityScenario.onActivity { activity ->
             context = activity
@@ -65,6 +66,30 @@ open class BaseWebViewSpec {
             )
             webResourceRequest = getWebResReq(miniAppWebView.getLoadUrl().toUri())
         }
+    }
+}
+
+@RunWith(AndroidJUnit4::class)
+class MiniAppHTTPWebViewSpec : BaseWebViewSpec() {
+
+    override fun setup() {
+        super.setup()
+        miniAppWebView = MiniAppHttpWebView(
+                context,
+                miniAppTitle = TEST_MA.displayName,
+                appUrl = TEST_MA_URL,
+                miniAppMessageBridge = miniAppMessageBridge,
+                miniAppNavigator = miniAppNavigator,
+                hostAppUserAgentInfo = TEST_HA_NAME,
+                miniAppWebChromeClient = webChromeClient,
+                miniAppCustomPermissionCache = miniAppCustomPermissionCache
+        )
+    }
+
+    @Test
+    fun `should remove cached permission data when window is closed`() {
+        (miniAppWebView as MiniAppHttpWebView).callOnDetached()
+        verify(miniAppCustomPermissionCache, times(1)).removeId(anyString())
     }
 }
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
@@ -98,7 +98,7 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
             activity = TestActivity(),
             webViewListener = webViewListener,
             customPermissionCache = mock(),
-            miniAppInfo = TEST_MA
+            miniAppId = TEST_MA_ID
         )
     }
 
@@ -120,7 +120,7 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
             activity = TestActivity(),
             webViewListener = webViewListener,
             customPermissionCache = mock(),
-            miniAppInfo = TEST_MA
+            miniAppId = TEST_MA_ID
         )
 
         miniAppBridge.postMessage(permissionJsonStr)
@@ -154,7 +154,7 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
             activity = TestActivity(),
             webViewListener = webViewListener,
             customPermissionCache = mock(),
-            miniAppInfo = TEST_MA
+            miniAppId = TEST_MA_ID
         )
         miniAppBridge.postMessage(uniqueIdJsonStr)
 
@@ -173,7 +173,7 @@ class ShareContentBridgeSpec : BridgeCommon() {
             activity = TestActivity(),
             webViewListener = webViewListener,
             customPermissionCache = mock(),
-            miniAppInfo = TEST_MA
+            miniAppId = TEST_MA_ID
         )
     }
 
@@ -198,7 +198,7 @@ class ShareContentBridgeSpec : BridgeCommon() {
                 activity = activity,
                 webViewListener = webViewListener,
                 customPermissionCache = mock(),
-                miniAppInfo = TEST_MA
+                miniAppId = TEST_MA_ID
             )
             miniAppBridge.postMessage(shareContentJsonStr)
 
@@ -217,7 +217,7 @@ class ShareContentBridgeSpec : BridgeCommon() {
             activity = TestActivity(),
             webViewListener = webViewListener,
             customPermissionCache = mock(),
-            miniAppInfo = TEST_MA
+            miniAppId = TEST_MA_ID
         )
         miniAppBridge.postMessage(shareContentJsonStr)
 
@@ -266,7 +266,7 @@ class AdBridgeSpec : BridgeCommon() {
             activity = TestActivity(),
             webViewListener = webViewListener,
             customPermissionCache = mock(),
-            miniAppInfo = TEST_MA
+            miniAppId = TEST_MA_ID
         )
         miniAppBridge.setAdMobDisplayer(TestAdMobDisplayer())
         return miniAppBridge
@@ -324,7 +324,7 @@ class ScreenBridgeSpec : BridgeCommon() {
             activity = TestActivity(),
             webViewListener = webViewListener,
             customPermissionCache = mock(),
-            miniAppInfo = TEST_MA
+            miniAppId = TEST_MA_ID
         )
     }
 
@@ -345,7 +345,7 @@ class ScreenBridgeSpec : BridgeCommon() {
                 activity = activity,
                 webViewListener = webViewListener,
                 customPermissionCache = mock(),
-                miniAppInfo = TEST_MA
+                miniAppId = TEST_MA_ID
             )
             miniAppBridge.allowScreenOrientation(true)
             miniAppBridge.postMessage(createCallbackJsonStr(ScreenOrientation.LOCK_PORTRAIT))

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
@@ -82,7 +82,7 @@ class UserInfoBridgeDispatcherSpec {
             activity = TestActivity(),
             webViewListener = webViewListener,
             customPermissionCache = customPermissionCache,
-            miniAppInfo = miniAppInfo
+            miniAppId = TEST_MA.id
         )
         userInfoBridgeDispatcher = Mockito.spy(createUserInfoBridgeDispatcher())
         miniAppBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/navigator/MiniAppExternalUrlLoaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/navigator/MiniAppExternalUrlLoaderSpec.kt
@@ -13,27 +13,42 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class MiniAppExternalUrlLoaderSpec {
-    private val miniAppScheme = MiniAppScheme(TEST_MA_ID)
+    private val miniAppSchemeId = MiniAppScheme.schemeWithAppId(TEST_MA_ID)
     private lateinit var externalUrlLoader: MiniAppExternalUrlLoader
+    private lateinit var externalUrlLoaderUrlBased: MiniAppExternalUrlLoader
 
     @Before
     fun setup() {
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
-            externalUrlLoader = MiniAppExternalUrlLoader(TEST_MA_ID, activity)
+            externalUrlLoader = MiniAppExternalUrlLoader.loaderWithId(TEST_MA_ID, activity)
+            externalUrlLoaderUrlBased = MiniAppExternalUrlLoader.loaderWithUrl(TEST_MA_URL, activity)
         }
     }
 
     @Test
     fun `should only override url when it is supported by mini app view`() {
         externalUrlLoader.shouldOverrideUrlLoading(TEST_URL_HTTPS_1) shouldBe false
-        externalUrlLoader.shouldOverrideUrlLoading(miniAppScheme.miniAppCustomScheme) shouldBe true
-        externalUrlLoader.shouldOverrideUrlLoading(miniAppScheme.miniAppCustomDomain) shouldBe true
+        externalUrlLoader.shouldOverrideUrlLoading(miniAppSchemeId.miniAppCustomScheme) shouldBe true
+        externalUrlLoader.shouldOverrideUrlLoading(miniAppSchemeId.miniAppCustomDomain) shouldBe true
         externalUrlLoader.shouldOverrideUrlLoading(TEST_PHONE_URI) shouldBe true
     }
 
     @Test
     fun `should not override phone url when there is no activity context`() {
-        val externalUrlLoader = MiniAppExternalUrlLoader(TEST_MA_ID, null)
+        val externalUrlLoader = MiniAppExternalUrlLoader.loaderWithId(TEST_MA_ID, null)
+        externalUrlLoader.shouldOverrideUrlLoading(TEST_PHONE_URI) shouldBe false
+    }
+
+    @Test
+    fun `should only override url when it is supported by mini app view (url based)`() {
+        externalUrlLoaderUrlBased.shouldOverrideUrlLoading(TEST_URL_HTTPS_1) shouldBe false
+        externalUrlLoaderUrlBased.shouldOverrideUrlLoading(TEST_MA_URL) shouldBe true
+        externalUrlLoaderUrlBased.shouldOverrideUrlLoading(TEST_PHONE_URI) shouldBe true
+    }
+
+    @Test
+    fun `should not override phone url when there is no activity context (url based)`() {
+        val externalUrlLoader = MiniAppExternalUrlLoader.loaderWithUrl(TEST_MA_URL, null)
         externalUrlLoader.shouldOverrideUrlLoading(TEST_PHONE_URI) shouldBe false
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
@@ -25,6 +25,7 @@ class MiniAppCustomPermissionCacheSpec {
         `when`(mockContext.getSharedPreferences(anyString(), anyInt()))
             .thenReturn(mockSharedPrefs)
         `when`(mockEditor.putString(anyString(), anyString())).thenReturn(mockEditor)
+        `when`(mockEditor.remove(anyString())).thenReturn(mockEditor)
 
         miniAppCustomPermissionCache = spy(MiniAppCustomPermissionCache(mockContext))
     }
@@ -83,6 +84,12 @@ class MiniAppCustomPermissionCacheSpec {
     }
 
     /** end region */
+
+    @Test
+    fun `removeId will remove all permission data from the store`() {
+        miniAppCustomPermissionCache.removeId(TEST_MA_ID)
+        verify(mockEditor, times(1)).remove(TEST_MA_ID)
+    }
 
     @Test
     fun `storePermissions will invoke necessary functions to save value`() {
@@ -147,7 +154,8 @@ class MiniAppCustomPermissionCacheSpec {
     @Test
     fun `prepareAllPermissionsToStore should combine cached and supplied list properly with unknown permissions`() {
         val cached = MiniAppCustomPermission(
-            TEST_MA_ID, listOf(Pair(MiniAppCustomPermissionType.UNKNOWN, MiniAppCustomPermissionResult.PERMISSION_NOT_AVAILABLE))
+            TEST_MA_ID,
+            listOf(Pair(MiniAppCustomPermissionType.UNKNOWN, MiniAppCustomPermissionResult.PERMISSION_NOT_AVAILABLE))
         )
         val supplied = listOf(
             Pair(

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        tools:ignore="GoogleAppIndexingWarning">
+        tools:ignore="GoogleAppIndexingWarning"
+        android:usesCleartextTraffic="true">
 
         <activity
             android:name="com.rakuten.tech.mobile.testapp.ui.miniapplist.MiniAppListActivity"
@@ -35,7 +36,7 @@
             android:configChanges="orientation|screenSize" />
         <activity
             android:name="com.rakuten.tech.mobile.testapp.ui.input.MiniAppInputActivity"
-            android:label="@string/action_go_input" />
+            android:label="@string/lb_display_input" />
         <activity
             android:name="com.rakuten.tech.mobile.testapp.ui.settings.SettingsMenuActivity"
             android:label="@string/lb_app_settings"

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
@@ -63,6 +63,25 @@ class MiniAppDisplayViewModel constructor(
         }
     }
 
+    fun obtainMiniAppDisplayUrl(
+        context: Context,
+        appUrl: String,
+        miniAppMessageBridge: MiniAppMessageBridge,
+        miniAppNavigator: MiniAppNavigator
+    ) = viewModelScope.launch(Dispatchers.IO) {
+        try {
+            _isLoading.postValue(true)
+            miniAppDisplay = miniapp.createWithUrl(appUrl, miniAppMessageBridge, miniAppNavigator)
+            hostLifeCycle?.addObserver(miniAppDisplay)
+            _miniAppView.postValue(miniAppDisplay.getMiniAppView(context))
+        } catch (e: MiniAppSdkException) {
+            e.printStackTrace()
+             _errorData.postValue(e.message)
+        } finally {
+            _isLoading.postValue(false)
+        }
+    }
+
     fun setHostLifeCycle(lifecycle: Lifecycle) {
         this.hostLifeCycle = lifecycle
     }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/WebViewActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/WebViewActivity.kt
@@ -15,11 +15,13 @@ class WebViewActivity : BaseActivity() {
     companion object {
         val loadUrlTag = "load_url_tag"
         val miniAppIdTag = "miniapp_id_tag"
+        val appUrlTag = "miniapp_url_tag"
 
-        fun startForResult(activity: Activity, url: String, appId: String, externalWebViewReqCode: Int) {
+        fun startForResult(activity: Activity, url: String, appId: String?, appUrl: String? = null, externalWebViewReqCode: Int) {
             val intent = Intent(activity, WebViewActivity::class.java).apply {
                 putExtra(loadUrlTag, url)
-                putExtra(miniAppIdTag, appId)
+                appId?.let { putExtra(miniAppIdTag, it) }
+                appUrl?.let { putExtra(appUrlTag, it) }
             }
             activity.startActivityForResult(intent, externalWebViewReqCode)
         }
@@ -30,8 +32,13 @@ class WebViewActivity : BaseActivity() {
         showBackIcon()
         title = "External WebView Sample"
 
-        val miniAppExternalUrlLoader = MiniAppExternalUrlLoader(
-            intent.getStringExtra(miniAppIdTag) ?: "", this)
+        val appUrl = intent.getStringExtra(appUrlTag) ?: ""
+        val miniAppExternalUrlLoader = if (appUrl.isNotBlank()) {
+            MiniAppExternalUrlLoader.loaderWithUrl(appUrl, this)
+        } else {
+            MiniAppExternalUrlLoader.loaderWithId(intent.getStringExtra(miniAppIdTag), this)
+        }
+
         val webViewClient = SampleWebViewClient(miniAppExternalUrlLoader)
 
         sampleExternalWebView = SampleExternalWebView(this, intent.getStringExtra(loadUrlTag) ?: "", webViewClient)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/input/MiniAppInputActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/input/MiniAppInputActivity.kt
@@ -4,6 +4,8 @@ import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
+import android.view.View
+import android.webkit.URLUtil
 import androidx.databinding.DataBindingUtil
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.MiniAppInputActivityBinding
@@ -12,6 +14,7 @@ import com.rakuten.tech.mobile.testapp.helper.isInvalidUuid
 import com.rakuten.tech.mobile.testapp.launchActivity
 import com.rakuten.tech.mobile.testapp.ui.display.MiniAppDisplayActivity
 import com.rakuten.tech.mobile.testapp.ui.miniapplist.MiniAppListActivity
+import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
 import com.rakuten.tech.mobile.testapp.ui.settings.MenuBaseActivity
 import com.rakuten.tech.mobile.testapp.ui.settings.SettingsMenuActivity
 
@@ -35,32 +38,73 @@ class MiniAppInputActivity : MenuBaseActivity() {
             }
         })
 
-        binding.btnDisplay.setOnClickListener {
-            raceExecutor.run { display() }
+        validateAppUrl(binding.edtUrl.text.toString())
+        binding.edtUrl.addTextChangedListener(object: TextWatcher {
+            override fun afterTextChanged(s: Editable?) {}
+
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                validateAppUrl(s.toString())
+            }
+        })
+
+        binding.btnDisplayAppId.setOnClickListener {
+            raceExecutor.run { displayAppId() }
+        }
+        binding.btnDisplayUrl.setOnClickListener {
+            raceExecutor.run { displayUrl() }
         }
         binding.btnDisplayList.setOnClickListener {
             raceExecutor.run { launchActivity<MiniAppListActivity>() }
+        }
+
+        if (AppSettings.instance.isPreviewMode) {
+            binding.edtAppId.visibility = View.GONE
+            binding.btnDisplayAppId.visibility = View.GONE
+            binding.edtUrl.requestFocus()
         }
     }
 
     private fun validateAppId(appId: String) {
         if (appId.isBlank())
-            binding.btnDisplay.isEnabled = false
+            binding.btnDisplayAppId.isEnabled = false
         else {
             if (appId.isInvalidUuid()) {
                 binding.edtAppId.error = getString(R.string.error_invalid_input)
-                binding.btnDisplay.isEnabled = false
+                binding.btnDisplayAppId.isEnabled = false
             } else {
                 binding.edtAppId.error = null
-                binding.btnDisplay.isEnabled = true
+                binding.btnDisplayAppId.isEnabled = true
             }
         }
     }
 
-    private fun display() {
+    private fun validateAppUrl(appUrl: String) {
+        if (appUrl.isBlank())
+            binding.btnDisplayUrl.isEnabled = false
+        else {
+            if (URLUtil.isValidUrl(appUrl)) {
+                binding.edtUrl.error = null
+                binding.btnDisplayUrl.isEnabled = true
+            } else {
+                binding.edtUrl.error = getString(R.string.error_invalid_input)
+                binding.btnDisplayUrl.isEnabled = false
+            }
+        }
+    }
+
+    private fun displayAppId() {
         MiniAppDisplayActivity.start(
             this,
             binding.edtAppId.text.toString().trim()
+        )
+    }
+
+    private fun displayUrl() {
+        MiniAppDisplayActivity.startUrl(
+            this,
+            binding.edtUrl.text.toString().trim()
         )
     }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListFragment.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListFragment.kt
@@ -62,8 +62,11 @@ class MiniAppListFragment : BaseFragment(), MiniAppListener, OnSearchListener,
         binding.rvMiniAppList.layoutManager = LinearLayoutManager(this.context)
         miniAppListAdapter = MiniAppListAdapter(ArrayList(), this)
         binding.rvMiniAppList.adapter = miniAppListAdapter
-        if (AppSettings.instance.isPreviewMode)
-            binding.btnInput.visibility = View.GONE
+        if (AppSettings.instance.isPreviewMode) {
+            binding.btnInput.text = getString(R.string.action_go_input_preview_mode)
+        } else {
+            binding.btnInput.text = getString(R.string.action_go_input)
+        }
         return binding.root
     }
 

--- a/testapp/src/main/res/layout/mini_app_input_activity.xml
+++ b/testapp/src/main/res/layout/mini_app_input_activity.xml
@@ -18,7 +18,7 @@
             <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/large_24">
+                android:layout_marginBottom="@dimen/medium_16">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/edtAppId"
@@ -29,11 +29,34 @@
             </com.google.android.material.textfield.TextInputLayout>
 
             <Button
-                android:id="@+id/btnDisplay"
+                android:id="@+id/btnDisplayAppId"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="start"
+                android:layout_marginTop="@dimen/medium_16"
+                android:layout_marginBottom="@dimen/large_24"
+                android:text="@string/action_display" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/large_24"
+                android:layout_marginBottom="@dimen/medium_16">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/edtUrl"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/lb_app_url"
+                    android:inputType="text" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <Button
+                android:id="@+id/btnDisplayUrl"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start"
+                android:layout_marginTop="@dimen/medium_16"
                 android:text="@string/action_display" />
         </LinearLayout>
 

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -2,12 +2,14 @@
     <string name="lb_version">Version</string>
     <string name="lb_description">Description</string>
     <string name="lb_app_id">App ID</string>
+    <string name="lb_app_url">URL</string>
     <string name="lb_app_settings">App Settings</string>
     <string name="lb_preview_mode">Preview Mode</string>
     <string name="lb_ras">RAS</string>
     <string name="lb_user_details">User Details</string>
     <string name="lb_access_token">Access Token</string>
     <string name="lb_valid_until">Expired Date</string>
+    <string name="lb_display_input">Display by Input</string>
 
     <string name="menu_title_search">Search</string>
     <string name="menu_title_settings">Settings</string>
@@ -21,7 +23,8 @@
     <string name="userdata_warning_empty_contact_list">No contact available!</string>
 
     <string name="action_display">Display</string>
-    <string name="action_go_input">Display Miniapp From ID</string>
+    <string name="action_go_input">Display Miniapp From ID or URL</string>
+    <string name="action_go_input_preview_mode">Display Miniapp From URL</string>
     <string name="action_display_list">Display Miniapp From List</string>
     <string name="action_save">Save</string>
     <string name="action_add">Add</string>


### PR DESCRIPTION
# Description
URL loading available when preview mode is off (not sure if that's correct).
I'll write more tests once the main part is accepted.

## Links
MINI-1981
SDKCF-3025

# Checklist
- [X] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [ ] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [/] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data before every commit, including API endpoints and keys
- [X] I ran `./gradlew check` without errors
