### PR TITLE
use IO dispatcher to fetch miniapps in settings 

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
@@ -27,7 +27,9 @@ import com.rakuten.tech.mobile.testapp.ui.settings.MenuBaseActivity.Companion.ME
 import com.rakuten.tech.mobile.testapp.ui.userdata.AccessTokenActivity
 import com.rakuten.tech.mobile.testapp.ui.userdata.ContactListActivity
 import com.rakuten.tech.mobile.testapp.ui.userdata.ProfileSettingsActivity
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlin.properties.Delegates
 
 class SettingsMenuActivity : BaseActivity() {
@@ -156,7 +158,9 @@ class SettingsMenuActivity : BaseActivity() {
 
         launch {
             try {
-                MiniApp.instance(AppSettings.instance.miniAppSettings).listMiniApp()
+                withContext(Dispatchers.IO) {
+                    MiniApp.instance(AppSettings.instance.miniAppSettings).listMiniApp()
+                }
                 settings.isSettingSaved = true
                 runOnUiThread {
                     settingsProgressDialog.cancel()


### PR DESCRIPTION
# Description
- `MiniApp.listMiniApp` should be run using `IO` context, this PR aims to add it in demo app's settings screen while fetching the list of miniapps.

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
