### PR TITLE
fix crash reporting for stg, rc and production build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ workflows:
       - app-center/publish:
           name: deploy-test-app-candidate
           group: Release_Candidate
-          file: apk/staging/testapp-rc.apk
+          file: apk/rc/testapp-rc.apk
           app: $APP_CENTER_APP_NAME
           token: $APP_CENTER_TOKEN
           notes: $CIRCLE_BUILD_URL

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -67,6 +67,7 @@ android {
             resValue "string", "appcenter_secret", debugManifestPlaceholders.appCenterSecret
             debuggable true
             minifyEnabled false
+            buildConfigField 'boolean', 'ENABLE_APPCENTER_CRASHLYTICS', 'false'
 
             manifestPlaceholders = debugManifestPlaceholders
         }
@@ -76,6 +77,7 @@ android {
             resValue "string", "appcenter_secret", prodManifestPlaceholders.appCenterSecret
             debuggable true
             minifyEnabled true
+            buildConfigField 'boolean', 'ENABLE_APPCENTER_CRASHLYTICS', 'true'
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 
             manifestPlaceholders = prodManifestPlaceholders
@@ -84,6 +86,7 @@ android {
             initWith release
             applicationIdSuffix '.staging'
             versionNameSuffix "-STG-build-$buildVersion"
+            buildConfigField 'boolean', 'ENABLE_APPCENTER_CRASHLYTICS', 'true'
             matchingFallbacks = ['release', 'debug']
 
             manifestPlaceholders = stagingManifestPlaceholders
@@ -92,6 +95,7 @@ android {
             initWith release
             applicationIdSuffix '.rc'
             versionNameSuffix "-RC-build-$buildVersion"
+            buildConfigField 'boolean', 'ENABLE_APPCENTER_CRASHLYTICS', 'true'
             matchingFallbacks = ['release', 'debug']
 
             manifestPlaceholders = stagingManifestPlaceholders

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/SampleApplication.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/SampleApplication.kt
@@ -18,8 +18,8 @@ class SampleApplication : Application() {
         MiniAppListStore.init(this)
         // Enable AdMob
         MobileAds.initialize(this)
-        // Enable microsoft.appcenter Crash class for staging and release builds
-        if (!BuildConfig.DEBUG)
+        // Enable microsoft.appcenter Crash class for staging, rc and release builds
+        if (BuildConfig.ENABLE_APPCENTER_CRASHLYTICS)
             AppCenter.start(this, getString(R.string.appcenter_secret), Crashes::class.java)
     }
 }


### PR DESCRIPTION
# Description
`BuildConfig.DEBUG` is returning `true` for all builds, so crash reporting is disabled for all builds. This PR will fix this issue.

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
