### PR TITLE
docs: Add note about admob not supported on Android 6

### DIFF
--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -374,13 +374,15 @@ The below implementation will allow ads to be shown when mini apps trigger a req
 
 Configure the Android Ads SDK from [here](https://developers.google.com/admob/android/quick-start). Don't forget to [initialize the Ads SDK](https://developers.google.com/admob/android/quick-start#initialize_the_mobile_ads_sdk).
 
+**Note:** We only support AdMob usage on Android 7.0+. Some ads from AdMob have inconsistent behavior on Android 6.0 due to the older webview implementation on those devices.
+
 #### AdMob
 **API Docs:** [AdMobDisplayer](api/com.rakuten.tech.mobile.miniapp.ads/-ad-mob-displayer/)
 
 Set the `AdMobDisplayer` provided by MiniApp SDK. This controller will handle the display of ad so no work is required from host app.
 ```kotlin
 miniAppMessageBridge.setAdMobDisplayer(AdMobDisplayer(activityContext))
-``` 
+```
 
 #### Custom Ads Provider
 **API Docs:** [MiniAppAdDisplayer](com.rakuten.tech.mobile.miniapp.ads/-mini-app-ad-displayer/)


### PR DESCRIPTION
# Description
- docs: Add note about admob not supported on Android 6

## Links
MINI-2207

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
