### PR TITLE
feat get contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 2.X.X (In progress)
 **SDK**
 - **Feature:** Added `rakuten.miniapp.device.LOCATION` custom permission.
+- **Feature:** Added `getContacts()` interface in `UserInfoBridgeDispatcher` for receiving list of contact IDs.
 
 **Sample App**
 - **Feature:** `rakuten.miniapp.device.LOCATION` permission as "Location" in custom permissions settings screen is visible now.
+- **Change:** Added `getContacts()` implementation for sending the list of contact IDs.
 
 ### 2.6.0 (2020-11-27)
 **SDK**

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -293,13 +293,13 @@ val userInfoBridgeDispatcher = object : UserInfoBridgeDispatcher() {
     }
 
      override fun getContacts(
-        onSuccess: (contactIdsAsJson: String) -> Unit,
+        onSuccess: (contacts: ArrayList<Contact>) -> Unit,
         onError: (message: String) -> Unit
     ) {
-        // Check if there is any contact id in hostapp to send
+        // Check if there is any contact id in HostApp
         // .. .. ..
         if (hasContact)
-            onSuccess(contactIds)
+            onSuccess(contacts) // invoke the list of contact IDs
         else
             onError("There is no contact found in HostApp.")
     }

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -212,6 +212,7 @@ The `UserInfoBridgeDispatcher`:
 | getUserName                  | 🚫       |
 | getProfilePhoto              | 🚫       |
 | getAccessToken               | 🚫       |
+| getContacts                  | 🚫       |
 
 The sections below explain each feature in more detail. 
 
