### PR TITLE
feat: allow profile photo and user name to be retrieved asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 ## CHANGELOG
 
-2.X.X (In progress)
+### 2.X.X (Next release)
+**SDK**
+- **Feature:** Added `getUserName(onSuccess: (name: String) -> Unit, onError: (message: String) -> Unit)` interface in `UserInfoBridgeDispatcher` for receiving user name.
+- **Feature:** Added `getProfilePhoto(onSuccess: (photoUrl: String) -> Unit, onError: (message: String) -> Unit)` interface in `UserInfoBridgeDispatcher` for receiving profile photo url.
+- **Deprecated:** `fun getUserName(): String` and `fun getProfilePhoto(): String` interfaces in `UserInfoBridgeDispatcher`, you can implement the new interfaces instead.
+
+**Sample App**
+- **Change:** Replaced the implementation of `getUserName` and `getProfilePhoto` using new interfaces.
+
+### 2.X.X (In progress)
 **SDK**
 - **Feature:** Added `rakuten.miniapp.device.LOCATION` custom permission.
 - **Feature:** Added `getContacts()` interface in `UserInfoBridgeDispatcher` for receiving list of contact IDs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ### 2.X.X (In progress)
 **SDK**
-- **Feature:** Added `getUserName`, `getProfilePhoto`, `getContacts` and `getAccessToken` new interfaces for invoking data using [Result](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result/).
-- **Deprecated:** Old `getUserName`, `getProfilePhoto`, `getContacts` and `getAccessToken` interfaces.
+- **Feature:** Added `getUserName`, `getProfilePhoto` new interfaces for invoking data using `onSuccess` and `onError`.
+- **Deprecated:** Old `getUserName`, `getProfilePhoto` interfaces.
 
 **Sample App**
-- **Change:** Replaced the implementation of `getUserName`, `getProfilePhoto`, `getContacts` and `getAccessToken` using new interfaces.
+- **Change:** Replaced the implementation of `getUserName`, `getProfilePhoto` using new interfaces.
 
 ### 2.7.1 (2020-12-23)
 **SDK**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### 2.X.X (Next release)
 **SDK**
-- **Feature:** Added `getUserName(onSuccess: (name: String) -> Unit, onError: (message: String) -> Unit)` interface in `UserInfoBridgeDispatcher` for receiving user name.
-- **Feature:** Added `getProfilePhoto(onSuccess: (photoUrl: String) -> Unit, onError: (message: String) -> Unit)` interface in `UserInfoBridgeDispatcher` for receiving profile photo url.
+- **Feature:** Added `getUserName(callback: (result: Result<String?>) -> Unit)` interface in `UserInfoBridgeDispatcher` for receiving user name.
+- **Feature:** Added `getProfilePhoto(callback: (result: Result<String?>) -> Unit)` interface in `UserInfoBridgeDispatcher` for receiving profile photo url.
 - **Deprecated:** `fun getUserName(): String` and `fun getProfilePhoto(): String` interfaces in `UserInfoBridgeDispatcher`, you can implement the new interfaces instead.
 
 **Sample App**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 - **Feature:** Added `getUserName(callback: (result: Result<String?>) -> Unit)` interface in `UserInfoBridgeDispatcher` for receiving user name.
 - **Feature:** Added `getProfilePhoto(callback: (result: Result<String?>) -> Unit)` interface in `UserInfoBridgeDispatcher` for receiving profile photo url.
 - **Deprecated:** `fun getUserName(): String` and `fun getProfilePhoto(): String` interfaces in `UserInfoBridgeDispatcher`, you can implement the new interfaces instead.
+- **Deprecated:** `fun getContacts(onSuccess: (contacts: ArrayList<Contact>) -> Unit, onError: (message: String) -> Unit)` interface in `UserInfoBridgeDispatcher`, you can implement the new interface instead.
+- **Deprecated:** `fun getAccessToken(miniAppId: String, onSuccess: (tokenData: TokenData) -> Unit, onError: (message: String) -> Unit)` interface in `UserInfoBridgeDispatcher`, you can implement the new interface instead.
 
 **Sample App**
-- **Change:** Replaced the implementation of `getUserName` and `getProfilePhoto` using new interfaces.
+- **Change:** Replaced the implementation of `getUserName`, `getProfilePhoto`, `getContacts` and `getAccessToken` using new interfaces.
 
 ### 2.7.1 (2020-12-23)
 **SDK**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,8 @@
 
 ### 2.X.X (In progress)
 **SDK**
