### PR TITLE
fix: MiniAppHttpWebView init once

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -51,7 +51,8 @@ internal open class MiniAppWebView(
     }
 
     init {
-        commonInit()
+        if (this::class.java.simpleName == "MiniAppWebView")
+            commonInit()
     }
 
     @Suppress("LongMethod")


### PR DESCRIPTION
# Description
Loading by url should not call `commonInit()` twice.

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
