### PR TITLE
fix: retrieve location correctly in geo location flow

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
@@ -11,7 +11,7 @@ import java.util.UUID
 
 internal class MiniAppHttpWebView(
     context: Context,
-    miniAppTitle: String,
+    miniAppInfo: MiniAppInfo,
     val appUrl: String,
     miniAppMessageBridge: MiniAppMessageBridge,
     miniAppNavigator: MiniAppNavigator?,
@@ -19,7 +19,7 @@ internal class MiniAppHttpWebView(
     miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
     miniAppWebChromeClient: MiniAppWebChromeClient = MiniAppWebChromeClient(
         context,
-        miniAppTitle,
+        miniAppInfo,
         miniAppCustomPermissionCache
     )
 ) : MiniAppWebView(

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
@@ -50,7 +50,7 @@ internal class MiniAppHttpWebView(
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        miniAppCustomPermissionCache.removeId(miniAppId)
+        miniAppCustomPermissionCache.removePermission(miniAppId)
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
@@ -16,8 +16,12 @@ internal class MiniAppHttpWebView(
     miniAppMessageBridge: MiniAppMessageBridge,
     miniAppNavigator: MiniAppNavigator?,
     hostAppUserAgentInfo: String,
-    miniAppWebChromeClient: MiniAppWebChromeClient = MiniAppWebChromeClient(context, miniAppTitle),
-    miniAppCustomPermissionCache: MiniAppCustomPermissionCache
+    miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
+    miniAppWebChromeClient: MiniAppWebChromeClient = MiniAppWebChromeClient(
+        context,
+        miniAppTitle,
+        miniAppCustomPermissionCache
+    )
 ) : MiniAppWebView(
     context,
     "",
@@ -25,8 +29,8 @@ internal class MiniAppHttpWebView(
     miniAppMessageBridge,
     miniAppNavigator,
     hostAppUserAgentInfo,
-    miniAppWebChromeClient,
-    miniAppCustomPermissionCache
+    miniAppCustomPermissionCache,
+    miniAppWebChromeClient
 ) {
     init {
         miniAppScheme = MiniAppScheme.schemeWithCustomUrl(appUrl)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
@@ -2,7 +2,6 @@ package com.rakuten.tech.mobile.miniapp.display
 
 import android.app.Activity
 import android.content.Context
-import android.content.pm.PackageManager
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.GeolocationPermissions
@@ -12,7 +11,6 @@ import android.webkit.WebChromeClient
 import android.webkit.WebView
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
-import androidx.core.app.ActivityCompat
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.js.DialogType
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
@@ -52,12 +50,8 @@ internal class MiniAppWebChromeClient(
                 }?.let {
                     it.second == MiniAppCustomPermissionResult.ALLOWED
                 }
-        val hasDevicePermission = ActivityCompat.checkSelfPermission(
-            context,
-            android.Manifest.permission.ACCESS_FINE_LOCATION
-        ) == PackageManager.PERMISSION_GRANTED
-        val allow = hasCustomPermission!! && hasDevicePermission
-        callback?.invoke(origin, allow, false)
+
+        callback?.invoke(origin, hasCustomPermission!!, false)
     }
 
     override fun onJsAlert(

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
@@ -2,6 +2,7 @@ package com.rakuten.tech.mobile.miniapp.display
 
 import android.app.Activity
 import android.content.Context
+import android.content.pm.PackageManager
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.GeolocationPermissions
@@ -11,6 +12,7 @@ import android.webkit.WebChromeClient
 import android.webkit.WebView
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
+import androidx.core.app.ActivityCompat
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.js.DialogType
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
@@ -43,14 +45,19 @@ internal class MiniAppWebChromeClient(
         origin: String?,
         callback: GeolocationPermissions.Callback?
     ) {
-        val hasLocationCustomPermission =
+        val hasCustomPermission =
             miniAppCustomPermissionCache.readPermissions(miniAppInfo.id)
                 .pairValues.find {
                     it.first == MiniAppCustomPermissionType.LOCATION
                 }?.let {
                     it.second == MiniAppCustomPermissionResult.ALLOWED
                 }
-        callback?.invoke(origin, hasLocationCustomPermission!!, false)
+        val hasDevicePermission = ActivityCompat.checkSelfPermission(
+            context,
+            android.Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
+        val allow = hasCustomPermission!! && hasDevicePermission
+        callback?.invoke(origin, allow, false)
     }
 
     override fun onJsAlert(

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
@@ -51,7 +51,8 @@ internal class MiniAppWebChromeClient(
                     it.second == MiniAppCustomPermissionResult.ALLOWED
                 }
 
-        callback?.invoke(origin, hasCustomPermission!!, false)
+        if (hasCustomPermission!!) callback?.invoke(origin, true, false)
+        else callback?.invoke(origin, false, false)
     }
 
     override fun onJsAlert(

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -32,7 +32,7 @@ internal open class MiniAppWebView(
     val miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
     val miniAppWebChromeClient: MiniAppWebChromeClient = MiniAppWebChromeClient(
         context,
-        miniAppInfo.displayName,
+        miniAppInfo,
         miniAppCustomPermissionCache
     )
 ) : WebView(context), WebViewListener {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -29,8 +29,12 @@ internal open class MiniAppWebView(
     val miniAppMessageBridge: MiniAppMessageBridge,
     var miniAppNavigator: MiniAppNavigator?,
     val hostAppUserAgentInfo: String,
-    val miniAppWebChromeClient: MiniAppWebChromeClient = MiniAppWebChromeClient(context, miniAppInfo.displayName),
-    val miniAppCustomPermissionCache: MiniAppCustomPermissionCache
+    val miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
+    val miniAppWebChromeClient: MiniAppWebChromeClient = MiniAppWebChromeClient(
+        context,
+        miniAppInfo.displayName,
+        miniAppCustomPermissionCache
+    )
 ) : WebView(context), WebViewListener {
 
     protected var miniAppScheme = MiniAppScheme.schemeWithAppId(miniAppInfo.id)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
@@ -95,7 +95,7 @@ internal class RealMiniAppDisplay(
             if (appUrl != null) {
                 miniAppWebView = MiniAppHttpWebView(
                     context = context,
-                    miniAppTitle = "Mini app",
+                    miniAppInfo = miniAppInfo,
                     appUrl = appUrl!!,
                     miniAppMessageBridge = miniAppMessageBridge,
                     miniAppNavigator = miniAppNavigator,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -50,6 +50,7 @@ abstract class MiniAppMessageBridge {
             customPermissionCache,
             miniAppId
         )
+
         this.customPermissionWindow = MiniAppCustomPermissionWindow(
             activity,
             customPermissionBridgeDispatcher

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -50,7 +50,6 @@ abstract class MiniAppMessageBridge {
             customPermissionCache,
             miniAppId
         )
-
         this.customPermissionWindow = MiniAppCustomPermissionWindow(
             activity,
             customPermissionBridgeDispatcher

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
@@ -96,7 +96,11 @@ internal class MiniAppCustomPermissionCache(context: Context) {
         applyStoringPermissions(MiniAppCustomPermission(miniAppId, allPermissions))
     }
 
-    fun removeId(miniAppId: String) {
+    /**
+     * Remove the grant results per MiniApp from SharedPreferences.
+     * @param [miniAppId] the key provided to find the stored results per MiniApp.
+     */
+    fun removePermission(miniAppId: String) {
         prefs.edit().remove(miniAppId).apply()
     }
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -398,7 +398,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
     }
 
     @Test
-    fun `should invoke callback from onRequestPermissionsResult when it is called`() {
+    fun `should allow geolocation callback when custom permission is allowed`() {
         val locationCustomPermission = MiniAppCustomPermission(
             TEST_MA_ID,
             listOf(Pair(MiniAppCustomPermissionType.LOCATION, MiniAppCustomPermissionResult.ALLOWED))
@@ -415,6 +415,26 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
         webChromeClient.onGeolocationPermissionsShowPrompt("", geoLocationCallback)
 
         verify(geoLocationCallback, times(1)).invoke("", true, false)
+    }
+
+    @Test
+    fun `should not allow geolocation callback when custom permission is denied`() {
+        val locationCustomPermission = MiniAppCustomPermission(
+            TEST_MA_ID,
+            listOf(Pair(MiniAppCustomPermissionType.LOCATION, MiniAppCustomPermissionResult.DENIED))
+        )
+        doReturn(locationCustomPermission).whenever(miniAppCustomPermissionCache)
+            .readPermissions(TEST_MA_ID)
+
+        val geoLocationCallback = Mockito.spy(
+            GeolocationPermissions.Callback { _, allow, retain ->
+                allow shouldBe false
+                retain shouldBe false
+            }
+        )
+        webChromeClient.onGeolocationPermissionsShowPrompt("", geoLocationCallback)
+
+        verify(geoLocationCallback, times(1)).invoke("", false, false)
     }
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -92,7 +92,7 @@ class MiniAppHTTPWebViewSpec : BaseWebViewSpec() {
     @Test
     fun `should remove cached permission data when window is closed`() {
         (miniAppWebView as MiniAppHttpWebView).callOnDetached()
-        verify(miniAppCustomPermissionCache, times(1)).removeId(anyString())
+        verify(miniAppCustomPermissionCache, times(1)).removePermission(anyString())
     }
 }
 
@@ -401,20 +401,20 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
     fun `should invoke callback from onRequestPermissionsResult when it is called`() {
         val locationCustomPermission = MiniAppCustomPermission(
             TEST_MA_ID,
-            listOf(Pair(MiniAppCustomPermissionType.LOCATION, MiniAppCustomPermissionResult.ALLOWED))
+            listOf(Pair(MiniAppCustomPermissionType.LOCATION, MiniAppCustomPermissionResult.DENIED))
         )
         doReturn(locationCustomPermission).whenever(miniAppCustomPermissionCache)
             .readPermissions(TEST_MA_ID)
 
         val geoLocationCallback = Mockito.spy(
             GeolocationPermissions.Callback { _, allow, retain ->
-                allow shouldBe true
+                allow shouldBe false
                 retain shouldBe false
             }
         )
         webChromeClient.onGeolocationPermissionsShowPrompt("", geoLocationCallback)
 
-        verify(geoLocationCallback, times(1)).invoke("", true, false)
+        verify(geoLocationCallback, times(1)).invoke("", false, false)
     }
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -401,7 +401,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
     fun `should invoke callback from onRequestPermissionsResult when it is called`() {
         val locationCustomPermission = MiniAppCustomPermission(
             TEST_MA_ID,
-            listOf(Pair(MiniAppCustomPermissionType.LOCATION, MiniAppCustomPermissionResult.DENIED))
+            listOf(Pair(MiniAppCustomPermissionType.LOCATION, MiniAppCustomPermissionResult.ALLOWED))
         )
         doReturn(locationCustomPermission).whenever(miniAppCustomPermissionCache)
             .readPermissions(TEST_MA_ID)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -408,13 +408,13 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
 
         val geoLocationCallback = Mockito.spy(
             GeolocationPermissions.Callback { _, allow, retain ->
-                allow shouldBe false
+                allow shouldBe true
                 retain shouldBe false
             }
         )
         webChromeClient.onGeolocationPermissionsShowPrompt("", geoLocationCallback)
 
-        verify(geoLocationCallback, times(1)).invoke("", false, false)
+        verify(geoLocationCallback, times(1)).invoke("", true, false)
     }
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
@@ -87,7 +87,7 @@ class MiniAppCustomPermissionCacheSpec {
 
     @Test
     fun `removeId will remove all permission data from the store`() {
-        miniAppCustomPermissionCache.removeId(TEST_MA_ID)
+        miniAppCustomPermissionCache.removePermission(TEST_MA_ID)
         verify(mockEditor, times(1)).remove(TEST_MA_ID)
     }
 


### PR DESCRIPTION
# Description
Fix issue when location was showing during custom permission is denied but device permission is allowed. It seems that `onGeolocationPermissionsShowPrompt` has an intention to check permission state for `android.permission.ACCESS_FINE_LOCATION`, so we should add a barricade of custom permission while invoking the permission which affects Geolocation API. 

Initially, I intended to show dialogs for both device and custom permission before executing `GeolocationPermissions.Callback?.invoke(origin, true, false)`, but it seems the checkup of JS SDK is already enough. So, in Android side, I have used the value of custom permission under `onGeolocationPermissionsShowPrompt` at runtime.

## Links
- MINI-2314

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