-- **Feature:** Added `getUserName(callback: (result: Result<String?>) -> Unit)` interface in `UserInfoBridgeDispatcher` for receiving user name.
-- **Feature:** Added `getProfilePhoto(callback: (result: Result<String?>) -> Unit)` interface in `UserInfoBridgeDispatcher` for receiving profile photo url.
-- **Deprecated:** `fun getUserName(): String` and `fun getProfilePhoto(): String` interfaces in `UserInfoBridgeDispatcher`, you can implement the new interfaces instead.
-- **Deprecated:** `fun getContacts(onSuccess: (contacts: ArrayList<Contact>) -> Unit, onError: (message: String) -> Unit)` interface in `UserInfoBridgeDispatcher`, you can implement the new interface instead.
-- **Deprecated:** `fun getAccessToken(miniAppId: String, onSuccess: (tokenData: TokenData) -> Unit, onError: (message: String) -> Unit)` interface in `UserInfoBridgeDispatcher`, you can implement the new interface instead.
+- **Feature:** Added `getUserName`, `getProfilePhoto`, `getContacts` and `getAccessToken` new interfaces for invoking data using [Result](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result/)
+- **Deprecated:** Old `getUserName`, `getProfilePhoto`, `getContacts` and `getAccessToken` interfaces.
 
 **Sample App**
 - **Change:** Replaced the implementation of `getUserName`, `getProfilePhoto`, `getContacts` and `getAccessToken` using new interfaces.

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -266,36 +266,38 @@ val miniAppMessageBridge = object: MiniAppMessageBridge() {
 val userInfoBridgeDispatcher = object : UserInfoBridgeDispatcher() {
 
     override fun getUserName(
-        onSuccess: (name: String) -> Unit,
-        onError: (message: String) -> Unit
+        callback: (result: Result<String?>) -> Unit
     ) {
         val name: String = ""
         // Check if there is any valid username in HostApp
         // .. .. ..
-        if (name is valid)
-            onSuccess(name) // allow miniapp to get the name.
-        else
-            onError(message) // reject miniapp to get the name with message explanation.
+        val result: Result<String> = run {
+            if (name is valid) success(name) // allow miniapp to get the name.
+            else failure(Exception("User name is not found.")) // reject miniapp to get the name with message explanation.
+        }
+
+        callback.invoke(result) // invoke the Result callback
     }
 
     override fun getProfilePhoto(
-        onSuccess: (photoUrl: String) -> Unit,
-        onError: (message: String) -> Unit
+            callback: (result: Result<String?>) -> Unit
     ) {
         val photoUrl: String = ""
         // Check if there is any valid photo url in HostApp
         // .. .. ..
-        if (photoUrl is valid)
-            onSuccess(photoUrl) // allow miniapp to get the photo url.
-        else
-            onError(message) // reject miniapp to get the photo url with message explanation.
+        val result: Result<String> = run {
+            if (photoUrl is valid) success(name) // allow miniapp to get the photo url.
+            else failure(Exception("User name is not found.")) // reject miniapp to get the photo url with message explanation.
+        }
+
+        callback.invoke(result) // invoke the Result callback
     }
 
     override fun getAccessToken(
         miniAppId: String,
         onSuccess: (tokenData: TokenData) -> Unit,
         onError: (message: String) -> Unit
-    ){
+    ) {
         var allowToken: Boolean = false
         // Check if you want to allow this Mini App ID to use the Access Token
         // .. .. ..

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -266,28 +266,28 @@ val miniAppMessageBridge = object: MiniAppMessageBridge() {
 val userInfoBridgeDispatcher = object : UserInfoBridgeDispatcher() {
 
     override fun getUserName(
-        callback: (result: Result<String?>) -> Unit
+        callback: (userName: Result<String?>) -> Unit
     ) {
         val name: String = ""
         // Check if there is any valid username in HostApp
         // .. .. ..
         val result: Result<String> = run {
             if (name is valid) success(name) // allow miniapp to get the name.
-            else failure(Exception("User name is not found.")) // reject miniapp to get the name with message explanation.
+            else failure(Exception(message)) // reject miniapp to get the name with message explanation.
         }
 
         callback.invoke(result) // invoke the Result callback
     }
 
     override fun getProfilePhoto(
-            callback: (result: Result<String?>) -> Unit
+        callback: (profilePhoto: Result<String?>) -> Unit
     ) {
         val photoUrl: String = ""
         // Check if there is any valid photo url in HostApp
         // .. .. ..
         val result: Result<String> = run {
-            if (photoUrl is valid) success(name) // allow miniapp to get the photo url.
-            else failure(Exception("User name is not found.")) // reject miniapp to get the photo url with message explanation.
+            if (photoUrl is valid) success(photoUrl) // allow miniapp to get the photo url.
+            else failure(Exception(message)) // reject miniapp to get the photo url with message explanation.
         }
 
         callback.invoke(result) // invoke the Result callback
@@ -295,28 +295,30 @@ val userInfoBridgeDispatcher = object : UserInfoBridgeDispatcher() {
 
     override fun getAccessToken(
         miniAppId: String,
-        onSuccess: (tokenData: TokenData) -> Unit,
-        onError: (message: String) -> Unit
+        callback: (accessToken: Result<TokenData?>) -> Unit
     ) {
         var allowToken: Boolean = false
         // Check if you want to allow this Mini App ID to use the Access Token
         // .. .. ..
-        if (allowToken)
-            onSuccess(tokenData) // allow miniapp to get token and return TokenData value.
-        else
-            onError(message)    // reject miniapp to get token and with message explanation.
+        val result: Result<TokenData> = run {
+            if (allowToken) success(data)
+            else failure(Exception(message))
+        }
+
+        callback.invoke(result)
     }
 
      override fun getContacts(
-        onSuccess: (contacts: ArrayList<Contact>) -> Unit,
-        onError: (message: String) -> Unit
+        callback: (contacts: Result<ArrayList<Contact>?>) -> Unit
     ) {
-        // Check if there is any contact id in HostApp
+        // Check if there is any contact in HostApp
         // .. .. ..
-        if (hasContact)
-            onSuccess(contacts) // allow miniapp to get the contacts.
-        else
-            onError(message) // reject miniapp to get the contacts with message explanation.
+        val result: Result<ArrayList<Contact>> = run {
+            if (hasContact) success(contacts) // allow miniapp to get the contacts.
+            else failure(Exception(message)) // reject miniapp to get the contacts with message explanation.
+        }
+
+        callback.invoke(result) // invoke the Result callback
     }
 }
 

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -269,10 +269,10 @@ val userInfoBridgeDispatcher = object : UserInfoBridgeDispatcher() {
         onSuccess: (userName: String) -> Unit,
         onError: (message: String) -> Unit
     ) {
-        val name: String = ""
+        val name: String?
         // Check if there is any valid username in HostApp
         // .. .. ..
-        if (name is valid)
+        if (isNameValid) // Check if name is valid
             onSuccess(name) // allow miniapp to get user name.
         else
             onError(message) // reject miniapp to get user name with message explanation.
@@ -282,10 +282,10 @@ val userInfoBridgeDispatcher = object : UserInfoBridgeDispatcher() {
         onSuccess: (profilePhoto: String) -> Unit,
         onError: (message: String) -> Unit
     ) {
-        val photoUrl: String = ""
+        val photoUrl: String?
         // Check if there is any valid photo url in HostApp
         // .. .. ..
-        if (photoUrl is valid)
+        if (isPhotoUrlValid) // Check if photoUrl is valid
             onSuccess(photoUrl) // allow miniapp to get photo url.
         else
             onError(message) // reject miniapp to get photo url with message explanation.

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -264,6 +264,8 @@ val miniAppMessageBridge = object: MiniAppMessageBridge() {
 }
 
 val userInfoBridgeDispatcher = object : UserInfoBridgeDispatcher() {
+
+    // note: it has been deprecated now.
     override fun getUserName(): String {
         var name: String = ""
         // Implementation details to get user name
@@ -271,11 +273,38 @@ val userInfoBridgeDispatcher = object : UserInfoBridgeDispatcher() {
         return name
     }
 
+    override fun getUserName(
+        onSuccess: (name: String) -> Unit,
+        onError: (message: String) -> Unit
+    ) {
+        val name: String = ""
+        // Check if there is any valid username in HostApp
+        // .. .. ..
+        if (name is valid)
+            onSuccess(name) // allow miniapp to get the name.
+        else
+            onError(message) // reject miniapp to get the name with message explanation.
+    }
+
+    // note: it has been deprecated now
     override fun getProfilePhoto(): String {
         var profilePhotoUrl: String = ""
         // Implementation details to get profile photo url
         // .. .. ..
         return profilePhotoUrl
+    }
+
+    override fun getProfilePhoto(
+        onSuccess: (photoUrl: String) -> Unit,
+        onError: (message: String) -> Unit
+    ) {
+        val photoUrl: String = ""
+        // Check if there is any valid photo url in HostApp
+        // .. .. ..
+        if (photoUrl is valid)
+            onSuccess(photoUrl) // allow miniapp to get the photo url.
+        else
+            onError(message) // reject miniapp to get the photo url with message explanation.
     }
 
     override fun getAccessToken(
@@ -299,9 +328,9 @@ val userInfoBridgeDispatcher = object : UserInfoBridgeDispatcher() {
         // Check if there is any contact id in HostApp
         // .. .. ..
         if (hasContact)
-            onSuccess(contacts) // invoke the list of contact IDs
+            onSuccess(contacts) // allow miniapp to get the contacts.
         else
-            onError("There is no contact found in HostApp.")
+            onError(message) // reject miniapp to get the contacts with message explanation.
     }
 }
 

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -266,59 +266,55 @@ val miniAppMessageBridge = object: MiniAppMessageBridge() {
 val userInfoBridgeDispatcher = object : UserInfoBridgeDispatcher() {
 
     override fun getUserName(
-        callback: (userName: Result<String?>) -> Unit
+        onSuccess: (userName: String) -> Unit,
+        onError: (message: String) -> Unit
     ) {
         val name: String = ""
         // Check if there is any valid username in HostApp
         // .. .. ..
-        val result: Result<String> = run {
-            if (name is valid) success(name) // allow miniapp to get the name.
-            else failure(Exception(message)) // reject miniapp to get the name with message explanation.
-        }
-
-        callback.invoke(result) // invoke the Result callback
+        if (name is valid)
+            onSuccess(name) // allow miniapp to get user name.
+        else
+            onError(message) // reject miniapp to get user name with message explanation.
     }
 
     override fun getProfilePhoto(
-        callback: (profilePhoto: Result<String?>) -> Unit
+        onSuccess: (profilePhoto: String) -> Unit,
+        onError: (message: String) -> Unit
     ) {
         val photoUrl: String = ""
         // Check if there is any valid photo url in HostApp
         // .. .. ..
-        val result: Result<String> = run {
-            if (photoUrl is valid) success(photoUrl) // allow miniapp to get the photo url.
-            else failure(Exception(message)) // reject miniapp to get the photo url with message explanation.
-        }
-
-        callback.invoke(result) // invoke the Result callback
+        if (photoUrl is valid)
+            onSuccess(photoUrl) // allow miniapp to get photo url.
+        else
+            onError(message) // reject miniapp to get photo url with message explanation.
     }
 
     override fun getAccessToken(
         miniAppId: String,
-        callback: (accessToken: Result<TokenData?>) -> Unit
+        onSuccess: (tokenData: TokenData) -> Unit,
+        onError: (message: String) -> Unit
     ) {
         var allowToken: Boolean = false
         // Check if you want to allow this Mini App ID to use the Access Token
         // .. .. ..
-        val result: Result<TokenData> = run {
-            if (allowToken) success(data)
-            else failure(Exception(message))
-        }
-
-        callback.invoke(result)
+        if (allowToken)
+            onSuccess(tokenData) // allow miniapp to get token and return TokenData value.
+        else
+            onError(message) // reject miniapp to get token with message explanation.
     }
 
-     override fun getContacts(
-        callback: (contacts: Result<ArrayList<Contact>?>) -> Unit
+    override fun getContacts(
+        onSuccess: (contacts: ArrayList<Contact>) -> Unit,
+        onError: (message: String) -> Unit
     ) {
-        // Check if there is any contact in HostApp
+        // Check if there is any contact id in HostApp
         // .. .. ..
-        val result: Result<ArrayList<Contact>> = run {
-            if (hasContact) success(contacts) // allow miniapp to get the contacts.
-            else failure(Exception(message)) // reject miniapp to get the contacts with message explanation.
-        }
-
-        callback.invoke(result) // invoke the Result callback
+        if (hasContact)
+            onSuccess(contacts) // allow miniapp to get contacts.
+        else
+            onError(message) // reject miniapp to get contacts with message explanation.
     }
 }
 

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -265,14 +265,6 @@ val miniAppMessageBridge = object: MiniAppMessageBridge() {
 
 val userInfoBridgeDispatcher = object : UserInfoBridgeDispatcher() {
 
-    // note: it has been deprecated now.
-    override fun getUserName(): String {
-        var name: String = ""
-        // Implementation details to get user name
-        // .. .. ..
-        return name
-    }
-
     override fun getUserName(
         onSuccess: (name: String) -> Unit,
         onError: (message: String) -> Unit
@@ -284,14 +276,6 @@ val userInfoBridgeDispatcher = object : UserInfoBridgeDispatcher() {
             onSuccess(name) // allow miniapp to get the name.
         else
             onError(message) // reject miniapp to get the name with message explanation.
-    }
-
-    // note: it has been deprecated now
-    override fun getProfilePhoto(): String {
-        var profilePhotoUrl: String = ""
-        // Implementation details to get profile photo url
-        // .. .. ..
-        return profilePhotoUrl
     }
 
     override fun getProfilePhoto(

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
@@ -31,10 +31,11 @@ abstract class UserInfoBridgeDispatcher {
 
     /**
      * Get user name from host app.
-     * You can send user name or throw an [Exception] from this method by passing a [Result].
+     * You can also throw an [Exception] from this method to pass an error message to the mini app.
      */
     open fun getUserName(
-        callback: (userName: Result<String?>) -> Unit
+        onSuccess: (userName: String) -> Unit,
+        onError: (message: String) -> Unit
     ) {
         throw MiniAppSdkException("The `UserInfoBridgeDispatcher.getUserName` $NO_IMPL")
     }
@@ -52,19 +53,16 @@ abstract class UserInfoBridgeDispatcher {
 
     /**
      * Get profile photo url from host app.
-     * You can send profile photo url or throw an [Exception] from this method by passing a [Result].
+     * You can also throw an [Exception] from this method to pass an error message to the mini app.
      */
     open fun getProfilePhoto(
-        callback: (profilePhoto: Result<String?>) -> Unit
+        onSuccess: (profilePhoto: String) -> Unit,
+        onError: (message: String) -> Unit
     ) {
         throw MiniAppSdkException("The `UserInfoBridgeDispatcher.getProfilePhoto` $NO_IMPL")
     }
 
     /** Get access token from host app. **/
-    @Deprecated(
-        "This function has been deprecated.",
-        ReplaceWith("getAccessToken(miniAppId: String, callback: (result: Result<TokenData?>) -> Unit)")
-    )
     open fun getAccessToken(
         miniAppId: String,
         onSuccess: (tokenData: TokenData) -> Unit,
@@ -73,37 +71,13 @@ abstract class UserInfoBridgeDispatcher {
         throw MiniAppSdkException("The `UserInfoBridgeDispatcher.getAccessToken` $NO_IMPL")
     }
 
-    /** Get access token from host app.
-     * You can send access token or throw an [Exception] from this method by passing a [Result].
-     * */
-    open fun getAccessToken(
-        miniAppId: String,
-        callback: (accessToken: Result<TokenData?>) -> Unit
-    ) {
-        throw MiniAppSdkException("The `UserInfoBridgeDispatcher.getAccessToken` $NO_IMPL")
-    }
-
     /**
      * Get contacts from host app.
      * You can also throw an [Exception] from this method to pass an error message to the mini app.
      */
-    @Deprecated(
-        "This function has been deprecated.",
-        ReplaceWith("getContacts(callback: (result: Result<ArrayList<Contact>?>) -> Unit)")
-    )
     open fun getContacts(
         onSuccess: (contacts: ArrayList<Contact>) -> Unit,
         onError: (message: String) -> Unit
-    ) {
-        throw MiniAppSdkException("The `UserInfoBridgeDispatcher.getContacts` $NO_IMPL")
-    }
-
-    /**
-     * Get contacts from host app.
-     * You can send contacts or throw an [Exception] from this method by passing a [Result].
-     */
-    open fun getContacts(
-        callback: (contacts: Result<ArrayList<Contact>?>) -> Unit
     ) {
         throw MiniAppSdkException("The `UserInfoBridgeDispatcher.getContacts` $NO_IMPL")
     }
@@ -118,8 +92,6 @@ abstract class UserInfoBridgeDispatcher {
         this.miniAppId = miniAppId
     }
 
-    /** region: user name. */
-    @Suppress("ComplexMethod")
     internal fun onGetUserName(callbackId: String) {
         if (customPermissionCache.hasPermission(
                 miniAppId,
@@ -128,17 +100,14 @@ abstract class UserInfoBridgeDispatcher {
         ) {
             try {
                 // asynchronously retrieve user name
-                val resultCallback = { result: Result<String?> ->
-                    if (result.isSuccess) bridgeExecutor.postValue(
-                        callbackId,
-                        result.getOrNull().toString()
-                    )
-                    else if (result.isFailure) bridgeExecutor.postError(
-                        callbackId,
-                        "$ERR_GET_USER_NAME ${result.exceptionOrNull()?.message}"
-                    )
+                val successCallback = { userName: String ->
+                    bridgeExecutor.postValue(callbackId, userName)
                 }
-                getUserName(resultCallback)
+                val errorCallback = { message: String ->
+                    bridgeExecutor.postError(callbackId, "$ERR_GET_USER_NAME $message")
+                }
+
+                getUserName(successCallback, errorCallback)
             } catch (e: Exception) {
                 if (e.message.toString().contains(NO_IMPL)) getUserNameSync(callbackId)
                 else bridgeExecutor.postError(callbackId, "$ERR_GET_USER_NAME ${e.message}")
@@ -163,10 +132,7 @@ abstract class UserInfoBridgeDispatcher {
             bridgeExecutor.postError(callbackId, "$ERR_GET_USER_NAME ${e.message}")
         }
     }
-    /** end region */
 
-    /** region: profile photo. */
-    @Suppress("ComplexMethod")
     internal fun onGetProfilePhoto(callbackId: String) {
         if (customPermissionCache.hasPermission(
                 miniAppId,
@@ -175,17 +141,14 @@ abstract class UserInfoBridgeDispatcher {
         ) {
             try {
                 // asynchronously retrieve profile photo url
-                val resultCallback = { result: Result<String?> ->
-                    if (result.isSuccess) bridgeExecutor.postValue(
-                        callbackId,
-                        result.getOrNull().toString()
-                    )
-                    else if (result.isFailure) bridgeExecutor.postError(
-                        callbackId,
-                        "$ERR_GET_PROFILE_PHOTO ${result.exceptionOrNull()?.message}"
-                    )
+                val successCallback = { photoUrl: String ->
+                    bridgeExecutor.postValue(callbackId, photoUrl)
                 }
-                getProfilePhoto(resultCallback)
+                val errorCallback = { message: String ->
+                    bridgeExecutor.postError(callbackId, "$ERR_GET_PROFILE_PHOTO $message")
+                }
+
+                getProfilePhoto(successCallback, errorCallback)
             } catch (e: Exception) {
                 if (e.message.toString().contains(NO_IMPL)) getProfilePhotoSync(callbackId)
                 else bridgeExecutor.postError(callbackId, "$ERR_GET_PROFILE_PHOTO ${e.message}")
@@ -210,69 +173,33 @@ abstract class UserInfoBridgeDispatcher {
             bridgeExecutor.postError(callbackId, "$ERR_GET_PROFILE_PHOTO ${e.message}")
         }
     }
-    /** end region */
 
-    /** region: access token. */
-    internal fun onGetAccessToken(callbackId: String) {
-        try {
-            // retrieve access token using Result
-            val resultCallback = { result: Result<TokenData?> ->
-                if (result.isSuccess) bridgeExecutor.postValue(
-                    callbackId,
-                    Gson().toJson(result.getOrNull())
-                )
-                else if (result.isFailure) bridgeExecutor.postError(
-                    callbackId,
-                    "$ERR_GET_ACCESS_TOKEN ${result.exceptionOrNull()?.message}"
-                )
-            }
-            getAccessToken(miniAppId, resultCallback)
-        } catch (e: Exception) {
-            if (e.message.toString().contains(NO_IMPL)) getAccessTokenWithoutResult(callbackId)
-            else bridgeExecutor.postError(callbackId, "$ERR_GET_ACCESS_TOKEN ${e.message}")
+    internal fun onGetAccessToken(callbackId: String) = try {
+        val successCallback = { accessToken: TokenData ->
+            bridgeExecutor.postValue(callbackId, Gson().toJson(accessToken))
         }
+        val errorCallback = { message: String ->
+            bridgeExecutor.postError(callbackId, "$ERR_GET_ACCESS_TOKEN $message")
+        }
+
+        getAccessToken(miniAppId, successCallback, errorCallback)
+    } catch (e: Exception) {
+        bridgeExecutor.postError(callbackId, "$ERR_GET_ACCESS_TOKEN ${e.message}")
     }
 
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun getAccessTokenWithoutResult(callbackId: String) {
-        try {
-            val successCallback = { accessToken: TokenData ->
-                bridgeExecutor.postValue(callbackId, Gson().toJson(accessToken))
-            }
-            val errorCallback = { message: String ->
-                bridgeExecutor.postError(callbackId, "$ERR_GET_ACCESS_TOKEN $message")
-            }
-            getAccessToken(miniAppId, successCallback, errorCallback)
-        } catch (e: Exception) {
-            bridgeExecutor.postError(callbackId, "$ERR_GET_ACCESS_TOKEN ${e.message}")
-        }
-    }
-    /** end region */
-
-    /** region: contacts. */
-    @Suppress("ComplexMethod")
     internal fun onGetContacts(callbackId: String) = try {
         if (customPermissionCache.hasPermission(
                 miniAppId, MiniAppCustomPermissionType.CONTACT_LIST
             )
         ) {
-            try {
-                // retrieve contacts using Result
-                val resultCallback = { result: Result<ArrayList<Contact>?> ->
-                    if (result.isSuccess) bridgeExecutor.postValue(
-                        callbackId,
-                        Gson().toJson(result.getOrNull())
-                    )
-                    else if (result.isFailure) bridgeExecutor.postError(
-                        callbackId,
-                        "$ERR_GET_CONTACTS ${result.exceptionOrNull()?.message}"
-                    )
-                }
-                getContacts(resultCallback)
-            } catch (e: Exception) {
-                if (e.message.toString().contains(NO_IMPL)) getContactsWithoutResult(callbackId)
-                else bridgeExecutor.postError(callbackId, "$ERR_GET_CONTACTS ${e.message}")
+            val successCallback = { contacts: ArrayList<Contact> ->
+                bridgeExecutor.postValue(callbackId, Gson().toJson(contacts))
             }
+            val errorCallback = { message: String ->
+                bridgeExecutor.postError(callbackId, "$ERR_GET_CONTACTS $message")
+            }
+
+            getContacts(successCallback, errorCallback)
         } else {
             bridgeExecutor.postError(
                 callbackId,
@@ -282,22 +209,6 @@ abstract class UserInfoBridgeDispatcher {
     } catch (e: Exception) {
         bridgeExecutor.postError(callbackId, "$ERR_GET_CONTACTS ${e.message}")
     }
-
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun getContactsWithoutResult(callbackId: String) {
-        try {
-            val successCallback = { contacts: ArrayList<Contact> ->
-                bridgeExecutor.postValue(callbackId, Gson().toJson(contacts))
-            }
-            val errorCallback = { message: String ->
-                bridgeExecutor.postError(callbackId, "$ERR_GET_CONTACTS $message")
-            }
-            getContacts(successCallback, errorCallback)
-        } catch (e: Exception) {
-            bridgeExecutor.postError(callbackId, "$ERR_GET_CONTACTS ${e.message}")
-        }
-    }
-    /** end region. */
 
     @VisibleForTesting
     internal companion object {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
@@ -11,7 +11,7 @@ import java.util.ArrayList
 /**
  * A class to provide the interfaces for getting user info e.g. user-name, profile-photo etc.
  */
-@Suppress("TooGenericExceptionCaught", "LongMethod", "UnnecessaryAbstractClass")
+@Suppress("TooGenericExceptionCaught", "LongMethod", "UnnecessaryAbstractClass", "LargeClass")
 abstract class UserInfoBridgeDispatcher {
 
     private lateinit var bridgeExecutor: MiniAppBridgeExecutor
@@ -118,7 +118,8 @@ abstract class UserInfoBridgeDispatcher {
         this.miniAppId = miniAppId
     }
 
-    /** region: user name */
+    /** region: user name. */
+    @Suppress("ComplexMethod")
     internal fun onGetUserName(callbackId: String) {
         if (customPermissionCache.hasPermission(
                 miniAppId,
@@ -164,7 +165,8 @@ abstract class UserInfoBridgeDispatcher {
     }
     /** end region */
 
-    /** region: profile photo */
+    /** region: profile photo. */
+    @Suppress("ComplexMethod")
     internal fun onGetProfilePhoto(callbackId: String) {
         if (customPermissionCache.hasPermission(
                 miniAppId,
@@ -210,7 +212,7 @@ abstract class UserInfoBridgeDispatcher {
     }
     /** end region */
 
-    /** region: access token */
+    /** region: access token. */
     internal fun onGetAccessToken(callbackId: String) {
         try {
             // retrieve access token using Result
@@ -247,7 +249,8 @@ abstract class UserInfoBridgeDispatcher {
     }
     /** end region */
 
-    /** region: contacts */
+    /** region: contacts. */
+    @Suppress("ComplexMethod")
     internal fun onGetContacts(callbackId: String) = try {
         if (customPermissionCache.hasPermission(
                 miniAppId, MiniAppCustomPermissionType.CONTACT_LIST
@@ -294,7 +297,7 @@ abstract class UserInfoBridgeDispatcher {
             bridgeExecutor.postError(callbackId, "$ERR_GET_CONTACTS ${e.message}")
         }
     }
-    /** end region */
+    /** end region. */
 
     @VisibleForTesting
     internal companion object {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
@@ -22,15 +22,45 @@ abstract class UserInfoBridgeDispatcher {
      * Get user name from host app.
      * You can also throw an [Exception] from this method to pass an error message to the mini app.
      */
+    @Deprecated(
+        "This function has been deprecated.",
+        ReplaceWith("getUserName(onSuccess: (name: String) -> Unit, onError: (message: String) -> Unit)")
+    )
     open fun getUserName(): String =
         throw MiniAppSdkException("The `UserInfoBridgeDispatcher.getUserName` $NO_IMPL")
+
+    /**
+     * Get user name from host app.
+     * You can also throw an [Exception] from this method to pass an error message to the mini app.
+     */
+    open fun getUserName(
+        onSuccess: (name: String) -> Unit,
+        onError: (message: String) -> Unit
+    ) {
+        throw MiniAppSdkException("The `UserInfoBridgeDispatcher.getUserName` $NO_IMPL")
+    }
 
     /**
      * Get profile photo url from host app.
      * You can also throw an [Exception] from this method to pass an error message to the mini app.
      */
+    @Deprecated(
+        "This function has been deprecated.",
+        ReplaceWith("getProfilePhoto(onSuccess: (photoUrl: String) -> Unit, onError: (message: String) -> Unit)")
+    )
     open fun getProfilePhoto(): String =
         throw MiniAppSdkException("The `UserInfoBridgeDispatcher.getProfilePhoto` $NO_IMPL")
+
+    /**
+     * Get profile photo url from host app.
+     * You can also throw an [Exception] from this method to pass an error message to the mini app.
+     */
+    open fun getProfilePhoto(
+        onSuccess: (photoUrl: String) -> Unit,
+        onError: (message: String) -> Unit
+    ) {
+        throw MiniAppSdkException("The `UserInfoBridgeDispatcher.getProfilePhoto` $NO_IMPL")
+    }
 
     /** Get access token from host app. **/
     open fun getAccessToken(
@@ -63,47 +93,78 @@ abstract class UserInfoBridgeDispatcher {
     }
 
     internal fun onGetUserName(callbackId: String) {
+        if (customPermissionCache.hasPermission(
+                miniAppId,
+                MiniAppCustomPermissionType.USER_NAME
+            )
+        ) {
+            try {
+                // asynchronously retrieve user name
+                val successCallback = { name: String ->
+                    bridgeExecutor.postValue(callbackId, name)
+                }
+                val errorCallback = { message: String ->
+                    bridgeExecutor.postError(callbackId, "$ERR_GET_USER_NAME $message")
+                }
+                getUserName(successCallback, errorCallback)
+            } catch (e: Exception) {
+                if (e.message.toString().contains(NO_IMPL)) getUserNameSynchronously(callbackId)
+                else bridgeExecutor.postError(callbackId, "$ERR_GET_USER_NAME ${e.message}")
+            }
+        } else
+            bridgeExecutor.postError(
+                callbackId,
+                "$ERR_GET_USER_NAME $ERR_USER_NAME_NO_PERMISSION"
+            )
+    }
+
+    private fun getUserNameSynchronously(callbackId: String) {
         try {
-            if (customPermissionCache.hasPermission(
-                    miniAppId,
-                    MiniAppCustomPermissionType.USER_NAME
-                )
-            ) {
-                val name = getUserName()
-                if (name.isNotEmpty()) bridgeExecutor.postValue(callbackId, name)
-                else bridgeExecutor.postError(
-                    callbackId,
-                    "$ERR_GET_USER_NAME User name is not found."
-                )
-            } else
-                bridgeExecutor.postError(
-                    callbackId,
-                    "$ERR_GET_USER_NAME $ERR_USER_NAME_NO_PERMISSION"
-                )
+            val name = getUserName()
+            if (name.isNotEmpty()) bridgeExecutor.postValue(callbackId, name)
+            else bridgeExecutor.postError(
+                callbackId,
+                "$ERR_GET_USER_NAME User name is not found."
+            )
         } catch (e: Exception) {
             bridgeExecutor.postError(callbackId, "$ERR_GET_USER_NAME ${e.message}")
         }
     }
 
     internal fun onGetProfilePhoto(callbackId: String) {
-        try {
-            if (customPermissionCache.hasPermission(
-                    miniAppId,
-                    MiniAppCustomPermissionType.PROFILE_PHOTO
-                )
-            ) {
-                val photoUrl = getProfilePhoto()
-                if (photoUrl.isNotEmpty())
+        if (customPermissionCache.hasPermission(
+                miniAppId,
+                MiniAppCustomPermissionType.PROFILE_PHOTO
+            )
+        ) {
+            try {
+                // asynchronously retrieve profile photo url
+                val successCallback = { photoUrl: String ->
                     bridgeExecutor.postValue(callbackId, photoUrl)
-                else bridgeExecutor.postError(
-                    callbackId,
-                    "$ERR_GET_PROFILE_PHOTO Profile photo is not found."
-                )
-            } else
-                bridgeExecutor.postError(
-                    callbackId,
-                    "$ERR_GET_PROFILE_PHOTO $ERR_PROFILE_PHOTO_NO_PERMISSION"
-                )
+                }
+                val errorCallback = { message: String ->
+                    bridgeExecutor.postError(callbackId, "$ERR_GET_PROFILE_PHOTO $message")
+                }
+                getProfilePhoto(successCallback, errorCallback)
+            } catch (e: Exception) {
+                if (e.message.toString().contains(NO_IMPL)) getProfilePhotoSynchronously(callbackId)
+                else bridgeExecutor.postError(callbackId, "$ERR_GET_PROFILE_PHOTO ${e.message}")
+            }
+        } else
+            bridgeExecutor.postError(
+                callbackId,
+                "$ERR_GET_PROFILE_PHOTO $ERR_PROFILE_PHOTO_NO_PERMISSION"
+            )
+    }
+
+    private fun getProfilePhotoSynchronously(callbackId: String) {
+        try {
+            val photoUrl = getProfilePhoto()
+            if (photoUrl.isNotEmpty()) bridgeExecutor.postValue(callbackId, photoUrl)
+            else bridgeExecutor.postError(
+                callbackId,
+                "$ERR_GET_PROFILE_PHOTO Profile photo is not found."
+            )
         } catch (e: Exception) {
             bridgeExecutor.postError(callbackId, "$ERR_GET_PROFILE_PHOTO ${e.message}")
         }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
@@ -175,6 +175,7 @@ class UserInfoBridgeDispatcherSpec {
     fun `postError should be called when profile photo permission hasn't been allowed`() {
         val userInfoBridgeDispatcher = Mockito.spy(createProfilePhotoImpl(true))
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
+        miniAppBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)
         val errMsg = "$ERR_GET_PROFILE_PHOTO Permission has not been accepted yet for getting profile photo."
         whenever(customPermissionCache.hasPermission(
             miniAppInfo.id, MiniAppCustomPermissionType.PROFILE_PHOTO)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
@@ -99,12 +99,14 @@ class UserInfoBridgeDispatcherSpec {
 
                 override fun getUserName(): String = ""
 
-                override fun getUserName(callback: (result: Result<String?>) -> Unit) {
-                    val result: Result<String> = run {
-                        if (canGetName) Result.success(TEST_USER_NAME)
-                        else Result.success("")
-                    }
-                    callback.invoke(result)
+                override fun getUserName(
+                    onSuccess: (userName: String) -> Unit,
+                    onError: (message: String) -> Unit
+                ) {
+                    if (canGetName)
+                        onSuccess.invoke(TEST_USER_NAME)
+                    else
+                        onError.invoke(TEST_ERROR_MSG)
                 }
             }
         } else {
@@ -143,11 +145,12 @@ class UserInfoBridgeDispatcherSpec {
     fun `postError should be called when user name is empty`() {
         val userInfoBridgeDispatcher = Mockito.spy(createUserNameImpl(true, false))
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
+        val errMsg = "Cannot get user name: User name is not found."
 
         userInfoBridgeDispatcher.onGetUserName(userNameCallbackObj.id)
         userInfoBridgeDispatcher.getUserNameSync(userNameCallbackObj.id)
 
-        verify(bridgeExecutor).postValue(userNameCallbackObj.id, "")
+        verify(bridgeExecutor).postError(userNameCallbackObj.id, errMsg)
     }
 
     @Test
@@ -172,12 +175,14 @@ class UserInfoBridgeDispatcherSpec {
             object : UserInfoBridgeDispatcher() {
                 override fun getProfilePhoto(): String = ""
 
-                override fun getProfilePhoto(callback: (result: Result<String?>) -> Unit) {
-                    val result: Result<String> = run {
-                        if (canGetPhoto) Result.success(TEST_PROFILE_PHOTO)
-                        else Result.success("")
-                    }
-                    callback.invoke(result)
+                override fun getProfilePhoto(
+                    onSuccess: (profilePhoto: String) -> Unit,
+                    onError: (message: String) -> Unit
+                ) {
+                    if (canGetPhoto)
+                        onSuccess.invoke(TEST_PROFILE_PHOTO)
+                    else
+                        onError.invoke(TEST_ERROR_MSG)
                 }
             }
         } else {
@@ -216,11 +221,12 @@ class UserInfoBridgeDispatcherSpec {
     fun `postError should be called when profile photo is empty`() {
         val userInfoBridgeDispatcher = Mockito.spy(createProfilePhotoImpl(true, false))
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
+        val errMsg = "Cannot get profile photo: Profile photo is not found."
 
         userInfoBridgeDispatcher.onGetProfilePhoto(profilePhotoCallbackObj.id)
         userInfoBridgeDispatcher.getProfilePhotoSync(profilePhotoCallbackObj.id)
 
-        verify(bridgeExecutor).postValue(profilePhotoCallbackObj.id, "")
+        verify(bridgeExecutor).postError(profilePhotoCallbackObj.id, errMsg)
     }
 
     @Test
@@ -279,9 +285,8 @@ class UserInfoBridgeDispatcherSpec {
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
 
         userInfoBridgeDispatcher.onGetAccessToken(tokenCallbackObj.id)
-        userInfoBridgeDispatcher.getAccessTokenWithoutResult(tokenCallbackObj.id)
 
-        verify(bridgeExecutor, times(2)).postError(tokenCallbackObj.id, errMsg)
+        verify(bridgeExecutor).postError(tokenCallbackObj.id, errMsg)
     }
 
     @Test
@@ -290,9 +295,8 @@ class UserInfoBridgeDispatcherSpec {
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
 
         userInfoBridgeDispatcher.onGetAccessToken(tokenCallbackObj.id)
-        userInfoBridgeDispatcher.getAccessTokenWithoutResult(tokenCallbackObj.id)
 
-        verify(bridgeExecutor, times(2)).postValue(tokenCallbackObj.id, Gson().toJson(testToken))
+        verify(bridgeExecutor).postValue(tokenCallbackObj.id, Gson().toJson(testToken))
     }
     /** end region */
 
@@ -341,7 +345,6 @@ class UserInfoBridgeDispatcherSpec {
         ).thenReturn(false)
 
         userInfoBridgeDispatcher.onGetContacts(contactsCallbackObj.id)
-        userInfoBridgeDispatcher.getContactsWithoutResult(contactsCallbackObj.id)
 
         verify(bridgeExecutor).postError(contactsCallbackObj.id, errMsg)
     }
@@ -353,9 +356,8 @@ class UserInfoBridgeDispatcherSpec {
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
 
         userInfoBridgeDispatcher.onGetContacts(contactsCallbackObj.id)
-        userInfoBridgeDispatcher.getContactsWithoutResult(contactsCallbackObj.id)
 
-        verify(bridgeExecutor, times(2)).postError(contactsCallbackObj.id, errMsg)
+        verify(bridgeExecutor).postError(contactsCallbackObj.id, errMsg)
     }
 
     @Test
@@ -364,9 +366,8 @@ class UserInfoBridgeDispatcherSpec {
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
 
         userInfoBridgeDispatcher.onGetContacts(contactsCallbackObj.id)
-        userInfoBridgeDispatcher.getContactsWithoutResult(contactsCallbackObj.id)
 
-        verify(bridgeExecutor, times(2)).postValue(contactsCallbackObj.id, Gson().toJson(contacts))
+        verify(bridgeExecutor).postValue(contactsCallbackObj.id, Gson().toJson(contacts))
     }
     /** end region */
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
@@ -89,14 +89,19 @@ class UserInfoBridgeDispatcherSpec {
     }
 
     /** start region: onGetUserName */
-    private fun createUserNameImpl(hasUserName: Boolean): UserInfoBridgeDispatcher {
+    private fun createUserNameImpl(
+        hasUserName: Boolean,
+        canGetName: Boolean
+    ): UserInfoBridgeDispatcher {
         return if (hasUserName) {
             object : UserInfoBridgeDispatcher() {
+
                 override fun getUserName(): String = ""
 
                 override fun getUserName(callback: (result: Result<String?>) -> Unit) {
                     val result: Result<String> = run {
-                        Result.success(TEST_USER_NAME)
+                        if (canGetName) Result.success(TEST_USER_NAME)
+                        else Result.success("")
                     }
                     callback.invoke(result)
                 }
@@ -108,7 +113,7 @@ class UserInfoBridgeDispatcherSpec {
 
     @Test
     fun `postError should be called when there is no get user name retrieval implementation`() {
-        val userInfoBridgeDispatcher = Mockito.spy(createUserNameImpl(false))
+        val userInfoBridgeDispatcher = Mockito.spy(createUserNameImpl(false, false))
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
         miniAppBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)
         val errMsg = "$ERR_GET_USER_NAME The `UserInfoBridgeDispatcher.getUserName`" +
@@ -120,7 +125,7 @@ class UserInfoBridgeDispatcherSpec {
 
     @Test
     fun `postError should be called when user name permission hasn't been allowed`() {
-        val userInfoBridgeDispatcher = Mockito.spy(createUserNameImpl(true))
+        val userInfoBridgeDispatcher = Mockito.spy(createUserNameImpl(true, false))
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
         val errMsg = "$ERR_GET_USER_NAME Permission has not been accepted yet for getting user name."
         whenever(customPermissionCache.hasPermission(
@@ -134,18 +139,17 @@ class UserInfoBridgeDispatcherSpec {
 
     @Test
     fun `postError should be called when user name is empty`() {
-        val userInfoBridgeDispatcher = Mockito.spy(createUserNameImpl(true))
+        val userInfoBridgeDispatcher = Mockito.spy(createUserNameImpl(true, false))
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
-        val errMsg = "$ERR_GET_USER_NAME User name is not found."
 
         userInfoBridgeDispatcher.onGetUserName(userNameCallbackObj.id)
 
-        verify(bridgeExecutor).postError(userNameCallbackObj.id, errMsg)
+        verify(bridgeExecutor).postValue(userNameCallbackObj.id, "")
     }
 
     @Test
     fun `postValue should be called when onGetUserName retrieve valid user name`() {
-        val userInfoBridgeDispatcher = Mockito.spy(createUserNameImpl(true))
+        val userInfoBridgeDispatcher = Mockito.spy(createUserNameImpl(true, true))
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
         whenever(userInfoBridgeDispatcher.getUserName()).thenReturn(TEST_USER_NAME)
 
@@ -156,14 +160,18 @@ class UserInfoBridgeDispatcherSpec {
     /** end region */
 
     /** start region: onGetProfilePhoto */
-    private fun createProfilePhotoImpl(hasProfilePhoto: Boolean): UserInfoBridgeDispatcher {
+    private fun createProfilePhotoImpl(
+        hasProfilePhoto: Boolean,
+        canGetPhoto: Boolean
+    ): UserInfoBridgeDispatcher {
         return if (hasProfilePhoto) {
             object : UserInfoBridgeDispatcher() {
                 override fun getProfilePhoto(): String = ""
 
                 override fun getProfilePhoto(callback: (result: Result<String?>) -> Unit) {
                     val result: Result<String> = run {
-                        Result.success(TEST_PROFILE_PHOTO)
+                        if (canGetPhoto) Result.success(TEST_PROFILE_PHOTO)
+                        else Result.success("")
                     }
                     callback.invoke(result)
                 }
@@ -175,7 +183,7 @@ class UserInfoBridgeDispatcherSpec {
 
     @Test
     fun `postError should be called when there is no get profile photo retrieval implementation`() {
-        val userInfoBridgeDispatcher = Mockito.spy(createProfilePhotoImpl(false))
+        val userInfoBridgeDispatcher = Mockito.spy(createProfilePhotoImpl(false, false))
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
         miniAppBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)
         val errMsg = "$ERR_GET_PROFILE_PHOTO The `UserInfoBridgeDispatcher.getProfilePhoto`" +
@@ -187,7 +195,7 @@ class UserInfoBridgeDispatcherSpec {
 
     @Test
     fun `postError should be called when profile photo permission hasn't been allowed`() {
-        val userInfoBridgeDispatcher = Mockito.spy(createProfilePhotoImpl(true))
+        val userInfoBridgeDispatcher = Mockito.spy(createProfilePhotoImpl(true, false))
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
         val errMsg = "$ERR_GET_PROFILE_PHOTO Permission has not been accepted yet for getting profile photo."
         whenever(customPermissionCache.hasPermission(
@@ -201,18 +209,17 @@ class UserInfoBridgeDispatcherSpec {
 
     @Test
     fun `postError should be called when profile photo is empty`() {
-        val userInfoBridgeDispatcher = Mockito.spy(createProfilePhotoImpl(true))
+        val userInfoBridgeDispatcher = Mockito.spy(createProfilePhotoImpl(true, false))
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
-        val errMsg = "$ERR_GET_PROFILE_PHOTO Profile photo is not found."
 
         userInfoBridgeDispatcher.onGetProfilePhoto(profilePhotoCallbackObj.id)
 
-        verify(bridgeExecutor).postError(profilePhotoCallbackObj.id, errMsg)
+        verify(bridgeExecutor).postValue(profilePhotoCallbackObj.id, "")
     }
 
     @Test
     fun `postValue should be called when onGetProfilePhoto retrieve valid profile photo url`() {
-        val userInfoBridgeDispatcher = Mockito.spy(createProfilePhotoImpl(true))
+        val userInfoBridgeDispatcher = Mockito.spy(createProfilePhotoImpl(true, true))
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
         whenever(userInfoBridgeDispatcher.getProfilePhoto()).thenReturn(TEST_PROFILE_PHOTO)
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
@@ -175,7 +175,6 @@ class UserInfoBridgeDispatcherSpec {
     fun `postError should be called when profile photo permission hasn't been allowed`() {
         val userInfoBridgeDispatcher = Mockito.spy(createProfilePhotoImpl(true))
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
-        miniAppBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)
         val errMsg = "$ERR_GET_PROFILE_PHOTO Permission has not been accepted yet for getting profile photo."
         whenever(customPermissionCache.hasPermission(
             miniAppInfo.id, MiniAppCustomPermissionType.PROFILE_PHOTO)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
@@ -3,6 +3,7 @@ package com.rakuten.tech.mobile.miniapp.js.userinfo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.gson.Gson
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import com.rakuten.tech.mobile.miniapp.*
@@ -133,6 +134,7 @@ class UserInfoBridgeDispatcherSpec {
         ).thenReturn(false)
 
         userInfoBridgeDispatcher.onGetUserName(userNameCallbackObj.id)
+        userInfoBridgeDispatcher.getUserNameSync(userNameCallbackObj.id)
 
         verify(bridgeExecutor).postError(userNameCallbackObj.id, errMsg)
     }
@@ -143,6 +145,7 @@ class UserInfoBridgeDispatcherSpec {
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
 
         userInfoBridgeDispatcher.onGetUserName(userNameCallbackObj.id)
+        userInfoBridgeDispatcher.getUserNameSync(userNameCallbackObj.id)
 
         verify(bridgeExecutor).postValue(userNameCallbackObj.id, "")
     }
@@ -154,8 +157,9 @@ class UserInfoBridgeDispatcherSpec {
         whenever(userInfoBridgeDispatcher.getUserName()).thenReturn(TEST_USER_NAME)
 
         userInfoBridgeDispatcher.onGetUserName(userNameCallbackObj.id)
+        userInfoBridgeDispatcher.getUserNameSync(userNameCallbackObj.id)
 
-        verify(bridgeExecutor).postValue(userNameCallbackObj.id, TEST_USER_NAME)
+        verify(bridgeExecutor, times(2)).postValue(userNameCallbackObj.id, TEST_USER_NAME)
     }
     /** end region */
 
@@ -203,6 +207,7 @@ class UserInfoBridgeDispatcherSpec {
         ).thenReturn(false)
 
         userInfoBridgeDispatcher.onGetProfilePhoto(profilePhotoCallbackObj.id)
+        userInfoBridgeDispatcher.getProfilePhotoSync(profilePhotoCallbackObj.id)
 
         verify(bridgeExecutor).postError(profilePhotoCallbackObj.id, errMsg)
     }
@@ -213,6 +218,7 @@ class UserInfoBridgeDispatcherSpec {
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
 
         userInfoBridgeDispatcher.onGetProfilePhoto(profilePhotoCallbackObj.id)
+        userInfoBridgeDispatcher.getProfilePhotoSync(profilePhotoCallbackObj.id)
 
         verify(bridgeExecutor).postValue(profilePhotoCallbackObj.id, "")
     }
@@ -224,8 +230,9 @@ class UserInfoBridgeDispatcherSpec {
         whenever(userInfoBridgeDispatcher.getProfilePhoto()).thenReturn(TEST_PROFILE_PHOTO)
 
         userInfoBridgeDispatcher.onGetProfilePhoto(profilePhotoCallbackObj.id)
+        userInfoBridgeDispatcher.getProfilePhotoSync(profilePhotoCallbackObj.id)
 
-        verify(bridgeExecutor).postValue(profilePhotoCallbackObj.id, TEST_PROFILE_PHOTO)
+        verify(bridgeExecutor, times(2)).postValue(profilePhotoCallbackObj.id, TEST_PROFILE_PHOTO)
     }
     /** end region */
 
@@ -272,8 +279,9 @@ class UserInfoBridgeDispatcherSpec {
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
 
         userInfoBridgeDispatcher.onGetAccessToken(tokenCallbackObj.id)
+        userInfoBridgeDispatcher.getAccessTokenWithoutResult(tokenCallbackObj.id)
 
-        verify(bridgeExecutor).postError(tokenCallbackObj.id, errMsg)
+        verify(bridgeExecutor, times(2)).postError(tokenCallbackObj.id, errMsg)
     }
 
     @Test
@@ -282,8 +290,9 @@ class UserInfoBridgeDispatcherSpec {
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
 
         userInfoBridgeDispatcher.onGetAccessToken(tokenCallbackObj.id)
+        userInfoBridgeDispatcher.getAccessTokenWithoutResult(tokenCallbackObj.id)
 
-        verify(bridgeExecutor).postValue(tokenCallbackObj.id, Gson().toJson(testToken))
+        verify(bridgeExecutor, times(2)).postValue(tokenCallbackObj.id, Gson().toJson(testToken))
     }
     /** end region */
 
@@ -332,6 +341,7 @@ class UserInfoBridgeDispatcherSpec {
         ).thenReturn(false)
 
         userInfoBridgeDispatcher.onGetContacts(contactsCallbackObj.id)
+        userInfoBridgeDispatcher.getContactsWithoutResult(contactsCallbackObj.id)
 
         verify(bridgeExecutor).postError(contactsCallbackObj.id, errMsg)
     }
@@ -343,8 +353,9 @@ class UserInfoBridgeDispatcherSpec {
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
 
         userInfoBridgeDispatcher.onGetContacts(contactsCallbackObj.id)
+        userInfoBridgeDispatcher.getContactsWithoutResult(contactsCallbackObj.id)
 
-        verify(bridgeExecutor).postError(contactsCallbackObj.id, errMsg)
+        verify(bridgeExecutor, times(2)).postError(contactsCallbackObj.id, errMsg)
     }
 
     @Test
@@ -353,8 +364,9 @@ class UserInfoBridgeDispatcherSpec {
         userInfoBridgeDispatcher.init(bridgeExecutor, customPermissionCache, TEST_MA_ID)
 
         userInfoBridgeDispatcher.onGetContacts(contactsCallbackObj.id)
+        userInfoBridgeDispatcher.getContactsWithoutResult(contactsCallbackObj.id)
 
-        verify(bridgeExecutor).postValue(contactsCallbackObj.id, Gson().toJson(contacts))
+        verify(bridgeExecutor, times(2)).postValue(contactsCallbackObj.id, Gson().toJson(contacts))
     }
     /** end region */
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
@@ -30,6 +30,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
+import java.lang.Exception
 import java.util.ArrayList
 
 @Suppress("LongMethod", "LargeClass")
@@ -93,6 +94,13 @@ class UserInfoBridgeDispatcherSpec {
         return if (hasUserName) {
             object : UserInfoBridgeDispatcher() {
                 override fun getUserName(): String = ""
+
+                override fun getUserName(callback: (result: Result<String?>) -> Unit) {
+                    val result: Result<String> = run {
+                        Result.success(TEST_USER_NAME)
+                    }
+                    callback.invoke(result)
+                }
             }
         } else {
             object : UserInfoBridgeDispatcher() {}
@@ -153,6 +161,13 @@ class UserInfoBridgeDispatcherSpec {
         return if (hasProfilePhoto) {
             object : UserInfoBridgeDispatcher() {
                 override fun getProfilePhoto(): String = ""
+
+                override fun getProfilePhoto(callback: (result: Result<String?>) -> Unit) {
+                    val result: Result<String> = run {
+                        Result.success(TEST_PROFILE_PHOTO)
+                    }
+                    callback.invoke(result)
+                }
             }
         } else {
             object : UserInfoBridgeDispatcher() {}
@@ -206,7 +221,6 @@ class UserInfoBridgeDispatcherSpec {
 
         verify(bridgeExecutor).postValue(profilePhotoCallbackObj.id, TEST_PROFILE_PHOTO)
     }
-
     /** end region */
 
     /** start region: access token */

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcherSpec.kt
@@ -30,7 +30,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
-import java.lang.Exception
 import java.util.ArrayList
 
 @Suppress("LongMethod", "LargeClass")

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -29,7 +29,10 @@ import com.rakuten.tech.mobile.miniapp.testapp.databinding.MiniAppDisplayActivit
 import com.rakuten.tech.mobile.testapp.helper.AppPermission
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
+import java.lang.Exception
 import java.util.ArrayList
+import kotlin.Result.Companion.failure
+import kotlin.Result.Companion.success
 
 class MiniAppDisplayActivity : BaseActivity() {
 
@@ -160,22 +163,24 @@ class MiniAppDisplayActivity : BaseActivity() {
 
         val userInfoBridgeDispatcher = object : UserInfoBridgeDispatcher() {
 
-            override fun getUserName(
-                onSuccess: (name: String) -> Unit,
-                onError: (message: String) -> Unit
-            ) {
-                val name = AppSettings.instance.profileName
-                if (name.isNotEmpty()) onSuccess(name)
-                else onError("User name is not found.")
+            override fun getUserName(callback: (result: Result<String?>) -> Unit) {
+                val result: Result<String> = run {
+                    val name = AppSettings.instance.profileName
+                    if (name.isNotEmpty()) success(name)
+                    else failure(Exception("User name is not found."))
+                }
+
+                callback.invoke(result)
             }
 
-            override fun getProfilePhoto(
-                onSuccess: (photoUrl: String) -> Unit,
-                onError: (message: String) -> Unit
-            ) {
-                val photoUrl = AppSettings.instance.profilePictureUrlBase64
-                if (photoUrl.isNotEmpty()) onSuccess(photoUrl)
-                else onError("Profile photo is not found.")
+            override fun getProfilePhoto(callback: (result: Result<String?>) -> Unit) {
+                val result: Result<String> = run {
+                    val photoUrl = AppSettings.instance.profilePictureUrlBase64
+                    if (photoUrl.isNotEmpty()) success(photoUrl)
+                    else failure(Exception("Profile photo is not found."))
+                }
+
+                callback.invoke(result)
             }
 
             override fun getAccessToken(

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -159,9 +159,24 @@ class MiniAppDisplayActivity : BaseActivity() {
         miniAppMessageBridge.allowScreenOrientation(true)
 
         val userInfoBridgeDispatcher = object : UserInfoBridgeDispatcher() {
-            override fun getUserName(): String = AppSettings.instance.profileName
 
-            override fun getProfilePhoto(): String = AppSettings.instance.profilePictureUrlBase64
+            override fun getUserName(
+                onSuccess: (name: String) -> Unit,
+                onError: (message: String) -> Unit
+            ) {
+                val name = AppSettings.instance.profileName
+                if (name.isNotEmpty()) onSuccess(name)
+                else onError("User name is not found.")
+            }
+
+            override fun getProfilePhoto(
+                onSuccess: (photoUrl: String) -> Unit,
+                onError: (message: String) -> Unit
+            ) {
+                val photoUrl = AppSettings.instance.profilePictureUrlBase64
+                if (photoUrl.isNotEmpty()) onSuccess(photoUrl)
+                else onError("Profile photo is not found.")
+            }
 
             override fun getAccessToken(
                 miniAppId: String,


### PR DESCRIPTION
# Description
Change `MiniAppMessageBridge.getProfilePhoto` and `MiniAppMessageBridge.getUserName` to use a callback so that the photo and name can be retrieved/generated asynchronously. Deprecate the old synchronous versions of these methods.

## Links
- MINI-2120

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
