### PR TITLE
move app name from sdk to hostapp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 2.X.X (In progress)
 **SDK**
 - **Feature:** Added `rakuten.miniapp.device.LOCATION` custom permission.
-- **Fix:** Remove app_name property to avoid conflict.
+- **Change:** Remove `app_name` property.
 
 **Sample App**
 - **Feature:** `rakuten.miniapp.device.LOCATION` permission as "Location" in custom permissions settings screen is visible now.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 2.X.X (In progress)
 **SDK**
 - **Feature:** Added `rakuten.miniapp.device.LOCATION` custom permission.
+- **Fix:** Remove app_name property to avoid conflict.
 
 **Sample App**
 - **Feature:** `rakuten.miniapp.device.LOCATION` permission as "Location" in custom permissions settings screen is visible now.

--- a/miniapp/src/main/res/values/strings.xml
+++ b/miniapp/src/main/res/values/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">MiniAppPlatform</string>
-
     <!-- Custom permission resources -->
     <string name="miniapp_custom_permission_save">Save</string>
     <string name="miniapp_custom_permission_close">Close</string>

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -32,14 +32,24 @@ android {
         }
     }
 
-    def appName = "Mini App Sample"
+    def defaultAppName = "Mini App Sample"
+    def debugManifestPlaceholders = [
+            baseUrl                 : property("MINIAPP_SERVER_BASE_URL") ?: "https://www.example.com/",
+            isPreviewMode           : property("IS_PREVIEW_MODE") ?: true,
+            hostAppUserAgentInfo    : property("HOST_APP_UA_INFO") ?: "MiniApp Demo App/$project.version",
+            projectId               : property("HOST_PROJECT_ID") ?: "test-host-project-id",
+            subscriptionKey         : property("HOST_APP_SUBSCRIPTION_KEY") ?: "test-subs-key",
+            adMobAppId              : property("ADMOB_APP_ID") ?: "",
+            appName                 : defaultAppName + " DEBUG"
+    ]
     def stagingManifestPlaceholders = [
             baseUrl                 : property("MINIAPP_SERVER_BASE_URL") ?: "https://www.example.com/",
             isPreviewMode           : property("IS_PREVIEW_MODE") ?: true,
             hostAppUserAgentInfo    : property("HOST_APP_UA_INFO") ?: "MiniApp Demo App/$project.version",
             projectId               : property("HOST_PROJECT_ID") ?: "test-host-project-id",
             subscriptionKey         : property("HOST_APP_SUBSCRIPTION_KEY") ?: "test-subs-key",
-            adMobAppId              : property("ADMOB_APP_ID") ?: ""
+            adMobAppId              : property("ADMOB_APP_ID") ?: "",
+            appName                 : defaultAppName + " STG"
     ]
     def prodManifestPlaceholders = [
             baseUrl                 : property("MINIAPP_PROD_SERVER_BASE_URL") ?: "https://www.example.com/",
@@ -47,7 +57,8 @@ android {
             hostAppUserAgentInfo    : property("HOST_APP_PROD_UA_INFO") ?: "MiniApp Demo App/$project.version",
             projectId               : property("HOST_PROJECT_PROD_ID") ?: "test-host-project-id",
             subscriptionKey         : property("HOST_APP_PROD_SUBSCRIPTION_KEY") ?: "test-subs-key",
-            adMobAppId              : property("PROD_ADMOB_APP_ID") ?: ""
+            adMobAppId              : property("PROD_ADMOB_APP_ID") ?: "",
+            appName                 : defaultAppName
     ]
 
     def buildVersion = System.getenv("CIRCLE_BUILD_NUM") ?: new Date().format('yyMMddHHmm')
@@ -56,16 +67,14 @@ android {
         debug {
             applicationIdSuffix '.debug'
             versionNameSuffix '-DEBUG'
-            resValue "string", "app_name", "$appName DEBUG"
             resValue "string", "build_version", buildVersion
             resValue "string", "miniapp_sdk_version", project.version
             debuggable true
             minifyEnabled false
 
-            manifestPlaceholders = stagingManifestPlaceholders
+            manifestPlaceholders = debugManifestPlaceholders
         }
         release {
-            resValue "string", "app_name", appName
             resValue "string", "build_version", buildVersion
             resValue "string", "miniapp_sdk_version", project.version
             debuggable true
@@ -78,7 +87,6 @@ android {
             initWith release
             applicationIdSuffix '.staging'
             versionNameSuffix "-STG-build-$buildVersion"
-            resValue "string", "app_name", "$appName STG"
             matchingFallbacks = ['release', 'debug']
 
             manifestPlaceholders = stagingManifestPlaceholders

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -42,15 +42,8 @@ android {
             adMobAppId              : property("ADMOB_APP_ID") ?: "",
             appName                 : defaultAppName + " DEBUG"
     ]
-    def stagingManifestPlaceholders = [
-            baseUrl                 : property("MINIAPP_SERVER_BASE_URL") ?: "https://www.example.com/",
-            isPreviewMode           : property("IS_PREVIEW_MODE") ?: true,
-            hostAppUserAgentInfo    : property("HOST_APP_UA_INFO") ?: "MiniApp Demo App/$project.version",
-            projectId               : property("HOST_PROJECT_ID") ?: "test-host-project-id",
-            subscriptionKey         : property("HOST_APP_SUBSCRIPTION_KEY") ?: "test-subs-key",
-            adMobAppId              : property("ADMOB_APP_ID") ?: "",
-            appName                 : defaultAppName + " STG"
-    ]
+    def stagingManifestPlaceholders = debugManifestPlaceholders.clone()
+    stagingManifestPlaceholders.appName = defaultAppName + " STG"
     def prodManifestPlaceholders = [
             baseUrl                 : property("MINIAPP_PROD_SERVER_BASE_URL") ?: "https://www.example.com/",
             isPreviewMode           : property("PROD_IS_PREVIEW_MODE") ?: true,

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:name="com.rakuten.tech.mobile.testapp.SampleApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
+        android:label="@string/hostapp_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:name="com.rakuten.tech.mobile.testapp.SampleApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/hostapp_name"
+        android:label="${appName}"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <resources>
+    <string name="hostapp_name">MiniApp Sample</string>
+
     <string name="lb_version">Version</string>
     <string name="lb_description">Description</string>
     <string name="lb_app_id">App ID</string>

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="hostapp_name">MiniApp Sample</string>
-
     <string name="lb_version">Version</string>
     <string name="lb_description">Description</string>
     <string name="lb_app_id">App ID</string>

--- a/testapp/src/main/res/xml/searchable.xml
+++ b/testapp/src/main/res/xml/searchable.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <searchable xmlns:android="http://schemas.android.com/apk/res/android"
   android:hint="@string/menu_hint_search_miniapps"
-  android:label="@string/app_name" />
+  android:label="@string/hostapp_name" />

--- a/testapp/src/main/res/xml/searchable.xml
+++ b/testapp/src/main/res/xml/searchable.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <searchable xmlns:android="http://schemas.android.com/apk/res/android"
   android:hint="@string/menu_hint_search_miniapps"
-  android:label="@string/hostapp_name" />
+  android:label="@string/menu_hint_search_miniapps" />


### PR DESCRIPTION
# Description
- Remove "app_name" resource from `miniapp/src/main/res/values/strings.xml`.

## Links
- MINI-2227

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
