### PR TITLE
fix: disable google backup for shared preferences

### DIFF
--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -8,8 +8,7 @@
 
     <application
         android:name="com.rakuten.tech.mobile.testapp.SampleApplication"
-        android:allowBackup="true"
-        android:fullBackupContent="@xml/data_backup_rules"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <application
         android:name="com.rakuten.tech.mobile.testapp.SampleApplication"
         android:allowBackup="true"
+        android:fullBackupContent="@xml/data_backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/testapp/src/main/res/xml/data_backup_rules.xml
+++ b/testapp/src/main/res/xml/data_backup_rules.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<full-backup-content>
-  <exclude domain="sharedpref" path="."/>
-</full-backup-content>

--- a/testapp/src/main/res/xml/data_backup_rules.xml
+++ b/testapp/src/main/res/xml/data_backup_rules.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+  <exclude domain="sharedpref" path="."/>
+</full-backup-content>


### PR DESCRIPTION
# Description
`android:allowBackup="true"` is using for Google backup which can be seen in Google drive. Data of AppSettings is storing in Shared preferences which is [one of the files to backup](https://developer.android.com/guide/topics/data/autobackup.html#Files). There is might unexpected behavior when we change these settings in new releases of the Demo App. In this case, we can restrict the rule for Shared preferences not to do auto-backup in Google drive. This PR aims to bring a solution for this. 

However, I was checking [the document ](https://developer.android.com/guide/topics/data/autobackup#XMLSyntax)if there is something to specify the data from AppSettings, I think, they only support files/folders to exclude. 

```
<exclude> - Specifies a file or folder to exclude during backup. Here are some files that are typically excluded from backup:
```

So, I have excluded all shared preferences data in the rule.

## Links
- MINI-2258

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
