### PR TITLE
build: no space group

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ workflows:
               ignore: /.*/
       - app-center/publish:
           name: deploy-test-app-candidate
-          group: Release Candidate
+          group: Release_Candidate
           file: apk/staging/testapp-staging.apk
           app: $APP_CENTER_APP_NAME
           token: $APP_CENTER_TOKEN


### PR DESCRIPTION
# Description
There is [error](https://app.circleci.com/pipelines/github/rakutentech/android-miniapp/1252/workflows/32c9e203-bbaf-4f88-9c31-972c9a2d59e5/jobs/1479) when pipeline parameter contains space so I have created the distribution group `Release_Candidate`.

## Links
MINI-2247

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
