### PR TITLE
ux debt: show text as notification when contacts are not saved 

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactListActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactListActivity.kt
@@ -104,12 +104,10 @@ class ContactListActivity : BaseActivity() {
         if (!isFirstLaunch && settings.isContactsSaved) {
             if (settings.contactNames.isEmpty()) {
                 renderAdapter(arrayListOf())
-                checkEmpty()
             } else renderAdapter(settings.contactNames)
         } else {
             val randomList = createRandomUUIDList()
             renderAdapter(randomList)
-            settings.contactNames = randomList
         }
     }
 
@@ -132,26 +130,39 @@ class ContactListActivity : BaseActivity() {
             @SuppressLint("SyntheticAccessor")
             override fun onChanged() {
                 super.onChanged()
-                checkEmpty()
+                observeUIState()
             }
 
             @SuppressLint("SyntheticAccessor")
             override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
                 super.onItemRangeInserted(positionStart, itemCount)
-                checkEmpty()
+                observeUIState()
             }
 
             @SuppressLint("SyntheticAccessor")
             override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
                 super.onItemRangeRemoved(positionStart, itemCount)
-                checkEmpty()
+                observeUIState()
             }
         })
+        observeUIState()
     }
 
-    private fun checkEmpty() {
-        binding.viewEmptyContact.visibility =
-            if (adapter.itemCount == 0) View.VISIBLE else View.GONE
+    private fun observeUIState() {
+        when {
+            adapter.itemCount == 0 -> {
+                binding.viewEmptyContact.visibility = View.VISIBLE
+                binding.statusNoContact.visibility = View.GONE
+            }
+            adapter.itemCount != 0 && !settings.isContactsSaved -> {
+                binding.viewEmptyContact.visibility = View.GONE
+                binding.statusNoContact.visibility = View.VISIBLE
+            }
+            else -> {
+                binding.viewEmptyContact.visibility = View.GONE
+                binding.statusNoContact.visibility = View.GONE
+            }
+        }
     }
 
     companion object {

--- a/testapp/src/main/res/layout/contacts_activity.xml
+++ b/testapp/src/main/res/layout/contacts_activity.xml
@@ -15,6 +15,19 @@
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent">
 
+      <TextView
+        android:id="@+id/status_no_contact"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/small_4"
+        android:background="@color/bg_section"
+        android:gravity="center"
+        android:text="@string/userdata_warning_not_saved_contact"
+        android:textColor="@color/colorAccent"
+        android:textSize="@dimen/text_medium_14"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
       <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/listContacts"
         android:layout_width="match_parent"

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     <string name="userdata_hint_edit_contact">Write contact name here</string>
     <string name="userdata_error_invalid_contact">Invalid Contact ID, please try again.</string>
     <string name="userdata_warning_empty_contact_list">No contact available!</string>
-    <string name="userdata_warning_not_saved_contact">No contact has been saved yet.</string>
+    <string name="userdata_warning_not_saved_contact">No contact has been saved yet</string>
 
     <string name="action_display">Display</string>
     <string name="action_go_input">Display Miniapp From ID or URL</string>

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="userdata_hint_edit_contact">Write contact name here</string>
     <string name="userdata_error_invalid_contact">Invalid Contact ID, please try again.</string>
     <string name="userdata_warning_empty_contact_list">No contact available!</string>
+    <string name="userdata_warning_not_saved_contact">No contact has been saved yet.</string>
 
     <string name="action_display">Display</string>
     <string name="action_go_input">Display Miniapp From ID or URL</string>


### PR DESCRIPTION
# Description
Previously, there was no ux acknowledgement when contacts are saved or not, this PR aims to improve this ux.

Business logic expectation: if no contacts saved, it will not show in sample miniapp. should be same experience like username / profile photo.

## Screenshot
<img width="306" alt="Screen Shot 2020-12-17 at 12 33 53" src="https://user-images.githubusercontent.com/66930373/102440761-2f55ee00-4064-11eb-9232-3f9e917e00c3.png">

## Links
TBD

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