@@ -289,6 +290,18 @@ val userInfoBridgeDispatcher = object : UserInfoBridgeDispatcher() {
             onSuccess(tokenData) // allow miniapp to get token and return TokenData value.
         else
             onError(message)    // reject miniapp to get token and with message explanation.
+    }
+
+     override fun getContacts(
+        onSuccess: (contactIdsAsJson: String) -> Unit,
+        onError: (message: String) -> Unit
+    ) {
+        // Check if there is any contact id in hostapp to send
+        // .. .. ..
+        if (hasContact)
+            onSuccess(contactIds)
+        else
+            onError("There is no contact found in HostApp.")
     }
 }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -132,6 +132,7 @@ abstract class MiniAppMessageBridge {
             ActionType.GET_PROFILE_PHOTO.action -> userInfoBridgeDispatcher.onGetProfilePhoto(callbackObj.id)
             ActionType.GET_ACCESS_TOKEN.action -> userInfoBridgeDispatcher.onGetAccessToken(callbackObj.id)
             ActionType.SET_SCREEN_ORIENTATION.action -> screenBridgeDispatcher.onScreenRequest(callbackObj)
+            ActionType.GET_CONTACTS.action -> userInfoBridgeDispatcher.onGetContacts(callbackObj.id)
         }
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/Type.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/Type.kt
@@ -10,7 +10,8 @@ internal enum class ActionType(val action: String) {
     GET_USER_NAME("getUserName"),
     GET_PROFILE_PHOTO("getProfilePhoto"),
     GET_ACCESS_TOKEN("getAccessToken"),
-    SET_SCREEN_ORIENTATION("setScreenOrientation")
+    SET_SCREEN_ORIENTATION("setScreenOrientation"),
+    GET_CONTACTS("getContacts"),
 }
 
 internal enum class DialogType {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/Contact.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/Contact.kt
@@ -1,0 +1,9 @@
+package com.rakuten.tech.mobile.miniapp.js.userinfo
+
+import androidx.annotation.Keep
+
+/** Contact object for miniapp. */
+@Keep
+data class Contact(
+    val id: String
+)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
@@ -7,6 +7,7 @@ import com.rakuten.tech.mobile.miniapp.js.MiniAppBridgeExecutor
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionResult
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
+import java.util.ArrayList
 
 /**
  * A class to provide the interfaces for getting user info e.g. user-name, profile-photo etc.
@@ -46,7 +47,7 @@ abstract class UserInfoBridgeDispatcher {
      * You can also throw an [Exception] from this method to pass an error message to the mini app.
      */
     open fun getContacts(
-        onSuccess: (contactIdsAsJson: String) -> Unit,
+        onSuccess: (contacts: ArrayList<Contact>) -> Unit,
         onError: (message: String) -> Unit
     ) {
         throw MiniAppSdkException("The `UserInfoBridgeDispatcher.getContacts` $NO_IMPL")
@@ -127,8 +128,8 @@ abstract class UserInfoBridgeDispatcher {
     }
 
     internal fun onGetContacts(callbackId: String) = try {
-        val successCallback = { contactIdsAsJson: String ->
-            bridgeExecutor.postValue(callbackId, contactIdsAsJson)
+        val successCallback = { contacts: ArrayList<Contact> ->
+            bridgeExecutor.postValue(callbackId, Gson().toJson(contacts))
         }
         val errorCallback = { message: String ->
             bridgeExecutor.postError(callbackId, "$ERR_GET_CONTACTS $message")

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
@@ -41,6 +41,17 @@ abstract class UserInfoBridgeDispatcher {
         throw MiniAppSdkException("The `UserInfoBridgeDispatcher.getAccessToken` $NO_IMPL")
     }
 
+    /**
+     * Get contacts from host app.
+     * You can also throw an [Exception] from this method to pass an error message to the mini app.
+     */
+    open fun getContacts(
+        onSuccess: (contactIdsAsJson: String) -> Unit,
+        onError: (message: String) -> Unit
+    ) {
+        throw MiniAppSdkException("The `UserInfoBridgeDispatcher.getContacts` $NO_IMPL")
+    }
+
     internal fun init(
         bridgeExecutor: MiniAppBridgeExecutor,
         miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
@@ -115,6 +126,19 @@ abstract class UserInfoBridgeDispatcher {
         bridgeExecutor.postError(callbackId, "$ERR_GET_ACCESS_TOKEN ${e.message}")
     }
 
+    internal fun onGetContacts(callbackId: String) = try {
+        val successCallback = { contactIdsAsJson: String ->
+            bridgeExecutor.postValue(callbackId, contactIdsAsJson)
+        }
+        val errorCallback = { message: String ->
+            bridgeExecutor.postError(callbackId, "$ERR_GET_CONTACTS $message")
+        }
+
+        getContacts(successCallback, errorCallback)
+    } catch (e: Exception) {
+        bridgeExecutor.postError(callbackId, "$ERR_GET_CONTACTS ${e.message}")
+    }
+
     @VisibleForTesting
     internal companion object {
         const val NO_IMPL = "method has not been implemented by the Host App."
@@ -125,5 +149,6 @@ abstract class UserInfoBridgeDispatcher {
         const val ERR_PROFILE_PHOTO_NO_PERMISSION =
             "Permission has not been accepted yet for getting profile photo."
         const val ERR_GET_ACCESS_TOKEN = "Cannot get access token:"
+        const val ERR_GET_CONTACTS = "Cannot get contacts:"
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
@@ -37,6 +37,7 @@ internal const val INVALID_FILE_URL_PATH = "https://78d85043-d04f-486a-8212-bf26
 
 internal const val TEST_USER_NAME = "test_user_name"
 internal const val TEST_PROFILE_PHOTO = "data:image/png;base64,encodedValue"
+internal const val TEST_CONTACT_ID = "test_contact_id"
 
 internal val TEST_MA = MiniAppInfo(
     id = TEST_MA_ID,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
@@ -30,6 +30,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
+import java.util.ArrayList
 
 @Suppress("LongMethod", "LargeClass")
 @RunWith(AndroidJUnit4::class)
@@ -252,14 +253,14 @@ class UserInfoBridgeDispatcherSpec {
     /** end region */
 
     /** start region: get contacts */
-    private val contactIdsAsJson = "dummy contacts id"
-    private fun createUserInfoContactsImpl(areContactsAvailable: Boolean) = object : UserInfoBridgeDispatcher() {
+    private val contacts = arrayListOf(Contact(TEST_CONTACT_ID))
+    private fun createUserInfoContactsImpl(hasContact: Boolean) = object : UserInfoBridgeDispatcher() {
         override fun getContacts(
-            onSuccess: (contactIdsAsJson: String) -> Unit,
+            onSuccess: (contacts: ArrayList<Contact>) -> Unit,
             onError: (message: String) -> Unit
         ) {
-            if (areContactsAvailable)
-                onSuccess.invoke(contactIdsAsJson)
+            if (hasContact)
+                onSuccess.invoke(contacts)
             else
                 onError.invoke(TEST_ERROR_MSG)
         }
@@ -292,7 +293,7 @@ class UserInfoBridgeDispatcherSpec {
 
         userInfoBridgeDispatcher.onGetContacts(contactsCallbackObj.id)
 
-        verify(bridgeExecutor).postValue(contactsCallbackObj.id, contactIdsAsJson)
+        verify(bridgeExecutor).postValue(contactsCallbackObj.id, Gson().toJson(contacts))
     }
     /** end region */
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -19,6 +19,7 @@ import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.ads.AdMobDisplayer
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
+import com.rakuten.tech.mobile.miniapp.js.userinfo.Contact
 import com.rakuten.tech.mobile.miniapp.js.userinfo.TokenData
 import com.rakuten.tech.mobile.miniapp.js.userinfo.UserInfoBridgeDispatcher
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppPermissionType
@@ -28,6 +29,7 @@ import com.rakuten.tech.mobile.miniapp.testapp.databinding.MiniAppDisplayActivit
 import com.rakuten.tech.mobile.testapp.helper.AppPermission
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
+import java.util.ArrayList
 
 class MiniAppDisplayActivity : BaseActivity() {
 
@@ -181,13 +183,17 @@ class MiniAppDisplayActivity : BaseActivity() {
             }
 
             override fun getContacts(
-                onSuccess: (contactIdsAsJson: String) -> Unit,
+                onSuccess: (contacts: ArrayList<Contact>) -> Unit,
                 onError: (message: String) -> Unit
             ) {
-                if (AppSettings.instance.isContactsSaved)
-                    onSuccess(AppSettings.instance.contactNames.toString())
-                else
-                    onError("There is no contact has been saved in HostApp yet.")
+                val hasContact = AppSettings.instance.isContactsSaved
+                if (hasContact) {
+                    val contacts: ArrayList<Contact> = arrayListOf()
+                    AppSettings.instance.contactNames.forEach {
+                        contacts.add(Contact(it))
+                    }
+                    onSuccess(contacts)
+                } else onError("There is no contact found in HostApp.")
             }
         }
         miniAppMessageBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -179,6 +179,16 @@ class MiniAppDisplayActivity : BaseActivity() {
                     .create()
                     .show()
             }
+
+            override fun getContacts(
+                onSuccess: (contactIdsAsJson: String) -> Unit,
+                onError: (message: String) -> Unit
+            ) {
+                if (AppSettings.instance.isContactsSaved)
+                    onSuccess(AppSettings.instance.contactNames.toString())
+                else
+                    onError("There is no contact has been saved in HostApp yet.")
+            }
         }
         miniAppMessageBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)
     }


### PR DESCRIPTION
# Description
- Add `getContacts` feature to the mini app message bridge. This should just pass a list of IDs (each ID represents a contact).
- The "Contacts" setting was already implemented in the Demo App, so this needs to be hooked into the new `getContacts` feature.
- TODO: Implement `getContacts` in JavaScript bridge.

## Links
- MINI-2295

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
