### PR TITLE
build: ci job for candidate build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,3 +81,15 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
+      - app-center/publish:
+          name: deploy-test-app-candidate
+          group: Release Candidate
+          file: apk/staging/testapp-staging.apk
+          app: $APP_CENTER_APP_NAME
+          token: $APP_CENTER_TOKEN
+          notes: $CIRCLE_BUILD_URL
+          requires:
+            - android-sdk/build
+          filters:
+            branches:
+              only: candidate


### PR DESCRIPTION
# Description
Deliver the apk from candidate branch.

Using the same staging apk. At first, I want to create the different config for candidate apk build but our CI job is running `./gradlew assemble` which execute all builds so I don't want many apk builds slow down the CI process. 

Note: After merging into `master` branch, `candidate` branch will follow. 

## Links
MINI-2246.

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
