### PR TITLE
refactor: add permission checkup in onGetContacts in UserInfoBridgeDispatcher

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
@@ -43,15 +43,11 @@ internal class MiniAppWebChromeClient(
         origin: String?,
         callback: GeolocationPermissions.Callback?
     ) {
-        val hasCustomPermission =
-            miniAppCustomPermissionCache.readPermissions(miniAppInfo.id)
-                .pairValues.find {
-                    it.first == MiniAppCustomPermissionType.LOCATION
-                }?.let {
-                    it.second == MiniAppCustomPermissionResult.ALLOWED
-                }
-
-        if (hasCustomPermission!!) callback?.invoke(origin, true, false)
+        if (miniAppCustomPermissionCache.hasPermission(
+                miniAppInfo.id,
+                MiniAppCustomPermissionType.LOCATION
+            )
+        ) callback?.invoke(origin, true, false)
         else callback?.invoke(origin, false, false)
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
@@ -14,7 +14,6 @@ import androidx.annotation.VisibleForTesting
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.js.DialogType
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
-import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionResult
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
 import java.io.BufferedReader
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
@@ -64,12 +64,11 @@ abstract class UserInfoBridgeDispatcher {
 
     internal fun onGetUserName(callbackId: String) {
         try {
-            val isPermissionGranted = customPermissionCache.hasPermission(
-                miniAppId,
-                MiniAppCustomPermissionType.USER_NAME
-            )
-
-            if (isPermissionGranted) {
+            if (customPermissionCache.hasPermission(
+                    miniAppId,
+                    MiniAppCustomPermissionType.USER_NAME
+                )
+            ) {
                 val name = getUserName()
                 if (name.isNotEmpty()) bridgeExecutor.postValue(callbackId, name)
                 else bridgeExecutor.postError(
@@ -88,12 +87,11 @@ abstract class UserInfoBridgeDispatcher {
 
     internal fun onGetProfilePhoto(callbackId: String) {
         try {
-            val isPermissionGranted = customPermissionCache.hasPermission(
-                miniAppId,
-                MiniAppCustomPermissionType.PROFILE_PHOTO
-            )
-
-            if (isPermissionGranted) {
+            if (customPermissionCache.hasPermission(
+                    miniAppId,
+                    MiniAppCustomPermissionType.PROFILE_PHOTO
+                )
+            ) {
                 val photoUrl = getProfilePhoto()
                 if (photoUrl.isNotEmpty())
                     bridgeExecutor.postValue(callbackId, photoUrl)
@@ -125,11 +123,10 @@ abstract class UserInfoBridgeDispatcher {
     }
 
     internal fun onGetContacts(callbackId: String) = try {
-        val isPermissionGranted = customPermissionCache.hasPermission(
-            miniAppId, MiniAppCustomPermissionType.CONTACT_LIST
-        )
-
-        if (isPermissionGranted) {
+        if (customPermissionCache.hasPermission(
+                miniAppId, MiniAppCustomPermissionType.CONTACT_LIST
+            )
+        ) {
             val successCallback = { contacts: ArrayList<Contact> ->
                 bridgeExecutor.postValue(callbackId, Gson().toJson(contacts))
             }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcher.kt
@@ -64,11 +64,8 @@ internal class CustomPermissionBridgeDispatcher(
     fun filterDeniedPermissions(): List<Pair<MiniAppCustomPermissionType, String>> {
         if (permissionsWithDescription.isEmpty()) return emptyList()
 
-        val cachedList = customPermissionCache.readPermissions(miniAppId).pairValues
         return permissionsWithDescription.filter { (first) ->
-            cachedList.find {
-                it.first == first && it.second == MiniAppCustomPermissionResult.DENIED
-            } != null
+            !customPermissionCache.hasPermission(miniAppId, first)
         }
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
@@ -133,6 +133,21 @@ internal class MiniAppCustomPermissionCache(context: Context) {
     }
 
     /**
+     * Check if any specific custom permission has been allowed or denied
+     * @param [miniAppId] the key provided to find the stored results per MiniApp
+     * @param [type] MiniAppCustomPermissionType to check
+     * @return [Boolean] True if the permission has been allowed, otherwise false
+     */
+    fun hasPermission(miniAppId: String, type: MiniAppCustomPermissionType): Boolean {
+        var isPermissionGranted = false
+        readPermissions(miniAppId).pairValues.find {
+            it.first == type && it.second == MiniAppCustomPermissionResult.ALLOWED
+        }?.let { isPermissionGranted = true }
+
+        return isPermissionGranted
+    }
+
+    /**
      * Note: Update this default list when adding or removing a custom permission,
      * [MiniAppCustomPermissionCache] should automatically handle the value.
      */

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
@@ -133,10 +133,10 @@ internal class MiniAppCustomPermissionCache(context: Context) {
     }
 
     /**
-     * Check if any specific custom permission has been allowed or denied
-     * @param [miniAppId] the key provided to find the stored results per MiniApp
-     * @param [type] MiniAppCustomPermissionType to check
-     * @return [Boolean] True if the permission has been allowed, otherwise false
+     * Check if any specific custom permission has been allowed or denied.
+     * @param [miniAppId] the key provided to find the stored results per MiniApp.
+     * @param [type] MiniAppCustomPermissionType to check.
+     * @return [Boolean] True if the permission has been allowed, otherwise false.
      */
     fun hasPermission(miniAppId: String, type: MiniAppCustomPermissionType): Boolean {
         var isPermissionGranted = false

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -24,9 +24,7 @@ import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.miniapp.navigator.ExternalResultHandler
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppExternalUrlLoader
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
-import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermission
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
-import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionResult
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
 import org.amshove.kluent.*
 import org.junit.Before

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -399,12 +399,8 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
 
     @Test
     fun `should allow geolocation callback when custom permission is allowed`() {
-        val locationCustomPermission = MiniAppCustomPermission(
-            TEST_MA_ID,
-            listOf(Pair(MiniAppCustomPermissionType.LOCATION, MiniAppCustomPermissionResult.ALLOWED))
-        )
-        doReturn(locationCustomPermission).whenever(miniAppCustomPermissionCache)
-            .readPermissions(TEST_MA_ID)
+        doReturn(true).whenever(miniAppCustomPermissionCache)
+            .hasPermission(TEST_MA_ID, MiniAppCustomPermissionType.LOCATION)
 
         val geoLocationCallback = Mockito.spy(
             GeolocationPermissions.Callback { _, allow, retain ->
@@ -419,12 +415,8 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
 
     @Test
     fun `should not allow geolocation callback when custom permission is denied`() {
-        val locationCustomPermission = MiniAppCustomPermission(
-            TEST_MA_ID,
-            listOf(Pair(MiniAppCustomPermissionType.LOCATION, MiniAppCustomPermissionResult.DENIED))
-        )
-        doReturn(locationCustomPermission).whenever(miniAppCustomPermissionCache)
-            .readPermissions(TEST_MA_ID)
+        doReturn(false).whenever(miniAppCustomPermissionCache)
+            .hasPermission(TEST_MA_ID, MiniAppCustomPermissionType.LOCATION)
 
         val geoLocationCallback = Mockito.spy(
             GeolocationPermissions.Callback { _, allow, retain ->

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
@@ -102,9 +102,8 @@ class UserInfoBridgeDispatcherSpec {
     @Test
     fun `postError should be called when there is no get user name retrieval implementation`() {
         val userInfoBridgeDispatcher = Mockito.spy(createUserNameImpl(false))
-        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
+        userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
         miniAppBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)
-
         val errMsg = "$ERR_GET_USER_NAME The `UserInfoBridgeDispatcher.getUserName`" +
                 " method has not been implemented by the Host App."
         miniAppBridge.postMessage(Gson().toJson(userNameCallbackObj))
@@ -115,14 +114,13 @@ class UserInfoBridgeDispatcherSpec {
     @Test
     fun `postError should be called when user name permission hasn't been allowed`() {
         val userInfoBridgeDispatcher = Mockito.spy(createUserNameImpl(true))
-        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
-
+        userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
         val errMsg = "$ERR_GET_USER_NAME Permission has not been accepted yet for getting user name."
         whenever(customPermissionCache.hasPermission(
             miniAppInfo.id, MiniAppCustomPermissionType.USER_NAME)
         ).thenReturn(false)
 
-        userInfoBridgeDispatcher?.onGetUserName(userNameCallbackObj.id)
+        userInfoBridgeDispatcher.onGetUserName(userNameCallbackObj.id)
 
         verify(bridgeExecutor).postError(userNameCallbackObj.id, errMsg)
     }
@@ -130,11 +128,10 @@ class UserInfoBridgeDispatcherSpec {
     @Test
     fun `postError should be called when user name is empty`() {
         val userInfoBridgeDispatcher = Mockito.spy(createUserNameImpl(true))
-        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
-
+        userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
         val errMsg = "$ERR_GET_USER_NAME User name is not found."
 
-        userInfoBridgeDispatcher?.onGetUserName(userNameCallbackObj.id)
+        userInfoBridgeDispatcher.onGetUserName(userNameCallbackObj.id)
 
         verify(bridgeExecutor).postError(userNameCallbackObj.id, errMsg)
     }
@@ -142,11 +139,10 @@ class UserInfoBridgeDispatcherSpec {
     @Test
     fun `postValue should be called when onGetUserName retrieve valid user name`() {
         val userInfoBridgeDispatcher = Mockito.spy(createUserNameImpl(true))
-        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
+        userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
+        whenever(userInfoBridgeDispatcher.getUserName()).thenReturn(TEST_USER_NAME)
 
-        whenever(userInfoBridgeDispatcher?.getUserName()).thenReturn(TEST_USER_NAME)
-
-        userInfoBridgeDispatcher?.onGetUserName(userNameCallbackObj.id)
+        userInfoBridgeDispatcher.onGetUserName(userNameCallbackObj.id)
 
         verify(bridgeExecutor).postValue(userNameCallbackObj.id, TEST_USER_NAME)
     }
@@ -166,9 +162,8 @@ class UserInfoBridgeDispatcherSpec {
     @Test
     fun `postError should be called when there is no get profile photo retrieval implementation`() {
         val userInfoBridgeDispatcher = Mockito.spy(createProfilePhotoImpl(false))
-        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
+        userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
         miniAppBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)
-
         val errMsg = "$ERR_GET_PROFILE_PHOTO The `UserInfoBridgeDispatcher.getProfilePhoto`" +
                 " method has not been implemented by the Host App."
         miniAppBridge.postMessage(Gson().toJson(profilePhotoCallbackObj))
@@ -179,13 +174,13 @@ class UserInfoBridgeDispatcherSpec {
     @Test
     fun `postError should be called when profile photo permission hasn't been allowed`() {
         val userInfoBridgeDispatcher = Mockito.spy(createProfilePhotoImpl(true))
-        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
+        userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
         val errMsg = "$ERR_GET_PROFILE_PHOTO Permission has not been accepted yet for getting profile photo."
         whenever(customPermissionCache.hasPermission(
             miniAppInfo.id, MiniAppCustomPermissionType.PROFILE_PHOTO)
         ).thenReturn(false)
 
-        userInfoBridgeDispatcher?.onGetProfilePhoto(profilePhotoCallbackObj.id)
+        userInfoBridgeDispatcher.onGetProfilePhoto(profilePhotoCallbackObj.id)
 
         verify(bridgeExecutor).postError(profilePhotoCallbackObj.id, errMsg)
     }
@@ -193,10 +188,10 @@ class UserInfoBridgeDispatcherSpec {
     @Test
     fun `postError should be called when profile photo is empty`() {
         val userInfoBridgeDispatcher = Mockito.spy(createProfilePhotoImpl(true))
-        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
+        userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
         val errMsg = "$ERR_GET_PROFILE_PHOTO Profile photo is not found."
 
-        userInfoBridgeDispatcher?.onGetProfilePhoto(profilePhotoCallbackObj.id)
+        userInfoBridgeDispatcher.onGetProfilePhoto(profilePhotoCallbackObj.id)
 
         verify(bridgeExecutor).postError(profilePhotoCallbackObj.id, errMsg)
     }
@@ -204,10 +199,10 @@ class UserInfoBridgeDispatcherSpec {
     @Test
     fun `postValue should be called when onGetProfilePhoto retrieve valid profile photo url`() {
         val userInfoBridgeDispatcher = Mockito.spy(createProfilePhotoImpl(true))
-        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
-        whenever(userInfoBridgeDispatcher?.getProfilePhoto()).thenReturn(TEST_PROFILE_PHOTO)
+        userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
+        whenever(userInfoBridgeDispatcher.getProfilePhoto()).thenReturn(TEST_PROFILE_PHOTO)
 
-        userInfoBridgeDispatcher?.onGetProfilePhoto(profilePhotoCallbackObj.id)
+        userInfoBridgeDispatcher.onGetProfilePhoto(profilePhotoCallbackObj.id)
 
         verify(bridgeExecutor).postValue(profilePhotoCallbackObj.id, TEST_PROFILE_PHOTO)
     }
@@ -241,7 +236,7 @@ class UserInfoBridgeDispatcherSpec {
     @Test
     fun `postError should be called when there is no access token retrieval implementation`() {
         val userInfoBridgeDispatcher = Mockito.spy(createAccessTokenImpl(false, false))
-        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
+        userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
         miniAppBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)
         val errMsg = "$ERR_GET_ACCESS_TOKEN The `UserInfoBridgeDispatcher.getAccessToken`" +
                 " method has not been implemented by the Host App."
@@ -298,7 +293,7 @@ class UserInfoBridgeDispatcherSpec {
     @Test
     fun `postError should be called when there is no get contacts retrieval implementation`() {
         val userInfoBridgeDispatcher = Mockito.spy(createContactsImpl(false, false))
-        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
+        userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
         miniAppBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)
         val errMsg = "$ERR_GET_CONTACTS The `UserInfoBridgeDispatcher.getContacts`" +
                 " method has not been implemented by the Host App."
@@ -310,7 +305,7 @@ class UserInfoBridgeDispatcherSpec {
     @Test
     fun `postError should be called when contact permission hasn't been allowed`() {
         val userInfoBridgeDispatcher = Mockito.spy(createContactsImpl(true, true))
-        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
+        userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
         val errMsg = "$ERR_GET_CONTACTS Permission has not been accepted yet for getting contacts."
         whenever(customPermissionCache.hasPermission(
             miniAppInfo.id, MiniAppCustomPermissionType.CONTACT_LIST)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
@@ -297,7 +297,7 @@ class UserInfoBridgeDispatcherSpec {
     }
 
     @Test
-    fun `postError should be called when get permission hasn't been allowed`() {
+    fun `postError should be called when contact permission hasn't been allowed`() {
         val errMsg = "$ERR_GET_CONTACTS Permission has not been accepted yet for getting contacts."
         val deniedContactsPermission = MiniAppCustomPermission(
             TEST_MA_ID,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
@@ -35,7 +35,6 @@ import java.util.ArrayList
 @Suppress("LongMethod", "LargeClass")
 @RunWith(AndroidJUnit4::class)
 class UserInfoBridgeDispatcherSpec {
-    private lateinit var userInfoBridgeDispatcher: UserInfoBridgeDispatcher
     private lateinit var miniAppBridge: MiniAppMessageBridge
     private val userNameCallbackObj = CallbackObj(
         action = ActionType.GET_USER_NAME.action,
@@ -64,20 +63,6 @@ class UserInfoBridgeDispatcherSpec {
         icon = TEST_MA_ICON,
         version = Version(TEST_MA_VERSION_TAG, TEST_MA_VERSION_ID)
     )
-    private val userInfoAllowedPermission = MiniAppCustomPermission(
-        TEST_MA_ID,
-        listOf(
-            Pair(
-                MiniAppCustomPermissionType.USER_NAME,
-                MiniAppCustomPermissionResult.ALLOWED
-            ),
-            Pair(
-                MiniAppCustomPermissionType.PROFILE_PHOTO,
-                MiniAppCustomPermissionResult.ALLOWED
-            )
-        )
-    )
-
     private val webViewListener: WebViewListener = mock()
     private val bridgeExecutor = Mockito.spy(MiniAppBridgeExecutor(webViewListener))
 
@@ -91,69 +76,101 @@ class UserInfoBridgeDispatcherSpec {
             customPermissionCache = customPermissionCache,
             miniAppId = TEST_MA.id
         )
-        userInfoBridgeDispatcher = Mockito.spy(createUserInfoBridgeDispatcher())
-        miniAppBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)
+
+        whenever(customPermissionCache.hasPermission(
+            miniAppInfo.id, MiniAppCustomPermissionType.USER_NAME)
+        ).thenReturn(true)
+        whenever(customPermissionCache.hasPermission(
+            miniAppInfo.id, MiniAppCustomPermissionType.PROFILE_PHOTO)
+        ).thenReturn(true)
+        whenever(customPermissionCache.hasPermission(
+            miniAppInfo.id, MiniAppCustomPermissionType.CONTACT_LIST)
+        ).thenReturn(true)
     }
 
     /** start region: onGetUserName */
+    private fun createUserNameImpl(hasUserName: Boolean): UserInfoBridgeDispatcher {
+        return if (hasUserName) {
+            object : UserInfoBridgeDispatcher() {
+                override fun getUserName(): String = ""
+            }
+        } else {
+            object : UserInfoBridgeDispatcher() {}
+        }
+    }
+
     @Test
-    fun `postError should be called when cannot get user name`() {
-        val errMsg = "$ERR_GET_USER_NAME null"
+    fun `postError should be called when there is no get user name retrieval implementation`() {
+        val userInfoBridgeDispatcher = Mockito.spy(createUserNameImpl(false))
+        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
+        miniAppBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)
+
+        val errMsg = "$ERR_GET_USER_NAME The `UserInfoBridgeDispatcher.getUserName`" +
+                " method has not been implemented by the Host App."
         miniAppBridge.postMessage(Gson().toJson(userNameCallbackObj))
 
-        verify(bridgeExecutor).postError(profilePhotoCallbackObj.id, errMsg)
+        verify(bridgeExecutor).postError(userNameCallbackObj.id, errMsg)
     }
 
     @Test
     fun `postError should be called when user name permission hasn't been allowed`() {
-        val errMsg = "$ERR_GET_USER_NAME Permission has not been accepted yet for getting user name."
-        val deniedUserNamePermission = MiniAppCustomPermission(
-            TEST_MA_ID,
-            listOf(
-                Pair(
-                    MiniAppCustomPermissionType.USER_NAME,
-                    MiniAppCustomPermissionResult.DENIED
-                )
-            )
-        )
-        whenever(customPermissionCache.readPermissions(miniAppInfo.id)).thenReturn(
-            deniedUserNamePermission
-        )
+        val userInfoBridgeDispatcher = Mockito.spy(createUserNameImpl(true))
+        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
 
-        userInfoBridgeDispatcher.onGetUserName(userNameCallbackObj.id)
+        val errMsg = "$ERR_GET_USER_NAME Permission has not been accepted yet for getting user name."
+        whenever(customPermissionCache.hasPermission(
+            miniAppInfo.id, MiniAppCustomPermissionType.USER_NAME)
+        ).thenReturn(false)
+
+        userInfoBridgeDispatcher?.onGetUserName(userNameCallbackObj.id)
 
         verify(bridgeExecutor).postError(userNameCallbackObj.id, errMsg)
     }
 
     @Test
     fun `postError should be called when user name is empty`() {
-        val errMsg = "$ERR_GET_USER_NAME User name is not found."
-        whenever(customPermissionCache.readPermissions(miniAppInfo.id)).thenReturn(
-            userInfoAllowedPermission
-        )
+        val userInfoBridgeDispatcher = Mockito.spy(createUserNameImpl(true))
+        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
 
-        userInfoBridgeDispatcher.onGetUserName(userNameCallbackObj.id)
+        val errMsg = "$ERR_GET_USER_NAME User name is not found."
+
+        userInfoBridgeDispatcher?.onGetUserName(userNameCallbackObj.id)
 
         verify(bridgeExecutor).postError(userNameCallbackObj.id, errMsg)
     }
 
     @Test
     fun `postValue should be called when onGetUserName retrieve valid user name`() {
-        whenever(customPermissionCache.readPermissions(miniAppInfo.id)).thenReturn(
-            userInfoAllowedPermission
-        )
-        whenever(userInfoBridgeDispatcher.getUserName()).thenReturn(TEST_USER_NAME)
+        val userInfoBridgeDispatcher = Mockito.spy(createUserNameImpl(true))
+        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
 
-        userInfoBridgeDispatcher.onGetUserName(userNameCallbackObj.id)
+        whenever(userInfoBridgeDispatcher?.getUserName()).thenReturn(TEST_USER_NAME)
+
+        userInfoBridgeDispatcher?.onGetUserName(userNameCallbackObj.id)
 
         verify(bridgeExecutor).postValue(userNameCallbackObj.id, TEST_USER_NAME)
     }
     /** end region */
 
     /** start region: onGetProfilePhoto */
+    private fun createProfilePhotoImpl(hasProfilePhoto: Boolean): UserInfoBridgeDispatcher {
+        return if (hasProfilePhoto) {
+            object : UserInfoBridgeDispatcher() {
+                override fun getProfilePhoto(): String = ""
+            }
+        } else {
+            object : UserInfoBridgeDispatcher() {}
+        }
+    }
+
     @Test
-    fun `postError should be called when cannot get profile photo`() {
-        val errMsg = "$ERR_GET_PROFILE_PHOTO null"
+    fun `postError should be called when there is no get profile photo retrieval implementation`() {
+        val userInfoBridgeDispatcher = Mockito.spy(createProfilePhotoImpl(false))
+        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
+        miniAppBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)
+
+        val errMsg = "$ERR_GET_PROFILE_PHOTO The `UserInfoBridgeDispatcher.getProfilePhoto`" +
+                " method has not been implemented by the Host App."
         miniAppBridge.postMessage(Gson().toJson(profilePhotoCallbackObj))
 
         verify(bridgeExecutor).postError(profilePhotoCallbackObj.id, errMsg)
@@ -161,45 +178,36 @@ class UserInfoBridgeDispatcherSpec {
 
     @Test
     fun `postError should be called when profile photo permission hasn't been allowed`() {
+        val userInfoBridgeDispatcher = Mockito.spy(createProfilePhotoImpl(true))
+        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
         val errMsg = "$ERR_GET_PROFILE_PHOTO Permission has not been accepted yet for getting profile photo."
-        val deniedProfilePhotoPermission = MiniAppCustomPermission(
-            TEST_MA_ID,
-            listOf(
-                Pair(
-                    MiniAppCustomPermissionType.PROFILE_PHOTO,
-                    MiniAppCustomPermissionResult.DENIED
-                )
-            )
-        )
-        whenever(customPermissionCache.readPermissions(miniAppInfo.id)).thenReturn(
-            deniedProfilePhotoPermission
-        )
+        whenever(customPermissionCache.hasPermission(
+            miniAppInfo.id, MiniAppCustomPermissionType.PROFILE_PHOTO)
+        ).thenReturn(false)
 
-        userInfoBridgeDispatcher.onGetProfilePhoto(profilePhotoCallbackObj.id)
+        userInfoBridgeDispatcher?.onGetProfilePhoto(profilePhotoCallbackObj.id)
 
         verify(bridgeExecutor).postError(profilePhotoCallbackObj.id, errMsg)
     }
 
     @Test
     fun `postError should be called when profile photo is empty`() {
+        val userInfoBridgeDispatcher = Mockito.spy(createProfilePhotoImpl(true))
+        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
         val errMsg = "$ERR_GET_PROFILE_PHOTO Profile photo is not found."
-        whenever(customPermissionCache.readPermissions(miniAppInfo.id)).thenReturn(
-            userInfoAllowedPermission
-        )
 
-        userInfoBridgeDispatcher.onGetProfilePhoto(profilePhotoCallbackObj.id)
+        userInfoBridgeDispatcher?.onGetProfilePhoto(profilePhotoCallbackObj.id)
 
         verify(bridgeExecutor).postError(profilePhotoCallbackObj.id, errMsg)
     }
 
     @Test
     fun `postValue should be called when onGetProfilePhoto retrieve valid profile photo url`() {
-        whenever(customPermissionCache.readPermissions(miniAppInfo.id)).thenReturn(
-            userInfoAllowedPermission
-        )
-        whenever(userInfoBridgeDispatcher.getProfilePhoto()).thenReturn(TEST_PROFILE_PHOTO)
+        val userInfoBridgeDispatcher = Mockito.spy(createProfilePhotoImpl(true))
+        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
+        whenever(userInfoBridgeDispatcher?.getProfilePhoto()).thenReturn(TEST_PROFILE_PHOTO)
 
-        userInfoBridgeDispatcher.onGetProfilePhoto(profilePhotoCallbackObj.id)
+        userInfoBridgeDispatcher?.onGetProfilePhoto(profilePhotoCallbackObj.id)
 
         verify(bridgeExecutor).postValue(profilePhotoCallbackObj.id, TEST_PROFILE_PHOTO)
     }
@@ -208,21 +216,33 @@ class UserInfoBridgeDispatcherSpec {
 
     /** start region: access token */
     private val testToken = TokenData("test_token", 0)
-    private fun createUserInfoImpl(canGetToken: Boolean) = object : UserInfoBridgeDispatcher() {
-        override fun getAccessToken(
-            miniAppId: String,
-            onSuccess: (tokenData: TokenData) -> Unit,
-            onError: (message: String) -> Unit
-        ) {
-            if (canGetToken)
-                onSuccess.invoke(testToken)
-            else
-                onError.invoke(TEST_ERROR_MSG)
+    private fun createAccessTokenImpl(
+        hasAccessToken: Boolean,
+        canGetToken: Boolean
+    ): UserInfoBridgeDispatcher {
+        return if (hasAccessToken) {
+            object : UserInfoBridgeDispatcher() {
+                override fun getAccessToken(
+                    miniAppId: String,
+                    onSuccess: (tokenData: TokenData) -> Unit,
+                    onError: (message: String) -> Unit
+                ) {
+                    if (canGetToken)
+                        onSuccess.invoke(testToken)
+                    else
+                        onError.invoke(TEST_ERROR_MSG)
+                }
+            }
+        } else {
+            object : UserInfoBridgeDispatcher() {}
         }
     }
 
     @Test
     fun `postError should be called when there is no access token retrieval implementation`() {
+        val userInfoBridgeDispatcher = Mockito.spy(createAccessTokenImpl(false, false))
+        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
+        miniAppBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)
         val errMsg = "$ERR_GET_ACCESS_TOKEN The `UserInfoBridgeDispatcher.getAccessToken`" +
                 " method has not been implemented by the Host App."
         miniAppBridge.postMessage(Gson().toJson(tokenCallbackObj))
@@ -233,7 +253,7 @@ class UserInfoBridgeDispatcherSpec {
     @Test
     fun `postError should be called when hostapp denies providing access token`() {
         val errMsg = "$ERR_GET_ACCESS_TOKEN $TEST_ERROR_MSG"
-        val userInfoBridgeDispatcher = Mockito.spy(createUserInfoImpl(false))
+        val userInfoBridgeDispatcher = Mockito.spy(createAccessTokenImpl(true, false))
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
 
         userInfoBridgeDispatcher.onGetAccessToken(tokenCallbackObj.id)
@@ -243,7 +263,7 @@ class UserInfoBridgeDispatcherSpec {
 
     @Test
     fun `postValue should be called when retrieve access token successfully`() {
-        val userInfoBridgeDispatcher = Mockito.spy(createUserInfoImpl(true))
+        val userInfoBridgeDispatcher = Mockito.spy(createAccessTokenImpl(true, true))
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
 
         userInfoBridgeDispatcher.onGetAccessToken(tokenCallbackObj.id)
@@ -254,20 +274,32 @@ class UserInfoBridgeDispatcherSpec {
 
     /** start region: get contacts */
     private val contacts = arrayListOf(Contact(TEST_CONTACT_ID))
-    private fun createUserInfoContactsImpl(hasContact: Boolean) = object : UserInfoBridgeDispatcher() {
-        override fun getContacts(
-            onSuccess: (contacts: ArrayList<Contact>) -> Unit,
-            onError: (message: String) -> Unit
-        ) {
-            if (hasContact)
-                onSuccess.invoke(contacts)
-            else
-                onError.invoke(TEST_ERROR_MSG)
+    private fun createContactsImpl(
+        hasGetContacts: Boolean,
+        canGetContacts: Boolean
+    ): UserInfoBridgeDispatcher {
+        return if (hasGetContacts) {
+            object : UserInfoBridgeDispatcher() {
+                override fun getContacts(
+                    onSuccess: (contacts: ArrayList<Contact>) -> Unit,
+                    onError: (message: String) -> Unit
+                ) {
+                    if (canGetContacts)
+                        onSuccess.invoke(contacts)
+                    else
+                        onError.invoke(TEST_ERROR_MSG)
+                }
+            }
+        } else {
+            object : UserInfoBridgeDispatcher() {}
         }
     }
 
     @Test
     fun `postError should be called when there is no get contacts retrieval implementation`() {
+        val userInfoBridgeDispatcher = Mockito.spy(createContactsImpl(false, false))
+        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
+        miniAppBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)
         val errMsg = "$ERR_GET_CONTACTS The `UserInfoBridgeDispatcher.getContacts`" +
                 " method has not been implemented by the Host App."
         miniAppBridge.postMessage(Gson().toJson(contactsCallbackObj))
@@ -276,9 +308,23 @@ class UserInfoBridgeDispatcherSpec {
     }
 
     @Test
+    fun `postError should be called when contact permission hasn't been allowed`() {
+        val userInfoBridgeDispatcher = Mockito.spy(createContactsImpl(true, true))
+        userInfoBridgeDispatcher?.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
+        val errMsg = "$ERR_GET_CONTACTS Permission has not been accepted yet for getting contacts."
+        whenever(customPermissionCache.hasPermission(
+            miniAppInfo.id, MiniAppCustomPermissionType.CONTACT_LIST)
+        ).thenReturn(false)
+
+        userInfoBridgeDispatcher.onGetContacts(contactsCallbackObj.id)
+
+        verify(bridgeExecutor).postError(contactsCallbackObj.id, errMsg)
+    }
+
+    @Test
     fun `postError should be called when hostapp doesn't providing contacts`() {
         val errMsg = "$ERR_GET_CONTACTS $TEST_ERROR_MSG"
-        val userInfoBridgeDispatcher = Mockito.spy(createUserInfoContactsImpl(false))
+        val userInfoBridgeDispatcher = Mockito.spy(createContactsImpl(true, false))
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
 
         userInfoBridgeDispatcher.onGetContacts(contactsCallbackObj.id)
@@ -288,33 +334,12 @@ class UserInfoBridgeDispatcherSpec {
 
     @Test
     fun `postValue should be called when retrieve contacts successfully`() {
-        val userInfoBridgeDispatcher = Mockito.spy(createUserInfoContactsImpl(true))
+        val userInfoBridgeDispatcher = Mockito.spy(createContactsImpl(true, true))
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
 
         userInfoBridgeDispatcher.onGetContacts(contactsCallbackObj.id)
 
         verify(bridgeExecutor).postValue(contactsCallbackObj.id, Gson().toJson(contacts))
-    }
-
-    @Test
-    fun `postError should be called when contact permission hasn't been allowed`() {
-        val errMsg = "$ERR_GET_CONTACTS Permission has not been accepted yet for getting contacts."
-        val deniedContactsPermission = MiniAppCustomPermission(
-            TEST_MA_ID,
-            listOf(
-                Pair(
-                    MiniAppCustomPermissionType.CONTACT_LIST,
-                    MiniAppCustomPermissionResult.DENIED
-                )
-            )
-        )
-        whenever(customPermissionCache.readPermissions(miniAppInfo.id)).thenReturn(
-            deniedContactsPermission
-        )
-
-        userInfoBridgeDispatcher.onGetContacts(contactsCallbackObj.id)
-
-        verify(bridgeExecutor).postError(contactsCallbackObj.id, errMsg)
     }
     /** end region */
 
@@ -329,12 +354,5 @@ class UserInfoBridgeDispatcherSpec {
             ) {
                 onRequestPermissionsResult(TEST_CALLBACK_ID, false)
             }
-        }
-
-    private fun createUserInfoBridgeDispatcher(): UserInfoBridgeDispatcher =
-        object : UserInfoBridgeDispatcher() {
-            override fun getUserName() = ""
-
-            override fun getProfilePhoto() = ""
         }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
@@ -295,6 +295,27 @@ class UserInfoBridgeDispatcherSpec {
 
         verify(bridgeExecutor).postValue(contactsCallbackObj.id, Gson().toJson(contacts))
     }
+
+    @Test
+    fun `postError should be called when get permission hasn't been allowed`() {
+        val errMsg = "$ERR_GET_CONTACTS Permission has not been accepted yet for getting contacts."
+        val deniedContactsPermission = MiniAppCustomPermission(
+            TEST_MA_ID,
+            listOf(
+                Pair(
+                    MiniAppCustomPermissionType.CONTACT_LIST,
+                    MiniAppCustomPermissionResult.DENIED
+                )
+            )
+        )
+        whenever(customPermissionCache.readPermissions(miniAppInfo.id)).thenReturn(
+            deniedContactsPermission
+        )
+
+        userInfoBridgeDispatcher.onGetContacts(contactsCallbackObj.id)
+
+        verify(bridgeExecutor).postError(contactsCallbackObj.id, errMsg)
+    }
     /** end region */
 
     private fun createMessageBridge(): MiniAppMessageBridge =

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcherSpec.kt
@@ -90,14 +90,14 @@ class CustomPermissionBridgeDispatcherSpec {
 
     @Test
     fun `filterDeniedPermissions should return correct list permissionsWithDescription is not empty`() {
-        val expected = listOf(
-            Pair(
-                MiniAppCustomPermissionType.USER_NAME,
-                ""
-            )
-        )
-
+        val expected = listOf(Pair(MiniAppCustomPermissionType.USER_NAME, ""))
         assertEquals(expected, customPermissionBridgeDispatcher.filterDeniedPermissions())
+    }
+
+    @Test
+    fun `filterDeniedPermissions should use hasPermission from MiniAppCustomPermissionCache`() {
+        customPermissionBridgeDispatcher.filterDeniedPermissions()
+        verify(miniAppCustomPermissionCache).hasPermission(TEST_MA_ID, MiniAppCustomPermissionType.USER_NAME)
     }
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
@@ -173,6 +173,42 @@ class MiniAppCustomPermissionCacheSpec {
     /** end region */
 
     /**
+     * region: hasPermission
+     */
+    @Test
+    fun `hasPermission should return false by default when there is no allowed permission found`() {
+        val actual = miniAppCustomPermissionCache.hasPermission(
+            TEST_MA_ID,
+            MiniAppCustomPermissionType.USER_NAME
+        )
+
+        actual shouldBe false
+    }
+
+    @Test
+    fun `hasPermission should return true when there is allowed permission found`() {
+        val allowedUserName = MiniAppCustomPermission(
+            TEST_MA_ID,
+            listOf(
+                Pair(
+                    MiniAppCustomPermissionType.USER_NAME,
+                    MiniAppCustomPermissionResult.ALLOWED
+                )
+            )
+        )
+
+        doReturn(allowedUserName).whenever(miniAppCustomPermissionCache).readPermissions(TEST_MA_ID)
+
+        val actual = miniAppCustomPermissionCache.hasPermission(
+            TEST_MA_ID,
+            MiniAppCustomPermissionType.USER_NAME
+        )
+
+        actual shouldBe true
+    }
+    /** end region */
+
+    /**
      * region: defaultDeniedList.
      * Update the values in the following tests when adding or removing a custom permission.
      */

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
@@ -12,7 +12,7 @@ import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.`when`
 
-@Suppress("LongMethod")
+@Suppress("LongMethod", "LargeClass")
 class MiniAppCustomPermissionCacheSpec {
     private lateinit var miniAppCustomPermissionCache: MiniAppCustomPermissionCache
     private val mockSharedPrefs: SharedPreferences = mock()


### PR DESCRIPTION
# Description
* In `UserInfoBridgeDispatcher.onGetContacts` PR, we haven't added the permission checkup for `MiniAppCustomPermissionType.CONTACT_LIST` like the user-name and profile photo we have. This PR aims to add the fix. 
* Add a common function e.g. `hasPermission` in `MiniAppCustomPermissionCache` for checking if any specific permission has been allowed or not.

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
