### PR TITLE
fix: proguard check MiniAppWebView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+2.7.1 (2020-12-23)
+**SDK**
+- **Fix:** MiniApp view did not display due to obfuscation code guard.
+
 2.7.0 (2020-12-18)
 **SDK**
 - **Feature:** Added `rakuten.miniapp.device.LOCATION` custom permission.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
 ## CHANGELOG
 
-2.X.X (In progress)
+2.7.0 (2020-12-18)
 **SDK**
 - **Feature:** Added `rakuten.miniapp.device.LOCATION` custom permission.
 - **Feature:** Added `getContacts()` interface in `UserInfoBridgeDispatcher` for receiving list of contact IDs.
+- **Feature:** Support loading miniapp by url. This feature is only for QA purpose to let developers have a quick look at their miniapps.
 - **Change:** Remove `app_name` property.
 
 **Sample App**
 - **Feature:** `rakuten.miniapp.device.LOCATION` permission as "Location" in custom permissions settings screen is visible now.
+- **Feature:** Support loading miniapp by url. This enables developers to test while their miniapps are still in development.
 - **Change:** Added `getContacts()` implementation for sending the list of contact IDs.
+- **Change:** Disable Google backup.
 
 ### 2.6.0 (2020-11-27)
 **SDK**

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -51,7 +51,7 @@ internal open class MiniAppWebView(
     }
 
     init {
-        if (this::class.java.simpleName == "MiniAppWebView")
+        if (this::class.java == MiniAppWebView::class.java)
             commonInit()
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -51,7 +51,7 @@ internal open class MiniAppWebView(
     }
 
     init {
-        if (this::class.java == MiniAppWebView::class.java)
+        if (this::class == MiniAppWebView::class)
             commonInit()
     }
 


### PR DESCRIPTION
# Description
Fix miniapp view init due to R8 obfuscation.

## Links
MINI-2445

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
