### PR TITLE
feat: first time screen UI in demo app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **Feature:** Added crash reports integration with [app-center diagnostics](https://docs.microsoft.com/en-us/appcenter/diagnostics/).
 - **Fix:** Correct the group and order display of miniapp list.
 - **Change:** Added the usage of `MiniAppMessageBridge.requestDevicePermission`.
+- **Feature:** Added first-time launching screen before downloading any miniapp.
 
 ### 2.7.1 (2020-12-23)
 **SDK**

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -133,8 +133,7 @@ class MiniAppDisplayActivity : BaseActivity(), FirstTimeWindow.FirstTimeLaunchLi
             )
         } else {
             val firstTimeWindow = FirstTimeWindow(this@MiniAppDisplayActivity, this)
-            if (appInfo != null) firstTimeWindow.initiate(appInfo, "")
-            else firstTimeWindow.initiate(null, appId!!)
+            firstTimeWindow.initiate(appInfo, appId!!)
         }
     }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -27,11 +27,14 @@ import com.rakuten.tech.mobile.miniapp.permission.MiniAppDevicePermissionType
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.MiniAppDisplayActivityBinding
 import com.rakuten.tech.mobile.testapp.helper.AppPermission
+import com.rakuten.tech.mobile.testapp.launchActivity
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
+import com.rakuten.tech.mobile.testapp.ui.display.firsttime.FirstTimeWindow
+import com.rakuten.tech.mobile.testapp.ui.miniapplist.MiniAppListActivity
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
 import java.util.ArrayList
 
