### PR TITLE
fix: sample app - display wrong order group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **Change:** Replaced the implementation of `getUserName`, `getProfilePhoto` using new interfaces.
 - **Feature:** Added input option in settings screen to keep query parameters to be passed using `MiniApp.create` and `MiniApp.createWithUrl`.
 - **Feature:** Added crash reports integration with [app-center diagnostics](https://docs.microsoft.com/en-us/appcenter/diagnostics/).
+- **Fix:** Correct the group and order display of miniapp list.
 
 ### 2.7.1 (2020-12-23)
 **SDK**

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListViewModel.kt
@@ -31,7 +31,7 @@ class MiniAppListViewModel constructor(
     fun getMiniAppList() = viewModelScope.launch(Dispatchers.IO) {
         try {
             val miniAppsList = miniapp.listMiniApp()
-            _miniAppListData.postValue(miniAppsList)
+            _miniAppListData.postValue(miniAppsList.sortedBy { it.id })
         } catch (error: MiniAppSdkException) {
             _errorData.postValue(error.message)
         }


### PR DESCRIPTION
# Description
Sample app:
Fix following the change from backend. The list is returned in created date order.

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
