### PR TITLE
feat: add crash reporting integration in demo app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 **Sample App**
 - **Change:** Replaced the implementation of `getUserName`, `getProfilePhoto` using new interfaces.
+- **Feature:** Added crash reports integration with [app-center diagnostics](https://docs.microsoft.com/en-us/appcenter/diagnostics/).
 
 ### 2.7.1 (2020-12-23)
 **SDK**

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ buildscript {
     ext.gson = '2.8.6'
     ext.google_ads = '19.4.0'
     ext.custom_tab = '1.2.0'
+    ext.appCenterSdkVersion = '4.0.0'
 
 //  Build Config.
     apply from: 'config/index.gradle'

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
@@ -11,7 +11,10 @@ import java.util.ArrayList
 /**
  * A class to provide the interfaces for getting user info e.g. user-name, profile-photo etc.
  */
-@Suppress("TooGenericExceptionCaught", "LongMethod", "UnnecessaryAbstractClass", "LargeClass")
+@Suppress(
+    "TooGenericExceptionCaught", "LongMethod", "UnnecessaryAbstractClass",
+    "LargeClass", "TooManyFunctions"
+)
 abstract class UserInfoBridgeDispatcher {
 
     private lateinit var bridgeExecutor: MiniAppBridgeExecutor

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -40,6 +40,7 @@ android {
             projectId               : property("HOST_PROJECT_ID") ?: "test-host-project-id",
             subscriptionKey         : property("HOST_APP_SUBSCRIPTION_KEY") ?: "test-subs-key",
             adMobAppId              : property("ADMOB_APP_ID") ?: "",
+            appCenterSecret         : property("APPCENTER_SECRET") ?: "",
             appName                 : defaultAppName + " DEBUG"
     ]
     def stagingManifestPlaceholders = debugManifestPlaceholders.clone()
@@ -51,6 +52,7 @@ android {
             projectId               : property("HOST_PROJECT_PROD_ID") ?: "test-host-project-id",
             subscriptionKey         : property("HOST_APP_PROD_SUBSCRIPTION_KEY") ?: "test-subs-key",
             adMobAppId              : property("PROD_ADMOB_APP_ID") ?: "",
+            appCenterSecret         : property("PROD_APPCENTER_SECRET") ?: "",
             appName                 : defaultAppName
     ]
 
@@ -62,6 +64,7 @@ android {
             versionNameSuffix '-DEBUG'
             resValue "string", "build_version", buildVersion
             resValue "string", "miniapp_sdk_version", project.version
+            resValue "string", "appcenter_secret", debugManifestPlaceholders.appCenterSecret
             debuggable true
             minifyEnabled false
 
@@ -70,6 +73,7 @@ android {
         release {
             resValue "string", "build_version", buildVersion
             resValue "string", "miniapp_sdk_version", project.version
+            resValue "string", "appcenter_secret", prodManifestPlaceholders.appCenterSecret
             debuggable true
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
@@ -117,6 +121,7 @@ dependencies {
     implementation "androidx.recyclerview:recyclerview:$recyclerview"
     implementation 'de.hdodenhof:circleimageview:3.1.0'
     implementation "com.google.android.gms:play-services-ads:$google_ads"
+    implementation "com.microsoft.appcenter:appcenter-crashes:$appCenterSdkVersion"
 
     testImplementation "junit:junit:$junit"
 }

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -52,7 +52,7 @@ android {
             projectId               : property("HOST_PROJECT_PROD_ID") ?: "test-host-project-id",
             subscriptionKey         : property("HOST_APP_PROD_SUBSCRIPTION_KEY") ?: "test-subs-key",
             adMobAppId              : property("PROD_ADMOB_APP_ID") ?: "",
-            appCenterSecret         : property("PROD_APPCENTER_SECRET") ?: "",
+            appCenterSecret         : property("APPCENTER_SECRET") ?: "",
             appName                 : defaultAppName
     ]
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/SampleApplication.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/SampleApplication.kt
@@ -2,10 +2,14 @@ package com.rakuten.tech.mobile.testapp
 
 import android.app.Application
 import com.google.android.gms.ads.MobileAds
+import com.microsoft.appcenter.AppCenter
+import com.microsoft.appcenter.crashes.Crashes
+import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.testapp.helper.MiniAppListStore
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
 
-class SampleApplication: Application() {
+class SampleApplication : Application() {
+
     override fun onCreate() {
         super.onCreate()
 
@@ -13,5 +17,11 @@ class SampleApplication: Application() {
         MiniAppListStore.init(this)
         // Enable AdMob
         MobileAds.initialize(this)
+
+        // Enable microsoft.appcenter Crash class
+        AppCenter.start(
+            this, getString(R.string.appcenter_secret),
+            Crashes::class.java
+        )
     }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/SampleApplication.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/SampleApplication.kt
@@ -17,11 +17,7 @@ class SampleApplication : Application() {
         MiniAppListStore.init(this)
         // Enable AdMob
         MobileAds.initialize(this)
-
         // Enable microsoft.appcenter Crash class
-        AppCenter.start(
-            this, getString(R.string.appcenter_secret),
-            Crashes::class.java
-        )
+        AppCenter.start(this, getString(R.string.appcenter_secret), Crashes::class.java)
     }
 }


### PR DESCRIPTION
# Description
Add [appcenter crash reporting library](https://docs.microsoft.com/en-us/appcenter/sdk/crashes/android) to the demo app to diagnosis crash reports in appcenter. 

## Links
- MINI-2009

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