-class MiniAppDisplayActivity : BaseActivity() {
+class MiniAppDisplayActivity : BaseActivity(), FirstTimeWindow.FirstTimeLaunchListener {
 
     private lateinit var miniAppMessageBridge: MiniAppMessageBridge
     private lateinit var miniAppNavigator: MiniAppNavigator
@@ -85,7 +88,7 @@ class MiniAppDisplayActivity : BaseActivity() {
 
         val appInfo = intent.getParcelableExtra<MiniAppInfo>(miniAppTag)
         val appUrl = intent.getStringExtra(appUrlTag)
-        var appId = intent.getStringExtra(appIdTag) ?: appInfo?.id
+        val appId = intent.getStringExtra(appIdTag) ?: appInfo?.id
 
         binding = DataBindingUtil.setContentView(this, R.layout.mini_app_display_activity)
 
@@ -129,14 +132,9 @@ class MiniAppDisplayActivity : BaseActivity() {
                 AppSettings.instance.urlParameters
             )
         } else {
-            viewModel.obtainMiniAppDisplay(
-                this@MiniAppDisplayActivity,
-                appInfo,
-                appId!!,
-                miniAppMessageBridge,
-                miniAppNavigator,
-                AppSettings.instance.urlParameters
-            )
+            val firstTimeWindow = FirstTimeWindow(this@MiniAppDisplayActivity, this)
+            if (appInfo != null) firstTimeWindow.initiate(appInfo, "")
+            else firstTimeWindow.initiate(null, appId!!)
         }
     }
 
@@ -244,5 +242,18 @@ class MiniAppDisplayActivity : BaseActivity() {
         if (!viewModel.canGoBackwards()) {
             super.onBackPressed()
         }
+    }
+
+    override fun onFirstTimeAccept(isAccepted: Boolean, appInfo: MiniAppInfo?, miniAppId: String) {
+        if (isAccepted)
+            viewModel.obtainMiniAppDisplay(
+                this@MiniAppDisplayActivity,
+                appInfo,
+                miniAppId,
+                miniAppMessageBridge,
+                miniAppNavigator,
+                AppSettings.instance.urlParameters
+            )
+        else raceExecutor.run { launchActivity<MiniAppListActivity>() }
     }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/firsttime/FirstTimeLaunch.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/firsttime/FirstTimeLaunch.kt
@@ -1,9 +1,0 @@
-package com.rakuten.tech.mobile.testapp.ui.display.firsttime
-
-import androidx.annotation.Keep
-
-@Keep
-data class FirstTimeLaunch(
-    val appId: String,
-    val isFirstTime: Boolean
-)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/firsttime/FirstTimeLaunch.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/firsttime/FirstTimeLaunch.kt
@@ -1,0 +1,9 @@
+package com.rakuten.tech.mobile.testapp.ui.display.firsttime
+
+import androidx.annotation.Keep
+
+@Keep
+data class FirstTimeLaunch(
+    val appId: String,
+    val isFirstTime: Boolean
+)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/firsttime/FirstTimeWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/firsttime/FirstTimeWindow.kt
@@ -3,15 +3,18 @@ package com.rakuten.tech.mobile.testapp.ui.display.firsttime
 import android.app.Activity
 import android.content.Context
 import android.content.SharedPreferences
+import android.net.Uri
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.Button
 import android.widget.ImageView
+import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.testapp.R
+import com.rakuten.tech.mobile.testapp.helper.setIcon
 import java.lang.Exception
 
 class FirstTimeWindow(
@@ -55,6 +58,14 @@ class FirstTimeWindow(
         firstTimeAlertDialog =
             AlertDialog.Builder(activity, R.style.AppTheme_DefaultWindow).create()
         firstTimeAlertDialog.setView(firstTimeLayout)
+
+        setIcon(
+            activity,
+            Uri.parse(miniAppInfo?.icon),
+            firstTimeLayout.findViewById(R.id.firstTimeAppIcon)
+        )
+        firstTimeLayout.findViewById<TextView>(R.id.firstTimeMiniAppInfo).text =
+            miniAppInfo?.displayName + "\n\n" + miniAppInfo?.version
 
         // set action listeners
         firstTimeLayout.findViewById<ImageView>(R.id.firstTimeCloseWindow).setOnClickListener {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/firsttime/FirstTimeWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/firsttime/FirstTimeWindow.kt
@@ -67,9 +67,8 @@ class FirstTimeWindow(
             )
 
             infoView.text = StringBuilder("Name: " + miniAppInfo?.displayName)
-                .append("\n\n")
-                .append("Version: " + miniAppInfo?.version?.versionTag)
-                .append("\n\n").toString()
+                .append("\n")
+                .append("Version: " + miniAppInfo?.version?.versionTag).toString()
         } else {
             infoView.text = "No info found for this miniapp!"
         }
@@ -84,7 +83,7 @@ class FirstTimeWindow(
             firstTimeLaunchListener.onFirstTimeAccept(true, miniAppInfo, miniAppId)
             firstTimeAlertDialog.dismiss()
         }
-        firstTimeLayout.findViewById<Button>(R.id.firstTimeCancel).setOnClickListener {
+        firstTimeLayout.findViewById<TextView>(R.id.firstTimeCancel).setOnClickListener {
             firstTimeLaunchListener.onFirstTimeAccept(false, miniAppInfo, miniAppId)
             firstTimeAlertDialog.dismiss()
         }
@@ -101,9 +100,8 @@ class FirstTimeWindow(
         return true
     }
 
-    private fun storeFirstTime(isFirstTime: Boolean) {
+    private fun storeFirstTime(isFirstTime: Boolean) =
         prefs.edit()?.putBoolean(miniAppId, isFirstTime)?.apply()
-    }
 
     interface FirstTimeLaunchListener {
         fun onFirstTimeAccept(isAccepted: Boolean, appInfo: MiniAppInfo?, miniAppId: String)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/firsttime/FirstTimeWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/firsttime/FirstTimeWindow.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.testapp.ui.display.firsttime
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.SharedPreferences
@@ -7,7 +8,6 @@ import android.net.Uri
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.Button
-import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
@@ -49,6 +49,7 @@ class FirstTimeWindow(
         firstTimeAlertDialog.show()
     }
 
+    @SuppressLint("SetTextI18n")
     private fun initDefaultWindow() {
         // set ui components
         val layoutInflater = LayoutInflater.from(activity)
@@ -58,7 +59,8 @@ class FirstTimeWindow(
         firstTimeAlertDialog.setView(firstTimeLayout)
 
         // set data to ui
-        val infoView = firstTimeLayout.findViewById<TextView>(R.id.firstTimeMiniAppInfo)
+        val nameView = firstTimeLayout.findViewById<TextView>(R.id.firstTimeMiniAppName)
+        val versionView = firstTimeLayout.findViewById<TextView>(R.id.firstTimeMiniAppVersion)
         if (miniAppInfo != null) {
             setIcon(
                 activity,
@@ -66,24 +68,19 @@ class FirstTimeWindow(
                 firstTimeLayout.findViewById(R.id.firstTimeAppIcon)
             )
 
-            infoView.text = StringBuilder("Name: " + miniAppInfo?.displayName)
-                .append("\n")
-                .append("Version: " + miniAppInfo?.version?.versionTag).toString()
+            nameView.text = miniAppInfo?.displayName.toString()
+            versionView.text = "Version: " + miniAppInfo?.version?.versionTag.toString()
         } else {
-            infoView.text = "No info found for this miniapp!"
+            nameView.text = "No info found for this miniapp!"
         }
 
         // set action listeners
-        firstTimeLayout.findViewById<ImageView>(R.id.firstTimeCloseWindow).setOnClickListener {
-            firstTimeLaunchListener.onFirstTimeAccept(false, miniAppInfo, miniAppId)
-            firstTimeAlertDialog.dismiss()
-        }
         firstTimeLayout.findViewById<Button>(R.id.firstTimeAccept).setOnClickListener {
             storeFirstTime(false) // set false when accept
             firstTimeLaunchListener.onFirstTimeAccept(true, miniAppInfo, miniAppId)
             firstTimeAlertDialog.dismiss()
         }
-        firstTimeLayout.findViewById<TextView>(R.id.firstTimeCancel).setOnClickListener {
+        firstTimeLayout.findViewById<Button>(R.id.firstTimeCancel).setOnClickListener {
             firstTimeLaunchListener.onFirstTimeAccept(false, miniAppInfo, miniAppId)
             firstTimeAlertDialog.dismiss()
         }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/firsttime/FirstTimeWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/firsttime/FirstTimeWindow.kt
@@ -10,8 +10,6 @@ import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.testapp.helper.setIcon
@@ -96,14 +94,7 @@ class FirstTimeWindow(
 
     private fun isFirstTime(): Boolean {
         try {
-            if (doesDataExist()) {
-                val firstTimeLaunch: FirstTimeLaunch = Gson().fromJson(
-                    prefs.getString(miniAppId, ""),
-                    object : TypeToken<FirstTimeLaunch>() {}.type
-                )
-
-                return firstTimeLaunch.isFirstTime
-            }
+            if (doesDataExist()) return prefs.getBoolean(miniAppId, DEFAULT_FIRST_TIME)
         } catch (e: Exception) {
             return true
         }
@@ -111,9 +102,7 @@ class FirstTimeWindow(
     }
 
     private fun storeFirstTime(isFirstTime: Boolean) {
-        val firstTimeLaunch = FirstTimeLaunch(miniAppId, isFirstTime)
-        val jsonToStore: String = Gson().toJson(firstTimeLaunch)
-        prefs.edit()?.putString(miniAppId, jsonToStore)?.apply()
+        prefs.edit()?.putBoolean(miniAppId, isFirstTime)?.apply()
     }
 
     interface FirstTimeLaunchListener {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/firsttime/FirstTimeWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/firsttime/FirstTimeWindow.kt
@@ -1,0 +1,110 @@
+package com.rakuten.tech.mobile.testapp.ui.display.firsttime
+
+import android.app.Activity
+import android.content.Context
+import android.content.SharedPreferences
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.Button
+import android.widget.ImageView
+import androidx.appcompat.app.AlertDialog
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.rakuten.tech.mobile.miniapp.MiniAppInfo
+import com.rakuten.tech.mobile.miniapp.testapp.R
+import java.lang.Exception
+
+class FirstTimeWindow(
+    private val activity: Activity,
+    private val firstTimeLaunchListener: FirstTimeLaunchListener
+) {
+    private lateinit var firstTimeAlertDialog: AlertDialog
+    private lateinit var firstTimeLayout: View
+    private var miniAppInfo: MiniAppInfo? = null
+    private var miniAppId: String = ""
+
+    private var prefs: SharedPreferences = activity.getSharedPreferences(
+        "com.rakuten.tech.mobile.miniapp.sample.first_time.launch", Context.MODE_PRIVATE
+    )
+
+    fun initiate(appInfo: MiniAppInfo?, miniAppId: String) {
+        if (appInfo != null) {
+            this.miniAppInfo = appInfo
+            this.miniAppId = miniAppInfo!!.id
+        } else this.miniAppId = miniAppId
+
+        if (isFirstTime()) {
+            launchScreen()
+        } else if (!doesDataExist()) {
+            storeFirstTime(DEFAULT_FIRST_TIME) // should be false only after accept.
+            launchScreen()
+        } else {
+            firstTimeLaunchListener.onFirstTimeAccept(true, miniAppInfo, miniAppId)
+        }
+    }
+
+    private fun launchScreen() {
+        initDefaultWindow()
+        firstTimeAlertDialog.show()
+    }
+
+    private fun initDefaultWindow() {
+        // set ui
+        val layoutInflater = LayoutInflater.from(activity)
+        firstTimeLayout = layoutInflater.inflate(R.layout.window_first_time_miniapp, null)
+        firstTimeAlertDialog =
+            AlertDialog.Builder(activity, R.style.AppTheme_DefaultWindow).create()
+        firstTimeAlertDialog.setView(firstTimeLayout)
+
+        // set action listeners
+        firstTimeLayout.findViewById<ImageView>(R.id.firstTimeCloseWindow).setOnClickListener {
+            firstTimeLaunchListener.onFirstTimeAccept(false, miniAppInfo, miniAppId)
+            firstTimeAlertDialog.dismiss()
+        }
+        firstTimeLayout.findViewById<Button>(R.id.firstTimeAccept).setOnClickListener {
+            storeFirstTime(false) // set false when accept
+            firstTimeLaunchListener.onFirstTimeAccept(true, miniAppInfo, miniAppId)
+            firstTimeAlertDialog.dismiss()
+        }
+        firstTimeLayout.findViewById<Button>(R.id.firstTimeCancel).setOnClickListener {
+            firstTimeLaunchListener.onFirstTimeAccept(false, miniAppInfo, miniAppId)
+            firstTimeAlertDialog.dismiss()
+        }
+    }
+
+    private fun doesDataExist() = prefs.contains(miniAppId)
+
+    private fun isAlreadyDownloaded(appId: String): Boolean {
+        return false
+    }
+
+    private fun isFirstTime(): Boolean {
+        try {
+            if (doesDataExist()) {
+                val firstTimeLaunch: FirstTimeLaunch = Gson().fromJson(
+                    prefs.getString(miniAppId, ""),
+                    object : TypeToken<FirstTimeLaunch>() {}.type
+                )
+
+                return firstTimeLaunch.isFirstTime
+            }
+        } catch (e: Exception) {
+            return true
+        }
+        return true
+    }
+
+    private fun storeFirstTime(isFirstTime: Boolean) {
+        val firstTimeLaunch = FirstTimeLaunch(miniAppId, isFirstTime)
+        val jsonToStore: String = Gson().toJson(firstTimeLaunch)
+        prefs.edit()?.putString(miniAppId, jsonToStore)?.apply()
+    }
+
+    interface FirstTimeLaunchListener {
+        fun onFirstTimeAccept(isAccepted: Boolean, appInfo: MiniAppInfo?, miniAppId: String)
+    }
+
+    private companion object {
+        const val DEFAULT_FIRST_TIME = true
+    }
+}

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/firsttime/FirstTimeWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/firsttime/FirstTimeWindow.kt
@@ -52,20 +52,29 @@ class FirstTimeWindow(
     }
 
     private fun initDefaultWindow() {
-        // set ui
+        // set ui components
         val layoutInflater = LayoutInflater.from(activity)
         firstTimeLayout = layoutInflater.inflate(R.layout.window_first_time_miniapp, null)
         firstTimeAlertDialog =
             AlertDialog.Builder(activity, R.style.AppTheme_DefaultWindow).create()
         firstTimeAlertDialog.setView(firstTimeLayout)
 
-        setIcon(
-            activity,
-            Uri.parse(miniAppInfo?.icon),
-            firstTimeLayout.findViewById(R.id.firstTimeAppIcon)
-        )
-        firstTimeLayout.findViewById<TextView>(R.id.firstTimeMiniAppInfo).text =
-            miniAppInfo?.displayName + "\n\n" + miniAppInfo?.version
+        // set data to ui
+        val infoView = firstTimeLayout.findViewById<TextView>(R.id.firstTimeMiniAppInfo)
+        if (miniAppInfo != null) {
+            setIcon(
+                activity,
+                Uri.parse(miniAppInfo?.icon),
+                firstTimeLayout.findViewById(R.id.firstTimeAppIcon)
+            )
+
+            infoView.text = StringBuilder("Name: " + miniAppInfo?.displayName)
+                .append("\n\n")
+                .append("Version: " + miniAppInfo?.version?.versionTag)
+                .append("\n\n").toString()
+        } else {
+            infoView.text = "No info found for this miniapp!"
+        }
 
         // set action listeners
         firstTimeLayout.findViewById<ImageView>(R.id.firstTimeCloseWindow).setOnClickListener {
@@ -84,10 +93,6 @@ class FirstTimeWindow(
     }
 
     private fun doesDataExist() = prefs.contains(miniAppId)
-
-    private fun isAlreadyDownloaded(appId: String): Boolean {
-        return false
-    }
 
     private fun isFirstTime(): Boolean {
         try {

--- a/testapp/src/main/res/drawable/bg_first_time_accept.xml
+++ b/testapp/src/main/res/drawable/bg_first_time_accept.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item>
+    <shape android:shape="rectangle">
+      <corners android:radius="24dp" />
+      <solid android:color="@color/colorPrimary" />
+    </shape>
+  </item>
+</selector>

--- a/testapp/src/main/res/drawable/bg_first_time_cancel.xml
+++ b/testapp/src/main/res/drawable/bg_first_time_cancel.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item>
+    <shape android:shape="rectangle">
+      <corners android:radius="24dp" />
+      <stroke android:color="@color/colorPrimary" android:width="2dp" />
+    </shape>
+  </item>
+</selector>

--- a/testapp/src/main/res/drawable/ic_close_24px.xml
+++ b/testapp/src/main/res/drawable/ic_close_24px.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M14.59,8L12,10.59 9.41,8 8,9.41 10.59,12 8,14.59 9.41,16 12,13.41 14.59,16 16,14.59 13.41,12 16,9.41 14.59,8zM12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z"/>
+</vector>

--- a/testapp/src/main/res/drawable/ic_close_24px.xml
+++ b/testapp/src/main/res/drawable/ic_close_24px.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-  <path
-      android:fillColor="#FF000000"
-      android:pathData="M14.59,8L12,10.59 9.41,8 8,9.41 10.59,12 8,14.59 9.41,16 12,13.41 14.59,16 16,14.59 13.41,12 16,9.41 14.59,8zM12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z"/>
-</vector>

--- a/testapp/src/main/res/layout/window_first_time_miniapp.xml
+++ b/testapp/src/main/res/layout/window_first_time_miniapp.xml
@@ -39,10 +39,9 @@
 
     <ImageView
       android:id="@+id/firstTimeAppIcon"
-      android:layout_width="@dimen/miniapp_icon_size"
-      android:layout_height="@dimen/miniapp_icon_size"
+      android:layout_width="@dimen/miniapp_logo_size"
+      android:layout_height="@dimen/miniapp_logo_size"
       android:layout_marginTop="@dimen/small_8"
-      android:layout_marginStart="@dimen/small_8"
       android:layout_gravity="center_horizontal"
       android:src="@drawable/ic_default" />
 
@@ -54,6 +53,7 @@
       android:layout_gravity="center_horizontal"
       android:paddingStart="@dimen/medium_16"
       android:paddingEnd="@dimen/medium_16"
+      android:textAlignment="center"
       tools:text="Dummy MiniApp Info" />
   </LinearLayout>
 
@@ -73,16 +73,22 @@
       android:layout_height="wrap_content"
       android:background="@color/colorAccent"
       android:text="@string/action_first_time_accept"
-      android:textColor="@android:color/white" />
+      android:textAllCaps="false"
+      android:textColor="@android:color/white"
+      android:textSize="@dimen/text_large_16" />
 
-    <Button
+    <TextView
       android:id="@+id/firstTimeCancel"
       android:textStyle="bold"
-      android:layout_width="match_parent"
+      android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_marginTop="@dimen/small_8"
+      android:layout_marginTop="@dimen/small_4"
       android:layout_marginStart="@dimen/large_32"
       android:layout_marginEnd="@dimen/large_32"
-      android:text="@string/action_first_time_cancel" />
+      android:padding="@dimen/small_8"
+      android:gravity="center"
+      android:text="@string/action_first_time_cancel"
+      android:textColor="@color/colorPrimary"
+      android:textSize="@dimen/text_large_16" />
   </LinearLayout>
 </RelativeLayout>

--- a/testapp/src/main/res/layout/window_first_time_miniapp.xml
+++ b/testapp/src/main/res/layout/window_first_time_miniapp.xml
@@ -10,56 +10,64 @@
     android:layout_alignParentStart="true"
     android:orientation="vertical">
 
-    <RelativeLayout
-      android:id="@+id/firstTimeTopView"
+    <TextView
+      android:id="@+id/firstTimeTutorial"
+      android:textStyle="bold"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:padding="@dimen/small_8"
-      android:background="@color/window_top_bar">
+      android:padding="@dimen/medium_16"
+      android:background="@color/window_top_bar"
+      android:text="@string/miniapp_first_time_tutorial"
+      android:textColor="@android:color/black"
+      android:textSize="@dimen/text_large_16" />
 
-      <ImageView
-        android:id="@+id/firstTimeCloseWindow"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:padding="@dimen/small_8"
-        android:src="@drawable/ic_close_24px" />
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_margin="@dimen/medium_16"
+      android:padding="@dimen/small_8"
+      android:background="@color/window_top_bar"
+      android:orientation="vertical">
+
+    <ImageView
+        android:id="@+id/firstTimeAppIcon"
+        android:layout_width="@dimen/miniapp_logo_size"
+        android:layout_height="@dimen/miniapp_logo_size"
+        android:layout_marginTop="@dimen/small_8"
+        android:layout_gravity="center_horizontal"
+        android:src="@drawable/ic_default" />
 
       <TextView
-        android:id="@+id/firstTimeTutorial"
+        android:id="@+id/firstTimeMiniAppName"
         android:textStyle="bold"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentStart="true"
-        android:padding="@dimen/small_8"
-        android:text="@string/miniapp_first_time_tutorial"
-        android:textSize="@dimen/text_large_16" />
+        android:layout_marginTop="@dimen/small_8"
+        android:layout_gravity="center_horizontal"
+        android:paddingStart="@dimen/medium_16"
+        android:paddingEnd="@dimen/medium_16"
+        android:textAlignment="center"
+        android:textColor="@android:color/black"
+        tools:text="Dummy MiniApp Name" />
 
-    </RelativeLayout>
-
-    <ImageView
-      android:id="@+id/firstTimeAppIcon"
-      android:layout_width="@dimen/miniapp_logo_size"
-      android:layout_height="@dimen/miniapp_logo_size"
-      android:layout_marginTop="@dimen/small_8"
-      android:layout_gravity="center_horizontal"
-      android:src="@drawable/ic_default" />
-
-    <TextView
-      android:id="@+id/firstTimeMiniAppInfo"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="@dimen/small_8"
-      android:layout_gravity="center_horizontal"
-      android:paddingStart="@dimen/medium_16"
-      android:paddingEnd="@dimen/medium_16"
-      android:textAlignment="center"
-      tools:text="Dummy MiniApp Info" />
+      <TextView
+        android:id="@+id/firstTimeMiniAppVersion"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/tiny_2dp"
+        android:layout_gravity="center_horizontal"
+        android:paddingStart="@dimen/medium_16"
+        android:paddingEnd="@dimen/medium_16"
+        android:textAlignment="center"
+        tools:text="Dummy MiniApp Version" />
+    </LinearLayout>
   </LinearLayout>
 
   <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/large_32"
+    android:layout_marginEnd="@dimen/large_32"
     android:layout_alignParentBottom="true"
     android:padding="@dimen/small_8"
     android:gravity="center_horizontal"
@@ -67,27 +75,22 @@
 
     <Button
       android:id="@+id/firstTimeAccept"
-      style="?android:attr/borderlessButtonStyle"
-      android:textStyle="bold"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:background="@color/colorAccent"
+      android:background="@drawable/bg_first_time_accept"
       android:text="@string/action_first_time_accept"
       android:textAllCaps="false"
       android:textColor="@android:color/white"
       android:textSize="@dimen/text_large_16" />
 
-    <TextView
+    <Button
       android:id="@+id/firstTimeCancel"
-      android:textStyle="bold"
-      android:layout_width="wrap_content"
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginTop="@dimen/small_4"
-      android:layout_marginStart="@dimen/large_32"
-      android:layout_marginEnd="@dimen/large_32"
-      android:padding="@dimen/small_8"
-      android:gravity="center"
+      android:layout_marginTop="@dimen/small_8"
+      android:background="@drawable/bg_first_time_cancel"
       android:text="@string/action_first_time_cancel"
+      android:textAllCaps="false"
       android:textColor="@color/colorPrimary"
       android:textSize="@dimen/text_large_16" />
   </LinearLayout>

--- a/testapp/src/main/res/layout/window_first_time_miniapp.xml
+++ b/testapp/src/main/res/layout/window_first_time_miniapp.xml
@@ -1,99 +1,88 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent">
 
-  <RelativeLayout
-    android:id="@+id/firstTimeTopView"
+  <LinearLayout
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:padding="@dimen/small_8"
-    android:background="@color/window_top_bar"
-    app:layout_constraintLeft_toLeftOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent">
+    android:layout_height="match_parent"
+    android:layout_alignParentStart="true"
+    android:orientation="vertical">
 
-    <ImageView
-      android:id="@+id/firstTimeCloseWindow"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_alignParentEnd="true"
-      android:padding="@dimen/small_8"
-      android:src="@drawable/ic_close_24px" />
-
-    <TextView
-      android:id="@+id/firstTimeTutorial"
-      android:textStyle="bold"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_alignParentStart="true"
-      android:padding="@dimen/small_8"
-      android:text="@string/miniapp_first_time_tutorial"
-      android:textSize="@dimen/text_large_16" />
-
-  </RelativeLayout>
-
-  <ScrollView
-    android:layout_width="match_parent"
-    android:layout_height="0dp"
-    android:fillViewport="true"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@+id/firstTimeTopView">
-
-    <LinearLayout
+    <RelativeLayout
+      android:id="@+id/firstTimeTopView"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:gravity="center"
-      android:orientation="vertical">
+      android:padding="@dimen/small_8"
+      android:background="@color/window_top_bar">
 
       <ImageView
-        android:id="@+id/firstTimeAppIcon"
-        android:layout_width="@dimen/miniapp_icon_size"
-        android:layout_height="@dimen/miniapp_icon_size"
-        android:layout_marginTop="@dimen/small_8"
-        android:layout_marginStart="@dimen/small_8"
-        android:src="@drawable/ic_default" />
+        android:id="@+id/firstTimeCloseWindow"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:padding="@dimen/small_8"
+        android:src="@drawable/ic_close_24px" />
 
       <TextView
-        android:id="@+id/firstTimeMiniAppInfo"
-        android:layout_width="match_parent"
+        android:id="@+id/firstTimeTutorial"
+        android:textStyle="bold"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/small_8"
-        android:paddingStart="@dimen/medium_16"
-        android:paddingEnd="@dimen/medium_16"
-        android:gravity="center"
-        tools:text="Dummy MiniApp Info" />
-    </LinearLayout>
+        android:layout_alignParentStart="true"
+        android:padding="@dimen/small_8"
+        android:text="@string/miniapp_first_time_tutorial"
+        android:textSize="@dimen/text_large_16" />
 
-  </ScrollView>
+    </RelativeLayout>
 
-  <RelativeLayout
+    <ImageView
+      android:id="@+id/firstTimeAppIcon"
+      android:layout_width="@dimen/miniapp_icon_size"
+      android:layout_height="@dimen/miniapp_icon_size"
+      android:layout_marginTop="@dimen/small_8"
+      android:layout_marginStart="@dimen/small_8"
+      android:layout_gravity="center_horizontal"
+      android:src="@drawable/ic_default" />
+
+    <TextView
+      android:id="@+id/firstTimeMiniAppInfo"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="@dimen/small_8"
+      android:layout_gravity="center_horizontal"
+      android:paddingStart="@dimen/medium_16"
+      android:paddingEnd="@dimen/medium_16"
+      tools:text="Dummy MiniApp Info" />
+  </LinearLayout>
+
+  <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginTop="@dimen/small_8"
+    android:layout_alignParentBottom="true"
     android:padding="@dimen/small_8"
-    android:background="@color/colorAccent"
     android:gravity="center_horizontal"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent">
+    android:orientation="vertical">
 
     <Button
       android:id="@+id/firstTimeAccept"
-      android:layout_width="wrap_content"
+      style="?android:attr/borderlessButtonStyle"
+      android:textStyle="bold"
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_alignParentStart="true"
-      android:text="@string/action_first_time_accept" />
+      android:background="@color/colorAccent"
+      android:text="@string/action_first_time_accept"
+      android:textColor="@android:color/white" />
 
     <Button
       android:id="@+id/firstTimeCancel"
-      android:layout_width="wrap_content"
+      android:textStyle="bold"
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginStart="@dimen/medium_16"
-      android:layout_alignParentEnd="true"
+      android:layout_marginTop="@dimen/small_8"
+      android:layout_marginStart="@dimen/large_32"
+      android:layout_marginEnd="@dimen/large_32"
       android:text="@string/action_first_time_cancel" />
-  </RelativeLayout>
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+  </LinearLayout>
+</RelativeLayout>

--- a/testapp/src/main/res/layout/window_first_time_miniapp.xml
+++ b/testapp/src/main/res/layout/window_first_time_miniapp.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  android:padding="@dimen/small_8"
-  xmlns:tools="http://schemas.android.com/tools">
+  android:layout_height="match_parent">
 
   <RelativeLayout
     android:id="@+id/firstTimeTopView"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:padding="@dimen/small_8"
     android:background="@color/window_top_bar"
     app:layout_constraintLeft_toLeftOf="parent"
     app:layout_constraintStart_toStartOf="parent"
@@ -25,48 +25,75 @@
 
     <TextView
       android:id="@+id/firstTimeTutorial"
+      android:textStyle="bold"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_alignParentStart="true"
       android:padding="@dimen/small_8"
       android:text="@string/miniapp_first_time_tutorial"
-      android:textSize="@dimen/text_large_16"
-      android:textStyle="bold" />
+      android:textSize="@dimen/text_large_16" />
 
   </RelativeLayout>
 
-  <TextView
-    android:id="@+id/firstTimeMiniAppInfo"
+  <ScrollView
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_margin="@dimen/small_4"
-    android:padding="@dimen/small_4"
+    android:layout_height="0dp"
+    android:fillViewport="true"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@+id/firstTimeTopView"
-    tools:text="Dummy MiniApp Info" />
+    app:layout_constraintTop_toBottomOf="@+id/firstTimeTopView">
 
-  <LinearLayout
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:gravity="center"
+      android:orientation="vertical">
+
+      <ImageView
+        android:id="@+id/firstTimeAppIcon"
+        android:layout_width="@dimen/miniapp_icon_size"
+        android:layout_height="@dimen/miniapp_icon_size"
+        android:layout_marginTop="@dimen/small_8"
+        android:layout_marginStart="@dimen/small_8"
+        android:src="@drawable/ic_default" />
+
+      <TextView
+        android:id="@+id/firstTimeMiniAppInfo"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/small_8"
+        android:paddingStart="@dimen/medium_16"
+        android:paddingEnd="@dimen/medium_16"
+        android:gravity="center"
+        tools:text="Dummy MiniApp Info" />
+    </LinearLayout>
+
+  </ScrollView>
+
+  <RelativeLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginTop="@dimen/small_8"
-    android:padding="@dimen/small_4"
+    android:padding="@dimen/small_8"
+    android:background="@color/colorAccent"
     android:gravity="center_horizontal"
-    android:orientation="horizontal"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@+id/firstTimeMiniAppInfo">
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent">
 
     <Button
       android:id="@+id/firstTimeAccept"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:text="ACCEPT" />
+      android:layout_alignParentStart="true"
+      android:text="@string/action_first_time_accept" />
 
     <Button
       android:id="@+id/firstTimeCancel"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginStart="@dimen/medium_16"
-      android:text="Cancel" />
-  </LinearLayout>
+      android:layout_alignParentEnd="true"
+      android:text="@string/action_first_time_cancel" />
+  </RelativeLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/testapp/src/main/res/layout/window_first_time_miniapp.xml
+++ b/testapp/src/main/res/layout/window_first_time_miniapp.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
+
+  <RelativeLayout
+    android:id="@+id/firstTimeTopView"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/small_8"
+    android:background="@color/window_top_bar"
+    app:layout_constraintLeft_toLeftOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent">
+
+    <ImageView
+      android:id="@+id/firstTimeCloseWindow"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_alignParentEnd="true"
+      android:padding="@dimen/small_8"
+      android:src="@drawable/ic_close_24px" />
+
+    <TextView
+      android:id="@+id/firstTimeTutorial"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_alignParentStart="true"
+      android:padding="@dimen/small_8"
+      android:text="@string/miniapp_first_time_tutorial"
+      android:textSize="@dimen/text_large_16"
+      android:textStyle="bold" />
+
+  </RelativeLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/testapp/src/main/res/layout/window_first_time_miniapp.xml
+++ b/testapp/src/main/res/layout/window_first_time_miniapp.xml
@@ -2,13 +2,14 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
-  android:layout_height="match_parent">
+  android:layout_height="match_parent"
+  android:padding="@dimen/small_8"
+  xmlns:tools="http://schemas.android.com/tools">
 
   <RelativeLayout
     android:id="@+id/firstTimeTopView"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/small_8"
     android:background="@color/window_top_bar"
     app:layout_constraintLeft_toLeftOf="parent"
     app:layout_constraintStart_toStartOf="parent"
@@ -33,5 +34,39 @@
       android:textStyle="bold" />
 
   </RelativeLayout>
+
+  <TextView
+    android:id="@+id/firstTimeMiniAppInfo"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="@dimen/small_4"
+    android:padding="@dimen/small_4"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@+id/firstTimeTopView"
+    tools:text="Dummy MiniApp Info" />
+
+  <LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/small_8"
+    android:padding="@dimen/small_4"
+    android:gravity="center_horizontal"
+    android:orientation="horizontal"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@+id/firstTimeMiniAppInfo">
+
+    <Button
+      android:id="@+id/firstTimeAccept"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="ACCEPT" />
+
+    <Button
+      android:id="@+id/firstTimeCancel"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="@dimen/medium_16"
+      android:text="Cancel" />
+  </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/testapp/src/main/res/values/colors.xml
+++ b/testapp/src/main/res/values/colors.xml
@@ -5,4 +5,5 @@
     <color name="colorAccent">#BF0000</color>
     <color name="color_bg_default_icon">#F5F1F1</color>
     <color name="bg_section">#DADADA</color>
+    <color name="window_top_bar">#F8F5F5</color>
 </resources>

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -36,7 +36,7 @@
     <string name="action_contacts">Contacts</string>
     <string name="action_custom_permissions">Permissions</string>
     <string name="action_first_time_accept">Accept</string>
-    <string name="action_first_time_cancel">Cancel &amp; Close</string>
+    <string name="action_first_time_cancel">Cancel</string>
 
     <string name="hint_host_project_id">Host Project ID</string>
     <string name="hint_subscription_key">Subscription Key</string>

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -35,6 +35,8 @@
     <string name="action_profile">Profile</string>
     <string name="action_contacts">Contacts</string>
     <string name="action_custom_permissions">Permissions</string>
+    <string name="action_first_time_accept">Accept</string>
+    <string name="action_first_time_cancel">Cancel</string>
 
     <string name="hint_host_project_id">Host Project ID</string>
     <string name="hint_subscription_key">Subscription Key</string>

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -24,6 +24,8 @@
     <string name="userdata_warning_empty_contact_list">No contact available!</string>
     <string name="userdata_warning_not_saved_contact">No contact has been saved yet</string>
 
+    <string name="miniapp_first_time_tutorial">Do you want to download this miniapp?</string>
+
     <string name="action_display">Display</string>
     <string name="action_go_input">Display Miniapp From ID or URL</string>
     <string name="action_go_input_preview_mode">Display Miniapp From URL</string>

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -36,7 +36,7 @@
     <string name="action_contacts">Contacts</string>
     <string name="action_custom_permissions">Permissions</string>
     <string name="action_first_time_accept">Accept</string>
-    <string name="action_first_time_cancel">Cancel</string>
+    <string name="action_first_time_cancel">Cancel &amp; Close</string>
 
     <string name="hint_host_project_id">Host Project ID</string>
     <string name="hint_subscription_key">Subscription Key</string>

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="userdata_warning_empty_contact_list">No contact available!</string>
     <string name="userdata_warning_not_saved_contact">No contact has been saved yet</string>
 
-    <string name="miniapp_first_time_tutorial">Do you want to download this miniapp?</string>
+    <string name="miniapp_first_time_tutorial">Would you like to download this miniapp?</string>
 
     <string name="action_display">Display</string>
     <string name="action_go_input">Display Miniapp From ID or URL</string>

--- a/testapp/src/main/res/values/styles.xml
+++ b/testapp/src/main/res/values/styles.xml
@@ -27,4 +27,9 @@
         <item name="actionMenuTextColor">@color/text_enable_state</item>
     </style>
 
+    <style name="AppTheme.DefaultWindow" parent="Theme.AppCompat.Dialog">
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:windowBackground">@android:color/white</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
# Description
- In Demo App: Add a screen which is displayed before downloading/launching a Mini App. The screen should be displayed only the first time that a particular Mini App is launched.
- The screen should display the Mini App's name, icon, and version.
- The screen should have buttons for "Accept" and "Cancel".
- "Accept" should download and launch the mini app.
- "Cancel" should return to listing screen without downloading the mini app.
 
## Links
- MINI-2499

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
