### PR TITLE
disable appcenter crash reporting when debug builds

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/SampleApplication.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/SampleApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.google.android.gms.ads.MobileAds
 import com.microsoft.appcenter.AppCenter
 import com.microsoft.appcenter.crashes.Crashes
+import com.rakuten.tech.mobile.miniapp.testapp.BuildConfig
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.testapp.helper.MiniAppListStore
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
@@ -17,7 +18,8 @@ class SampleApplication : Application() {
         MiniAppListStore.init(this)
         // Enable AdMob
         MobileAds.initialize(this)
-        // Enable microsoft.appcenter Crash class
-        AppCenter.start(this, getString(R.string.appcenter_secret), Crashes::class.java)
+        // Enable microsoft.appcenter Crash class for staging and release builds
+        if (!BuildConfig.DEBUG)
+            AppCenter.start(this, getString(R.string.appcenter_secret), Crashes::class.java)
     }
 }


### PR DESCRIPTION
# Description
App-center crash reporting is enabled for all types of build before this PR, we can skip it for debug build.

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
