### PR TITLE
feat: pass parameters to a mini app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 ## CHANGELOG
 
-2.7.1 (2020-12-23)
+### 2.X.X (In progress)
+**SDK**
+- **Feature:** Added `queryParams: String` using `MiniApp.create` and `MiniApp.createWithUrl` for appending it with the miniapp's url.
+
+**Sample App**
+- **Feature:** Added input option in settings screen to keep query parameters to be passed using `MiniApp.create` and `MiniApp.createWithUrl`.
+
+### 2.7.1 (2020-12-23)
 **SDK**
 - **Fix:** MiniApp view did not display due to obfuscation code guard.
 
-2.7.0 (2020-12-18)
+### 2.7.0 (2020-12-18)
 **SDK**
 - **Feature:** Added `rakuten.miniapp.device.LOCATION` custom permission.
 - **Feature:** Added `getContacts()` interface in `UserInfoBridgeDispatcher` for receiving list of contact IDs.

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -576,6 +576,26 @@ downloadedMiniApps.forEach {
 }
 ```
 
+### Passing parameters to a miniapp
+
+For a mini app, you can pass query parameters as String using `MiniApp.create` to be appended with miniapp's url.
+For example: `https://mscheme.1234/miniapp/index.html?param1=value1&param2=value2`
+
+```kotlin
+class MiniAppActivity : Activity(), CoroutineScope {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+    //...
+        launch {
+            val miniAppDisplay = withContext(Dispatchers.IO) {
+                MiniApp.instance().create("mini_app_id", "param1=value1&param2=value2", miniAppMessageBridge)
+            }
+    //...
+        }
+    }
+}
+```
+
 ## Troubleshooting & FAQs
 
 <details><summary markdown="span"><b>Exception: "Network requests must not be performed on the main thread."</b>

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -601,7 +601,7 @@ class MiniAppActivity : Activity(), CoroutineScope {
     //...
         launch {
             val miniAppDisplay = withContext(Dispatchers.IO) {
-                MiniApp.instance().create("mini_app_id", "param1=value1&param2=value2", miniAppMessageBridge)
+                MiniApp.instance().create("mini_app_id", miniAppMessageBridge, "param1=value1&param2=value2")
             }
     //...
         }

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -601,7 +601,12 @@ class MiniAppActivity : Activity(), CoroutineScope {
     //...
         launch {
             val miniAppDisplay = withContext(Dispatchers.IO) {
-                MiniApp.instance().create("mini_app_id", miniAppMessageBridge, "param1=value1&param2=value2")
+                MiniApp.instance().create(
+                    appId = "mini_app_id",
+                    miniAppMessageBridge = miniAppMessageBridge,
+                    miniAppNavigator = miniAppNavigator,
+                    queryParams = "param1=value1&param2=value2"
+                )
             }
     //...
         }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -34,6 +34,7 @@ abstract class MiniApp internal constructor() {
      * Creates a mini app.
      * The mini app is downloaded, saved and provides a [MiniAppDisplay] when successful.
      * @param appId mini app id.
+     * @param appUrlParameters the parameters will be appended with the appUrl.
      * @param miniAppMessageBridge the interface for communicating between host app & mini app.
      * @param miniAppNavigator allow host app to handle specific urls such as external link.
      * @throws [MiniAppNotFoundException] when the specified project ID does not have any mini app exist on the server.
@@ -45,6 +46,7 @@ abstract class MiniApp internal constructor() {
     @Throws(MiniAppNotFoundException::class, MiniAppHasNoPublishedVersionException::class, MiniAppSdkException::class)
     abstract suspend fun create(
         appId: String,
+        appUrlParameters: String,
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator? = null
     ): MiniAppDisplay
@@ -54,6 +56,7 @@ abstract class MiniApp internal constructor() {
      * This should only be used in "Preview Mode".
      * The mini app is downloaded, saved and provides a [MiniAppDisplay] when successful.
      * @param appInfo metadata of a mini app.
+     * @param appUrlParameters the parameters will be appended with the appUrl.
      * @param miniAppMessageBridge the interface for communicating between host app & mini app.
      * @param miniAppNavigator allow host app to handle specific urls such as external link.
      * @throws [MiniAppNotFoundException] when the specified project ID does not have any mini app exist on the server.
@@ -65,6 +68,7 @@ abstract class MiniApp internal constructor() {
     @Throws(MiniAppNotFoundException::class, MiniAppHasNoPublishedVersionException::class, MiniAppSdkException::class)
     abstract suspend fun create(
         appInfo: MiniAppInfo,
+        appUrlParameters: String,
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator? = null
     ): MiniAppDisplay

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -34,9 +34,9 @@ abstract class MiniApp internal constructor() {
      * Creates a mini app.
      * The mini app is downloaded, saved and provides a [MiniAppDisplay] when successful.
      * @param appId mini app id.
-     * @param queryParams the parameters will be appended with the miniapp url scheme.
      * @param miniAppMessageBridge the interface for communicating between host app & mini app.
      * @param miniAppNavigator allow host app to handle specific urls such as external link.
+     * @param queryParams the parameters will be appended with the miniapp url scheme.
      * @throws [MiniAppNotFoundException] when the specified project ID does not have any mini app exist on the server.
      * @throws [MiniAppHasNoPublishedVersionException] when the specified mini app ID exists on the
      * server but has no published versions
@@ -46,9 +46,9 @@ abstract class MiniApp internal constructor() {
     @Throws(MiniAppNotFoundException::class, MiniAppHasNoPublishedVersionException::class, MiniAppSdkException::class)
     abstract suspend fun create(
         appId: String,
-        queryParams: String,
         miniAppMessageBridge: MiniAppMessageBridge,
-        miniAppNavigator: MiniAppNavigator? = null
+        miniAppNavigator: MiniAppNavigator? = null,
+        queryParams: String = ""
     ): MiniAppDisplay
 
     /**
@@ -56,9 +56,9 @@ abstract class MiniApp internal constructor() {
      * This should only be used in "Preview Mode".
      * The mini app is downloaded, saved and provides a [MiniAppDisplay] when successful.
      * @param appInfo metadata of a mini app.
-     * @param queryParams the parameters will be appended with the miniapp url scheme.
      * @param miniAppMessageBridge the interface for communicating between host app & mini app.
      * @param miniAppNavigator allow host app to handle specific urls such as external link.
+     * @param queryParams the parameters will be appended with the miniapp url scheme.
      * @throws [MiniAppNotFoundException] when the specified project ID does not have any mini app exist on the server.
      * @throws [MiniAppHasNoPublishedVersionException] when the specified mini app ID exists on the
      * server but has no published versions
@@ -68,9 +68,9 @@ abstract class MiniApp internal constructor() {
     @Throws(MiniAppNotFoundException::class, MiniAppHasNoPublishedVersionException::class, MiniAppSdkException::class)
     abstract suspend fun create(
         appInfo: MiniAppInfo,
-        queryParams: String,
         miniAppMessageBridge: MiniAppMessageBridge,
-        miniAppNavigator: MiniAppNavigator? = null
+        miniAppNavigator: MiniAppNavigator? = null,
+        queryParams: String = ""
     ): MiniAppDisplay
 
     /**
@@ -78,18 +78,18 @@ abstract class MiniApp internal constructor() {
      * Mini app is NOT downloaded and cached in local, its content are read directly from the url.
      * This should only be used for previewing a mini app from a local server.
      * @param appUrl a HTTP url containing Mini App content.
-     * @param queryParams the parameters will be appended with miniapp url scheme.
      * @param miniAppMessageBridge the interface for communicating between host app & mini app.
      * @param miniAppNavigator allow host app to handle specific urls such as external link.
+     * @param queryParams the parameters will be appended with the miniapp url scheme.
      * @throws [MiniAppNotFoundException] when the specified Mini App URL cannot be reached.
      * @throws [MiniAppSdkException] when there is any other issue during loading or creating the view.
      */
     @Throws(MiniAppNotFoundException::class, MiniAppSdkException::class)
     abstract suspend fun createWithUrl(
         appUrl: String,
-        queryParams: String,
         miniAppMessageBridge: MiniAppMessageBridge,
-        miniAppNavigator: MiniAppNavigator? = null
+        miniAppNavigator: MiniAppNavigator? = null,
+        queryParams: String = ""
     ): MiniAppDisplay
 
     /**

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -34,7 +34,7 @@ abstract class MiniApp internal constructor() {
      * Creates a mini app.
      * The mini app is downloaded, saved and provides a [MiniAppDisplay] when successful.
      * @param appId mini app id.
-     * @param appUrlParameters the parameters will be appended with the appUrl.
+     * @param queryParams the parameters will be appended with the miniapp url scheme.
      * @param miniAppMessageBridge the interface for communicating between host app & mini app.
      * @param miniAppNavigator allow host app to handle specific urls such as external link.
      * @throws [MiniAppNotFoundException] when the specified project ID does not have any mini app exist on the server.
@@ -46,7 +46,7 @@ abstract class MiniApp internal constructor() {
     @Throws(MiniAppNotFoundException::class, MiniAppHasNoPublishedVersionException::class, MiniAppSdkException::class)
     abstract suspend fun create(
         appId: String,
-        appUrlParameters: String,
+        queryParams: String,
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator? = null
     ): MiniAppDisplay
@@ -56,7 +56,7 @@ abstract class MiniApp internal constructor() {
      * This should only be used in "Preview Mode".
      * The mini app is downloaded, saved and provides a [MiniAppDisplay] when successful.
      * @param appInfo metadata of a mini app.
-     * @param appUrlParameters the parameters will be appended with the appUrl.
+     * @param queryParams the parameters will be appended with the miniapp url scheme.
      * @param miniAppMessageBridge the interface for communicating between host app & mini app.
      * @param miniAppNavigator allow host app to handle specific urls such as external link.
      * @throws [MiniAppNotFoundException] when the specified project ID does not have any mini app exist on the server.
@@ -68,7 +68,7 @@ abstract class MiniApp internal constructor() {
     @Throws(MiniAppNotFoundException::class, MiniAppHasNoPublishedVersionException::class, MiniAppSdkException::class)
     abstract suspend fun create(
         appInfo: MiniAppInfo,
-        appUrlParameters: String,
+        queryParams: String,
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator? = null
     ): MiniAppDisplay
@@ -78,6 +78,7 @@ abstract class MiniApp internal constructor() {
      * Mini app is NOT downloaded and cached in local, its content are read directly from the url.
      * This should only be used for previewing a mini app from a local server.
      * @param appUrl a HTTP url containing Mini App content.
+     * @param queryParams the parameters will be appended with miniapp url scheme.
      * @param miniAppMessageBridge the interface for communicating between host app & mini app.
      * @param miniAppNavigator allow host app to handle specific urls such as external link.
      * @throws [MiniAppNotFoundException] when the specified Mini App URL cannot be reached.
@@ -86,6 +87,7 @@ abstract class MiniApp internal constructor() {
     @Throws(MiniAppNotFoundException::class, MiniAppSdkException::class)
     abstract suspend fun createWithUrl(
         appUrl: String,
+        queryParams: String,
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator? = null
     ): MiniAppDisplay

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppScheme.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppScheme.kt
@@ -35,6 +35,23 @@ internal class MiniAppScheme private constructor(miniAppId: String) {
         }
     }
 
+    fun appendParametersToUrl(url: String, queryParams: String): String {
+        return if (queryParams.isEmpty()) url
+        else "$url${resolveParameters(queryParams)}"
+    }
+
+    private fun resolveParameters(queryParams: String): String {
+        // regex for the expected format of query parameters
+        // e.g. https://mscheme.XXXX/miniapp/index.html?param1=value1&param2=value2
+        val regex = Regex("^\\?([\\w-]+(=[\\w-]*)?(&[\\w-]+(=[\\w-]*)?)*)?\$")
+        val qusMark = "?"
+        val input =
+            if (queryParams.contains(qusMark) && queryParams.startsWith(qusMark)) queryParams
+            else qusMark + queryParams
+
+        return if (regex.matches(input)) input else ""
+    }
+
     internal fun openPhoneDialer(context: Context, url: String) = Intent(Intent.ACTION_DIAL).let {
         it.data = url.toUri()
         context.startActivity(it)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppScheme.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppScheme.kt
@@ -2,6 +2,7 @@ package com.rakuten.tech.mobile.miniapp
 
 import android.content.Context
 import android.content.Intent
+import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 
 internal class MiniAppScheme private constructor(miniAppId: String) {
@@ -40,16 +41,11 @@ internal class MiniAppScheme private constructor(miniAppId: String) {
         else "$url${resolveParameters(queryParams)}"
     }
 
-    private fun resolveParameters(queryParams: String): String {
-        // regex for the expected format of query parameters
-        // e.g. https://mscheme.XXXX/miniapp/index.html?param1=value1&param2=value2
-        val regex = Regex("^\\?([\\w-]+(=[\\w-]*)?(&[\\w-]+(=[\\w-]*)?)*)?\$")
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun resolveParameters(queryParams: String): String {
         val qusMark = "?"
-        val input =
-            if (queryParams.contains(qusMark) && queryParams.startsWith(qusMark)) queryParams
-            else qusMark + queryParams
-
-        return if (regex.matches(input)) input else ""
+        return if (queryParams.contains(qusMark) && queryParams.startsWith(qusMark)) queryParams
+        else qusMark + queryParams
     }
 
     internal fun openPhoneDialer(context: Context, url: String) = Intent(Intent.ACTION_DIAL).let {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppScheme.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppScheme.kt
@@ -42,11 +42,7 @@ internal class MiniAppScheme private constructor(miniAppId: String) {
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    fun resolveParameters(queryParams: String): String {
-        val qusMark = "?"
-        return if (queryParams.contains(qusMark) && queryParams.startsWith(qusMark)) queryParams
-        else qusMark + queryParams
-    }
+    fun resolveParameters(queryParams: String): String = "?$queryParams"
 
     internal fun openPhoneDialer(context: Context, url: String) = Intent(Intent.ACTION_DIAL).let {
         it.data = url.toUri()

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -39,44 +39,47 @@ internal class RealMiniApp(
 
     override suspend fun create(
         appId: String,
-        appUrlParameters: String,
+        queryParams: String,
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator?
     ): MiniAppDisplay = when {
         appId.isBlank() -> throw sdkExceptionForInvalidArguments()
         else -> {
-            val (basePath, miniAppInfo) = miniAppDownloader.getMiniApp(appId, appUrlParameters)
+            val (basePath, miniAppInfo) = miniAppDownloader.getMiniApp(appId)
             displayer.createMiniAppDisplay(
                 basePath,
                 miniAppInfo,
                 miniAppMessageBridge,
                 miniAppNavigator,
-                miniAppCustomPermissionCache
+                miniAppCustomPermissionCache,
+                queryParams
             )
         }
     }
 
     override suspend fun create(
         appInfo: MiniAppInfo,
-        appUrlParameters: String,
+        queryParams: String,
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator?
     ): MiniAppDisplay = when {
         appInfo.id.isBlank() -> throw sdkExceptionForInvalidArguments()
         else -> {
-            val (basePath, miniAppInfo) = miniAppDownloader.getMiniApp(appInfo, appUrlParameters)
+            val (basePath, miniAppInfo) = miniAppDownloader.getMiniApp(appInfo)
             displayer.createMiniAppDisplay(
                 basePath,
                 miniAppInfo,
                 miniAppMessageBridge,
                 miniAppNavigator,
-                miniAppCustomPermissionCache
+                miniAppCustomPermissionCache,
+                queryParams
             )
         }
     }
 
     override suspend fun createWithUrl(
         appUrl: String,
+        queryParams: String,
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator?
     ): MiniAppDisplay = when {
@@ -87,7 +90,8 @@ internal class RealMiniApp(
                 appUrl,
                 miniAppMessageBridge,
                 miniAppNavigator,
-                miniAppCustomPermissionCache
+                miniAppCustomPermissionCache,
+                queryParams
             )
         }
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -39,9 +39,9 @@ internal class RealMiniApp(
 
     override suspend fun create(
         appId: String,
-        queryParams: String,
         miniAppMessageBridge: MiniAppMessageBridge,
-        miniAppNavigator: MiniAppNavigator?
+        miniAppNavigator: MiniAppNavigator?,
+        queryParams: String
     ): MiniAppDisplay = when {
         appId.isBlank() -> throw sdkExceptionForInvalidArguments()
         else -> {
@@ -59,9 +59,9 @@ internal class RealMiniApp(
 
     override suspend fun create(
         appInfo: MiniAppInfo,
-        queryParams: String,
         miniAppMessageBridge: MiniAppMessageBridge,
-        miniAppNavigator: MiniAppNavigator?
+        miniAppNavigator: MiniAppNavigator?,
+        queryParams: String
     ): MiniAppDisplay = when {
         appInfo.id.isBlank() -> throw sdkExceptionForInvalidArguments()
         else -> {
@@ -79,9 +79,9 @@ internal class RealMiniApp(
 
     override suspend fun createWithUrl(
         appUrl: String,
-        queryParams: String,
         miniAppMessageBridge: MiniAppMessageBridge,
-        miniAppNavigator: MiniAppNavigator?
+        miniAppNavigator: MiniAppNavigator?,
+        queryParams: String
     ): MiniAppDisplay = when {
         appUrl.isBlank() -> throw sdkExceptionForInvalidArguments()
         else -> {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -39,12 +39,13 @@ internal class RealMiniApp(
 
     override suspend fun create(
         appId: String,
+        appUrlParameters: String,
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator?
     ): MiniAppDisplay = when {
         appId.isBlank() -> throw sdkExceptionForInvalidArguments()
         else -> {
-            val (basePath, miniAppInfo) = miniAppDownloader.getMiniApp(appId)
+            val (basePath, miniAppInfo) = miniAppDownloader.getMiniApp(appId, appUrlParameters)
             displayer.createMiniAppDisplay(
                 basePath,
                 miniAppInfo,
@@ -57,12 +58,13 @@ internal class RealMiniApp(
 
     override suspend fun create(
         appInfo: MiniAppInfo,
+        appUrlParameters: String,
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator?
     ): MiniAppDisplay = when {
         appInfo.id.isBlank() -> throw sdkExceptionForInvalidArguments()
         else -> {
-            val (basePath, miniAppInfo) = miniAppDownloader.getMiniApp(appInfo)
+            val (basePath, miniAppInfo) = miniAppDownloader.getMiniApp(appInfo, appUrlParameters)
             displayer.createMiniAppDisplay(
                 basePath,
                 miniAppInfo,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
@@ -14,7 +14,8 @@ internal class Displayer(private val context: Context, private val hostAppUserAg
         miniAppInfo: MiniAppInfo,
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator?,
-        miniAppCustomPermissionCache: MiniAppCustomPermissionCache
+        miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
+        queryParams: String
     ): MiniAppDisplay = RealMiniAppDisplay(
         context = context,
         basePath = basePath,
@@ -22,20 +23,23 @@ internal class Displayer(private val context: Context, private val hostAppUserAg
         miniAppMessageBridge = miniAppMessageBridge,
         miniAppNavigator = miniAppNavigator,
         hostAppUserAgentInfo = hostAppUserAgentInfo,
-        miniAppCustomPermissionCache = miniAppCustomPermissionCache
+        miniAppCustomPermissionCache = miniAppCustomPermissionCache,
+        queryParams = queryParams
     )
 
     fun createMiniAppDisplay(
         appUrl: String,
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator?,
-        miniAppCustomPermissionCache: MiniAppCustomPermissionCache
+        miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
+        queryParams: String
     ): MiniAppDisplay = RealMiniAppDisplay(
         context = context,
         appUrl = appUrl,
         miniAppMessageBridge = miniAppMessageBridge,
         miniAppNavigator = miniAppNavigator,
         hostAppUserAgentInfo = hostAppUserAgentInfo,
-        miniAppCustomPermissionCache = miniAppCustomPermissionCache
+        miniAppCustomPermissionCache = miniAppCustomPermissionCache,
+        queryParams = queryParams
     )
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
@@ -20,7 +20,8 @@ internal class MiniAppHttpWebView(
         context,
         miniAppInfo,
         miniAppCustomPermissionCache
-    )
+    ),
+    queryParams: String
 ) : MiniAppWebView(
     context,
     "",
@@ -29,7 +30,8 @@ internal class MiniAppHttpWebView(
     miniAppNavigator,
     hostAppUserAgentInfo,
     miniAppCustomPermissionCache,
-    miniAppWebChromeClient
+    miniAppWebChromeClient,
+    queryParams
 ) {
     init {
         miniAppScheme = MiniAppScheme.schemeWithCustomUrl(appUrl)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -38,7 +38,7 @@ internal open class MiniAppWebView(
     val queryParams: String
 ) : WebView(context), WebViewListener {
 
-    protected var miniAppScheme = MiniAppScheme.schemeWithAppId(miniAppInfo.id)
+    var miniAppScheme = MiniAppScheme.schemeWithAppId(miniAppInfo.id)
     protected var miniAppId = miniAppInfo.id
 
     @VisibleForTesting

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -34,7 +34,8 @@ internal open class MiniAppWebView(
         context,
         miniAppInfo,
         miniAppCustomPermissionCache
-    )
+    ),
+    val queryParams: String
 ) : WebView(context), WebViewListener {
 
     protected var miniAppScheme = MiniAppScheme.schemeWithAppId(miniAppInfo.id)
@@ -154,7 +155,10 @@ internal open class MiniAppWebView(
         )
         .build()
 
-    internal open fun getLoadUrl(): String = "${miniAppScheme.miniAppCustomDomain}$SUB_DOMAIN_PATH/index.html"
+    internal open fun getLoadUrl(): String {
+        val parentUrl = "${miniAppScheme.miniAppCustomDomain}$SUB_DOMAIN_PATH/index.html"
+        return miniAppScheme.appendParametersToUrl(parentUrl, queryParams)
+    }
 
     protected open fun getMiniAppWebViewClient(): MiniAppWebViewClient = MiniAppWebViewClient(
         context,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
@@ -26,7 +26,8 @@ internal class RealMiniAppDisplay(
     val miniAppMessageBridge: MiniAppMessageBridge,
     val miniAppNavigator: MiniAppNavigator?,
     val hostAppUserAgentInfo: String,
-    val miniAppCustomPermissionCache: MiniAppCustomPermissionCache
+    val miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
+    val queryParams: String
 ) : MiniAppDisplay {
 
     var appUrl: String? = null
@@ -40,7 +41,8 @@ internal class RealMiniAppDisplay(
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator?,
         hostAppUserAgentInfo: String,
-        miniAppCustomPermissionCache: MiniAppCustomPermissionCache
+        miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
+        queryParams: String
     ) : this(
         context,
         "",
@@ -48,7 +50,8 @@ internal class RealMiniAppDisplay(
         miniAppMessageBridge,
         miniAppNavigator,
         hostAppUserAgentInfo,
-        miniAppCustomPermissionCache
+        miniAppCustomPermissionCache,
+        queryParams
     ) {
         this.appUrl = appUrl
     }
@@ -100,7 +103,8 @@ internal class RealMiniAppDisplay(
                     miniAppMessageBridge = miniAppMessageBridge,
                     miniAppNavigator = miniAppNavigator,
                     hostAppUserAgentInfo = hostAppUserAgentInfo,
-                    miniAppCustomPermissionCache = miniAppCustomPermissionCache
+                    miniAppCustomPermissionCache = miniAppCustomPermissionCache,
+                    queryParams = queryParams
                 )
             } else {
                 miniAppWebView = MiniAppWebView(
@@ -110,7 +114,8 @@ internal class RealMiniAppDisplay(
                     miniAppMessageBridge = miniAppMessageBridge,
                     miniAppNavigator = miniAppNavigator,
                     hostAppUserAgentInfo = hostAppUserAgentInfo,
-                    miniAppCustomPermissionCache = miniAppCustomPermissionCache
+                    miniAppCustomPermissionCache = miniAppCustomPermissionCache,
+                    queryParams = queryParams
                 )
             }
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSchemeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSchemeSpec.kt
@@ -74,16 +74,14 @@ internal class MiniAppSchemeSpec {
         schemeWithAppId.appendParametersToUrl(
             expectedUrl,
             expectedQuery
-        ) shouldEqual expectedUrl + expectedQuery
+        ) shouldEqual "$expectedUrl?$expectedQuery"
     }
 
     /** end region */
 
     @Test
     fun `resolveParameters should append qus mark prior to the parameters`() {
-        val expectedQuery1 = "?param1=value1&param2=value2"
-        val expectedQuery2 = "param1=value1&param2=value2"
-        schemeWithAppId.resolveParameters(expectedQuery1) shouldEqual expectedQuery1
-        schemeWithAppId.resolveParameters(expectedQuery2) shouldEqual expectedQuery1
+        val query = "param1=value1&param2=value2"
+        schemeWithAppId.resolveParameters(query) shouldEqual "?$query"
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSchemeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSchemeSpec.kt
@@ -1,0 +1,89 @@
+package com.rakuten.tech.mobile.miniapp
+
+import org.amshove.kluent.shouldEqual
+import org.amshove.kluent.shouldEqualTo
+import org.amshove.kluent.shouldNotEqual
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class MiniAppSchemeSpec {
+
+    private lateinit var schemeWithAppId: MiniAppScheme
+    private lateinit var schemeWithCustomUrl: MiniAppScheme
+
+    @Before
+    fun setup() {
+        schemeWithAppId = MiniAppScheme.schemeWithAppId(TEST_ID_MINIAPP)
+        schemeWithCustomUrl = MiniAppScheme.schemeWithCustomUrl(TEST_URL_HTTPS_1)
+    }
+
+    @Test
+    fun `miniAppDomain with AppId should return the expected value`() {
+        schemeWithAppId.miniAppDomain shouldEqual "mscheme.$TEST_ID_MINIAPP"
+        schemeWithAppId.appUrl shouldEqual null
+    }
+
+    @Test
+    fun `miniAppCustomScheme with AppId should return the expected value`() {
+        schemeWithAppId.miniAppCustomScheme shouldEqual "mscheme.$TEST_ID_MINIAPP://"
+        schemeWithAppId.appUrl shouldEqual null
+    }
+
+    @Test
+    fun `miniAppCustomDomain with AppId should return the expected value`() {
+        schemeWithAppId.miniAppCustomDomain shouldEqual "https://mscheme.$TEST_ID_MINIAPP/"
+        schemeWithAppId.appUrl shouldEqual null
+    }
+
+    @Test
+    fun `miniAppScheme with custom url should return the expected values`() {
+        schemeWithCustomUrl.appUrl shouldEqual TEST_URL_HTTPS_1
+        schemeWithCustomUrl.miniAppDomain shouldNotEqual "mscheme.$TEST_ID_MINIAPP"
+        schemeWithCustomUrl.miniAppCustomScheme shouldNotEqual "mscheme.$TEST_ID_MINIAPP://"
+        schemeWithCustomUrl.miniAppCustomDomain shouldNotEqual "https://mscheme.$TEST_ID_MINIAPP/"
+    }
+
+    /** region: isMiniAppUrl */
+    @Test
+    fun `isMiniAppUrl with AppId should return the expected values`() {
+        schemeWithAppId.isMiniAppUrl("mscheme.$TEST_ID_MINIAPP://") shouldEqualTo true
+        schemeWithAppId.isMiniAppUrl("https://mscheme.$TEST_ID_MINIAPP/") shouldEqualTo true
+    }
+
+    @Test
+    fun `isMiniAppUrl with custom url should return the expected values`() {
+        schemeWithCustomUrl.appUrl shouldEqual TEST_URL_HTTPS_1
+        schemeWithCustomUrl.isMiniAppUrl(TEST_URL_HTTPS_1) shouldEqualTo true
+    }
+    /** end region */
+
+    /** region: appendParametersToUrl */
+    @Test
+    fun `appendParametersToUrl should return the url when query is empty`() {
+        val expectedUrl = "mscheme.$TEST_ID_MINIAPP://"
+        schemeWithAppId.appendParametersToUrl(expectedUrl, "") shouldEqual expectedUrl
+    }
+
+    @Test
+    fun `appendParametersToUrl should return the appended url when query is not empty`() {
+        val expectedUrl = "mscheme.$TEST_ID_MINIAPP://"
+        val expectedQuery = TEST_URL_PARAMS
+        schemeWithAppId.appendParametersToUrl(
+            expectedUrl,
+            expectedQuery
+        ) shouldEqual expectedUrl + expectedQuery
+    }
+
+    /** end region */
+
+    @Test
+    fun `resolveParameters should append qus mark prior to the parameters`() {
+        val expectedQuery1 = "?param1=value1&param2=value2"
+        val expectedQuery2 = "param1=value1&param2=value2"
+        schemeWithAppId.resolveParameters(expectedQuery1) shouldEqual expectedQuery1
+        schemeWithAppId.resolveParameters(expectedQuery2) shouldEqual expectedQuery1
+    }
+}

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -61,13 +61,13 @@ class RealMiniAppSpec {
 
     @Test(expected = MiniAppSdkException::class)
     fun `should throw exception when app id is blank`() = runBlockingTest {
-        realMiniApp.create(" ", miniAppMessageBridge)
+        realMiniApp.create(" ", TEST_URL_PARAMS, miniAppMessageBridge)
     }
 
     @Test(expected = MiniAppSdkException::class)
     fun `should throw exception when id of MiniAppInfo is blank`() = runBlockingTest {
         val testMiniAppInfo = TEST_MA.copy(id = "")
-        realMiniApp.create(testMiniAppInfo, miniAppMessageBridge)
+        realMiniApp.create(testMiniAppInfo, TEST_URL_PARAMS, miniAppMessageBridge)
     }
 
     @Test
@@ -75,12 +75,14 @@ class RealMiniAppSpec {
         runBlockingTest {
             val getMiniAppResult = Pair(TEST_BASE_PATH, TEST_MA)
             When calling miniAppDownloader.getMiniApp(TEST_MA_ID) itReturns getMiniAppResult
-            realMiniApp.create(TEST_MA_ID, miniAppMessageBridge)
+            realMiniApp.create(TEST_MA_ID, TEST_URL_PARAMS, miniAppMessageBridge)
 
             verify(miniAppDownloader, times(1)).getMiniApp(TEST_MA_ID)
             verify(displayer, times(1))
-                .createMiniAppDisplay(getMiniAppResult.first, getMiniAppResult.second,
-                    miniAppMessageBridge, null, miniAppCustomPermissionCache)
+                .createMiniAppDisplay(
+                    getMiniAppResult.first, getMiniAppResult.second,
+                    miniAppMessageBridge, null, miniAppCustomPermissionCache, TEST_URL_PARAMS
+                )
         }
 
     @Test
@@ -88,12 +90,18 @@ class RealMiniAppSpec {
         runBlockingTest {
             val getMiniAppResult = Pair(TEST_BASE_PATH, TEST_MA)
             When calling miniAppDownloader.getMiniApp(TEST_MA) itReturns getMiniAppResult
-            realMiniApp.create(TEST_MA, miniAppMessageBridge, miniAppNavigator)
+            realMiniApp.create(TEST_MA, TEST_URL_PARAMS, miniAppMessageBridge, miniAppNavigator)
 
             verify(miniAppDownloader, times(1)).getMiniApp(TEST_MA)
             verify(displayer, times(1))
-                .createMiniAppDisplay(getMiniAppResult.first, getMiniAppResult.second,
-                    miniAppMessageBridge, miniAppNavigator, miniAppCustomPermissionCache)
+                .createMiniAppDisplay(
+                    getMiniAppResult.first,
+                    getMiniAppResult.second,
+                    miniAppMessageBridge,
+                    miniAppNavigator,
+                    miniAppCustomPermissionCache,
+                    TEST_URL_PARAMS
+                )
         }
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -61,13 +61,13 @@ class RealMiniAppSpec {
 
     @Test(expected = MiniAppSdkException::class)
     fun `should throw exception when app id is blank`() = runBlockingTest {
-        realMiniApp.create(" ", TEST_URL_PARAMS, miniAppMessageBridge)
+        realMiniApp.create(" ", miniAppMessageBridge)
     }
 
     @Test(expected = MiniAppSdkException::class)
     fun `should throw exception when id of MiniAppInfo is blank`() = runBlockingTest {
         val testMiniAppInfo = TEST_MA.copy(id = "")
-        realMiniApp.create(testMiniAppInfo, TEST_URL_PARAMS, miniAppMessageBridge)
+        realMiniApp.create(testMiniAppInfo, miniAppMessageBridge)
     }
 
     @Test
@@ -75,13 +75,13 @@ class RealMiniAppSpec {
         runBlockingTest {
             val getMiniAppResult = Pair(TEST_BASE_PATH, TEST_MA)
             When calling miniAppDownloader.getMiniApp(TEST_MA_ID) itReturns getMiniAppResult
-            realMiniApp.create(TEST_MA_ID, TEST_URL_PARAMS, miniAppMessageBridge)
+            realMiniApp.create(TEST_MA_ID, miniAppMessageBridge)
 
             verify(miniAppDownloader, times(1)).getMiniApp(TEST_MA_ID)
             verify(displayer, times(1))
                 .createMiniAppDisplay(
                     getMiniAppResult.first, getMiniAppResult.second,
-                    miniAppMessageBridge, null, miniAppCustomPermissionCache, TEST_URL_PARAMS
+                    miniAppMessageBridge, null, miniAppCustomPermissionCache, ""
                 )
         }
 
@@ -90,7 +90,7 @@ class RealMiniAppSpec {
         runBlockingTest {
             val getMiniAppResult = Pair(TEST_BASE_PATH, TEST_MA)
             When calling miniAppDownloader.getMiniApp(TEST_MA) itReturns getMiniAppResult
-            realMiniApp.create(TEST_MA, TEST_URL_PARAMS, miniAppMessageBridge, miniAppNavigator)
+            realMiniApp.create(TEST_MA, miniAppMessageBridge, miniAppNavigator)
 
             verify(miniAppDownloader, times(1)).getMiniApp(TEST_MA)
             verify(displayer, times(1))
@@ -100,7 +100,7 @@ class RealMiniAppSpec {
                     miniAppMessageBridge,
                     miniAppNavigator,
                     miniAppCustomPermissionCache,
-                    TEST_URL_PARAMS
+                    ""
                 )
         }
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
@@ -46,4 +46,4 @@ internal val TEST_MA = MiniAppInfo(
     version = Version(versionTag = TEST_MA_VERSION_TAG, versionId = TEST_MA_VERSION_ID)
 )
 
-internal const val TEST_URL_PARAMS = "?param1=value1&param2=value2"
+internal const val TEST_URL_PARAMS = "param1=value1&param2=value2"

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
@@ -45,3 +45,5 @@ internal val TEST_MA = MiniAppInfo(
     icon = TEST_MA_ICON,
     version = Version(versionTag = TEST_MA_VERSION_TAG, versionId = TEST_MA_VERSION_ID)
 )
+
+internal const val TEST_URL_PARAMS = "?param1=value1&param2=value2"

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerSpec.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.LifecycleObserver
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.mock
-import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
+import com.rakuten.tech.mobile.miniapp.*
 import com.rakuten.tech.mobile.miniapp.TEST_HA_NAME
 import com.rakuten.tech.mobile.miniapp.TEST_MA
 import com.rakuten.tech.mobile.miniapp.TEST_MA_URL
@@ -48,7 +48,8 @@ class DisplayerSpec {
             miniAppInfo = TEST_MA,
             miniAppMessageBridge = miniAppMessageBridge,
             miniAppNavigator = mock(),
-            miniAppCustomPermissionCache = mock()
+            miniAppCustomPermissionCache = mock(),
+            queryParams = TEST_URL_PARAMS
         )
 
     private fun getMiniAppDisplayUrl(): MiniAppDisplay =
@@ -56,6 +57,7 @@ class DisplayerSpec {
             appUrl = TEST_MA_URL,
             miniAppMessageBridge = miniAppMessageBridge,
             miniAppNavigator = mock(),
-            miniAppCustomPermissionCache = mock()
+            miniAppCustomPermissionCache = mock(),
+            queryParams = TEST_URL_PARAMS
         )
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -63,7 +63,8 @@ open class BaseWebViewSpec {
                 miniAppNavigator = miniAppNavigator,
                 hostAppUserAgentInfo = TEST_HA_NAME,
                 miniAppWebChromeClient = webChromeClient,
-                miniAppCustomPermissionCache = miniAppCustomPermissionCache
+                miniAppCustomPermissionCache = miniAppCustomPermissionCache,
+                queryParams = TEST_URL_PARAMS
             )
             webResourceRequest = getWebResReq(miniAppWebView.getLoadUrl().toUri())
         }
@@ -83,7 +84,8 @@ class MiniAppHTTPWebViewSpec : BaseWebViewSpec() {
                 miniAppNavigator = miniAppNavigator,
                 hostAppUserAgentInfo = TEST_HA_NAME,
                 miniAppWebChromeClient = webChromeClient,
-                miniAppCustomPermissionCache = miniAppCustomPermissionCache
+                miniAppCustomPermissionCache = miniAppCustomPermissionCache,
+                queryParams = TEST_URL_PARAMS
         )
     }
 
@@ -103,8 +105,8 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
     }
 
     @Test
-    fun `should have corrected load url format`() {
-        miniAppWebView.getLoadUrl() shouldEqual "https://mscheme.${miniAppWebView.miniAppInfo.id}/miniapp/index.html"
+    fun `should start with corrected load url format`() {
+        miniAppWebView.getLoadUrl() shouldEqual "https://mscheme.${miniAppWebView.miniAppInfo.id}/miniapp/index.html$TEST_URL_PARAMS"
     }
 
     @Test
@@ -154,7 +156,8 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
             miniAppNavigator = miniAppNavigator,
             hostAppUserAgentInfo = "",
             miniAppWebChromeClient = webChromeClient,
-            miniAppCustomPermissionCache = mock()
+            miniAppCustomPermissionCache = mock(),
+            queryParams = TEST_URL_PARAMS
         )
         miniAppWebView.settings.userAgentString shouldNotEndWith TEST_HA_NAME
     }
@@ -203,11 +206,12 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
             miniAppNavigator,
             TEST_HA_NAME,
             mock(),
-            mock()
+            mock(),
+            TEST_URL_PARAMS
         )
         val miniAppWebViewForMiniapp2 = MiniAppWebView(
             context, miniAppWebView.basePath, TEST_MA.copy(id = "app-id-2"), miniAppMessageBridge,
-            miniAppNavigator, TEST_HA_NAME, mock(), mock())
+            miniAppNavigator, TEST_HA_NAME, mock(), mock(), TEST_URL_PARAMS)
         miniAppWebViewForMiniapp1.url shouldNotBeEqualTo miniAppWebViewForMiniapp2.url
     }
 
@@ -222,7 +226,7 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
         miniAppWebView.externalResultHandler.emitResult(intent)
 
         miniAppWebView.getLoadUrl() shouldBeEqualTo
-                "https://mscheme.${miniAppWebView.miniAppInfo.id}/miniapp/index.html"
+                "https://mscheme.${miniAppWebView.miniAppInfo.id}/miniapp/index.html$TEST_URL_PARAMS"
     }
 
     @Test
@@ -313,7 +317,8 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
             miniAppNavigator = null,
             hostAppUserAgentInfo = TEST_HA_NAME,
             miniAppWebChromeClient = webChromeClient,
-            miniAppCustomPermissionCache = miniAppCustomPermissionCache
+            miniAppCustomPermissionCache = miniAppCustomPermissionCache,
+            queryParams = TEST_URL_PARAMS
         ))
         val miniAppNavigator = Mockito.spy(displayer.miniAppNavigator)
         val webAssetLoader: WebViewAssetLoader? = (displayer.webViewClient as MiniAppWebViewClient).loader

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -106,7 +106,7 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
 
     @Test
     fun `should start with corrected load url format`() {
-        miniAppWebView.getLoadUrl() shouldEqual "https://mscheme.${miniAppWebView.miniAppInfo.id}/miniapp/index.html$TEST_URL_PARAMS"
+        miniAppWebView.getLoadUrl() shouldEqual "https://mscheme.${miniAppWebView.miniAppInfo.id}/miniapp/index.html?$TEST_URL_PARAMS"
     }
 
     @Test
@@ -226,7 +226,7 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
         miniAppWebView.externalResultHandler.emitResult(intent)
 
         miniAppWebView.getLoadUrl() shouldBeEqualTo
-                "https://mscheme.${miniAppWebView.miniAppInfo.id}/miniapp/index.html$TEST_URL_PARAMS"
+                "https://mscheme.${miniAppWebView.miniAppInfo.id}/miniapp/index.html?$TEST_URL_PARAMS"
     }
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplaySpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplaySpec.kt
@@ -9,10 +9,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
-import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
+import com.rakuten.tech.mobile.miniapp.*
 import com.rakuten.tech.mobile.miniapp.TEST_HA_NAME
 import com.rakuten.tech.mobile.miniapp.TEST_MA
-import com.rakuten.tech.mobile.miniapp.TestActivity
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
@@ -43,7 +42,8 @@ class RealMiniAppDisplaySpec {
                 miniAppMessageBridge = miniAppMessageBridge,
                 miniAppNavigator = mock(),
                 hostAppUserAgentInfo = TEST_HA_NAME,
-                miniAppCustomPermissionCache = mock()
+                miniAppCustomPermissionCache = mock(),
+                queryParams = TEST_URL_PARAMS
             )
         }
     }
@@ -56,7 +56,8 @@ class RealMiniAppDisplaySpec {
             miniAppMessageBridge = miniAppMessageBridge,
             miniAppNavigator = mock(),
             hostAppUserAgentInfo = TEST_HA_NAME,
-            miniAppCustomPermissionCache = mock()
+            miniAppCustomPermissionCache = mock(),
+            queryParams = TEST_URL_PARAMS
         )
 
         realDisplay.miniAppInfo.apply {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -124,6 +124,7 @@ class MiniAppDisplayActivity : BaseActivity() {
             viewModel.obtainMiniAppDisplayUrl(
                 this@MiniAppDisplayActivity,
                 appUrl,
+                AppSettings.instance.urlParameters,
                 miniAppMessageBridge,
                 miniAppNavigator
             )

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -124,18 +124,18 @@ class MiniAppDisplayActivity : BaseActivity() {
             viewModel.obtainMiniAppDisplayUrl(
                 this@MiniAppDisplayActivity,
                 appUrl,
-                AppSettings.instance.urlParameters,
                 miniAppMessageBridge,
-                miniAppNavigator
+                miniAppNavigator,
+                AppSettings.instance.urlParameters
             )
         } else {
             viewModel.obtainMiniAppDisplay(
                 this@MiniAppDisplayActivity,
                 appInfo,
                 appId!!,
-                AppSettings.instance.urlParameters,
                 miniAppMessageBridge,
-                miniAppNavigator
+                miniAppNavigator,
+                AppSettings.instance.urlParameters
             )
         }
     }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -132,6 +132,7 @@ class MiniAppDisplayActivity : BaseActivity() {
                 this@MiniAppDisplayActivity,
                 appInfo,
                 appId!!,
+                AppSettings.instance.urlParameters,
                 miniAppMessageBridge,
                 miniAppNavigator
             )

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
@@ -38,15 +38,16 @@ class MiniAppDisplayViewModel constructor(
         context: Context,
         appInfo: MiniAppInfo?,
         appId: String,
+        appParameters: String,
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator
     ) = viewModelScope.launch(Dispatchers.IO) {
         try {
             _isLoading.postValue(true)
             miniAppDisplay = if (appInfo != null)
-                miniapp.create(appInfo, miniAppMessageBridge, miniAppNavigator)
+                miniapp.create(appInfo, appParameters, miniAppMessageBridge, miniAppNavigator)
             else
-                miniapp.create(appId, miniAppMessageBridge, miniAppNavigator)
+                miniapp.create(appId, appParameters, miniAppMessageBridge, miniAppNavigator)
             hostLifeCycle?.addObserver(miniAppDisplay)
             _miniAppView.postValue(miniAppDisplay.getMiniAppView(context))
         } catch (e: MiniAppSdkException) {
@@ -71,7 +72,8 @@ class MiniAppDisplayViewModel constructor(
     ) = viewModelScope.launch(Dispatchers.IO) {
         try {
             _isLoading.postValue(true)
-            miniAppDisplay = miniapp.createWithUrl(appUrl, miniAppMessageBridge, miniAppNavigator)
+            miniAppDisplay =
+                miniapp.createWithUrl(appUrl, miniAppMessageBridge, miniAppNavigator)
             hostLifeCycle?.addObserver(miniAppDisplay)
             _miniAppView.postValue(miniAppDisplay.getMiniAppView(context))
         } catch (e: MiniAppSdkException) {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
@@ -67,13 +67,14 @@ class MiniAppDisplayViewModel constructor(
     fun obtainMiniAppDisplayUrl(
         context: Context,
         appUrl: String,
+        appParameters: String,
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator
     ) = viewModelScope.launch(Dispatchers.IO) {
         try {
             _isLoading.postValue(true)
             miniAppDisplay =
-                miniapp.createWithUrl(appUrl, miniAppMessageBridge, miniAppNavigator)
+                miniapp.createWithUrl(appUrl, appParameters, miniAppMessageBridge, miniAppNavigator)
             hostLifeCycle?.addObserver(miniAppDisplay)
             _miniAppView.postValue(miniAppDisplay.getMiniAppView(context))
         } catch (e: MiniAppSdkException) {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
@@ -38,16 +38,16 @@ class MiniAppDisplayViewModel constructor(
         context: Context,
         appInfo: MiniAppInfo?,
         appId: String,
-        appParameters: String,
         miniAppMessageBridge: MiniAppMessageBridge,
-        miniAppNavigator: MiniAppNavigator
+        miniAppNavigator: MiniAppNavigator,
+        appParameters: String
     ) = viewModelScope.launch(Dispatchers.IO) {
         try {
             _isLoading.postValue(true)
             miniAppDisplay = if (appInfo != null)
-                miniapp.create(appInfo, appParameters, miniAppMessageBridge, miniAppNavigator)
+                miniapp.create(appInfo, miniAppMessageBridge, miniAppNavigator, appParameters)
             else
-                miniapp.create(appId, appParameters, miniAppMessageBridge, miniAppNavigator)
+                miniapp.create(appId, miniAppMessageBridge, miniAppNavigator, appParameters)
             hostLifeCycle?.addObserver(miniAppDisplay)
             _miniAppView.postValue(miniAppDisplay.getMiniAppView(context))
         } catch (e: MiniAppSdkException) {
@@ -67,14 +67,14 @@ class MiniAppDisplayViewModel constructor(
     fun obtainMiniAppDisplayUrl(
         context: Context,
         appUrl: String,
-        appParameters: String,
         miniAppMessageBridge: MiniAppMessageBridge,
-        miniAppNavigator: MiniAppNavigator
+        miniAppNavigator: MiniAppNavigator,
+        appParameters: String
     ) = viewModelScope.launch(Dispatchers.IO) {
         try {
             _isLoading.postValue(true)
             miniAppDisplay =
-                miniapp.createWithUrl(appUrl, appParameters, miniAppMessageBridge, miniAppNavigator)
+                miniapp.createWithUrl(appUrl, miniAppMessageBridge, miniAppNavigator, appParameters)
             hostLifeCycle?.addObserver(miniAppDisplay)
             _miniAppView.postValue(miniAppDisplay.getMiniAppView(context))
         } catch (e: MiniAppSdkException) {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -83,6 +83,12 @@ class AppSettings private constructor(context: Context) {
     val isContactsSaved: Boolean
         get() = cache.isContactsSaved
 
+    var urlParameters: String
+        get() = cache.urlParameters ?: ""
+        set(urlParameters) {
+            cache.urlParameters = urlParameters
+        }
+
     val baseUrl = manifestConfig.baseUrl()
 
     val miniAppSettings: MiniAppSdkConfig
@@ -166,6 +172,10 @@ private class Settings(context: Context) {
     val isContactsSaved: Boolean
         get() = prefs.contains(CONTACT_NAMES)
 
+    var urlParameters: String?
+        get() = prefs.getString(URL_PARAMETERS, null)
+        set(urlParameters) = prefs.edit().putString(URL_PARAMETERS, urlParameters).apply()
+
     companion object {
         private const val IS_PREVIEW_MODE = "is_preview_mode"
         private const val APP_ID = "app_id"
@@ -177,5 +187,6 @@ private class Settings(context: Context) {
         private const val PROFILE_PICTURE_URL_BASE_64 = "profile_picture_url_base_64"
         private const val CONTACT_NAMES = "contact_names"
         private const val TOKEN_DATA = "token_data"
+        private const val URL_PARAMETERS = "url_parameters"
     }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
@@ -88,6 +88,7 @@ class SettingsMenuActivity : BaseActivity() {
         updateSettings(
             binding.editProjectId.text.toString(),
             binding.editSubscriptionKey.text.toString(),
+            binding.editParametersUrl.text.toString(),
             binding.switchPreviewMode.isChecked
         )
     }
@@ -102,6 +103,7 @@ class SettingsMenuActivity : BaseActivity() {
         binding.textInfo.text = createBuildInfo()
         binding.editProjectId.setText(settings.projectId)
         binding.editSubscriptionKey.setText(settings.subscriptionKey)
+        binding.editParametersUrl.setText(settings.urlParameters)
         binding.switchPreviewMode.isChecked = settings.isPreviewMode
 
         binding.editProjectId.addTextChangedListener(settingsTextWatcher)
@@ -146,12 +148,19 @@ class SettingsMenuActivity : BaseActivity() {
         }
     }
 
-    private fun updateSettings(projectId: String, subscriptionKey: String, isPreviewMode: Boolean) {
+    private fun updateSettings(
+        projectId: String,
+        subscriptionKey: String,
+        urlParameters: String,
+        isPreviewMode: Boolean
+    ) {
         val appIdHolder = settings.projectId
         val subscriptionKeyHolder = settings.subscriptionKey
+        val urlParametersHolder = settings.urlParameters
         val isPreviewModeHolder = settings.isPreviewMode
         settings.projectId = projectId
         settings.subscriptionKey = subscriptionKey
+        settings.urlParameters = urlParameters
         settings.isPreviewMode = isPreviewMode
 
         launch {
@@ -165,6 +174,7 @@ class SettingsMenuActivity : BaseActivity() {
             } catch (error: MiniAppSdkException) {
                 settings.projectId = appIdHolder
                 settings.subscriptionKey = subscriptionKeyHolder
+                settings.urlParameters = urlParametersHolder
                 settings.isPreviewMode = isPreviewModeHolder
                 runOnUiThread {
                     settingsProgressDialog.cancel()

--- a/testapp/src/main/res/layout/settings_menu_activity.xml
+++ b/testapp/src/main/res/layout/settings_menu_activity.xml
@@ -201,6 +201,30 @@
             android:layout_height="@dimen/horizontal_divider_height"
             android:background="@color/bg_section" />
 
+        <androidx.appcompat.widget.AppCompatTextView
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:paddingTop="@dimen/small_4"
+          android:paddingBottom="@dimen/small_4"
+          android:paddingStart="@dimen/medium_16"
+          android:paddingEnd="@dimen/medium_16"
+          android:background="@color/bg_section"
+          android:text="@string/lb_miniapp_url_parameters" />
+
+        <com.google.android.material.textfield.TextInputLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_margin="@dimen/small_8">
+
+          <androidx.appcompat.widget.AppCompatEditText
+            android:id="@+id/editParametersUrl"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_miniapp_url_parameters"
+            android:imeOptions="actionDone"
+            android:inputType="text" />
+        </com.google.android.material.textfield.TextInputLayout>
+
       </LinearLayout>
 
     </ScrollView>

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="lb_preview_mode">Preview Mode</string>
     <string name="lb_ras">RAS</string>
     <string name="lb_user_details">User Details</string>
-    <string name="lb_miniapp_url_parameters">MiniApp URL Parameters</string>
+    <string name="lb_miniapp_url_parameters">MiniApp URL Query Parameters</string>
     <string name="lb_access_token">Access Token</string>
     <string name="lb_valid_until">Expired Date</string>
     <string name="lb_display_input">Display by Input</string>

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="lb_preview_mode">Preview Mode</string>
     <string name="lb_ras">RAS</string>
     <string name="lb_user_details">User Details</string>
+    <string name="lb_miniapp_url_parameters">MiniApp URL Parameters</string>
     <string name="lb_access_token">Access Token</string>
     <string name="lb_valid_until">Expired Date</string>
     <string name="lb_display_input">Display by Input</string>
@@ -34,6 +35,7 @@
 
     <string name="hint_host_project_id">Host Project ID</string>
     <string name="hint_subscription_key">Subscription Key</string>
+    <string name="hint_miniapp_url_parameters">param1=value1&amp;param2=value2</string>
 
     <string name="error_empty">Required</string>
     <string name="error_invalid_input">Invalid Input</string>


### PR DESCRIPTION
# Description
- Allow the Host App to pass a String parameters to a mini app when calling `MiniApp.create`. The parameters should then be appended to the mini app's URL as query params. For example: `https://mscheme.1234/miniapp/index.html?param1=value1&param2=value2`.
- Update the Demo App settings page with a new setting for the mini app parameters which will be passed to the mini app. 

## Links
- MINI-2284

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
