### PR TITLE
docs: Reformat user guide into feature sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,22 @@ $ ./gradlew assembleRelease
 
 We currently don't provide an API for public use, so you must provide your own API.
 
-## How to generate KDocs SDK documentation locally
+## Writing and generating documentation
+
+Our documentation is hosted on Github Pages using the `gh-pages` branch of this repo. So this means that the docs are hosted as markdown and then Github Pages generates HTML using Jekyll. The documentation has two parts: a userguide and the API docs. The userguide is generated from [USERGUIDE.md](miniapp/USERGUIDE.md) and the API docs are generated using Dokka.
+
+For the most part, you can use standard markdown in the userguide, but please note the following:
+
+- If you wish to use a `<details>` tag for an expandable section, then you must use the following format (note that the closing `</summary>` tag is on a new line):
+```xml
+<details><summary markdown="span">Title goes here
+</summary>
+
+    Content goes here.
+</details>
+```
+
+### How to generate KDocs SDK documentation locally
 
 You may want to generate the SDK documentation locally so that you can ensure that the generated docs look correct. We use Dokka for this, so you can run the following command, and the generated docs will be output at `miniapp/build/publishableDocs` in the markdown format. 
 
@@ -76,7 +91,7 @@ The docs are hosted on Github Pages in markdown, and therefore the HTML version 
 ```
 $ ./gradlew generatePublishableDocs
 $ git checkout gh-pages
-$ cp miniapp/build/publishableDocs/docs ./
+$ cp -r miniapp/build/publishableDocs/docs/ ./
 $ bundle install
 $ bundle exec jekyll serve
 ```


### PR DESCRIPTION
# Description
Sorry it looks like there are a lot of changes. Most of the content is still the same but was just rearranged. The only new content is the Mini App Features section which explains what each feature does. Also added a Table of Contents - this will be automatically generated by Jekyll when the documentation is published to Github Pages. Also put some of the longer code examples inside of expandable sections.

It's probably easier to preview it directly on my branch: 
https://github.com/corycaywood/android-miniapp/blob/docs/userguide-reformat/miniapp/USERGUIDE.md

## Links
MINI-1978

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [ x I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
