### PR TITLE
fix: dialog cancel event

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ workflows:
       - app-center/publish:
           name: deploy-test-app-candidate
           group: Release_Candidate
-          file: apk/staging/testapp-rc.apk
+          file: apk/rc/testapp-rc.apk
           app: $APP_CENTER_APP_NAME
           token: $APP_CENTER_TOKEN
           notes: $CIRCLE_BUILD_URL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **Feature:** Added `queryParams: String` using `MiniApp.create` and `MiniApp.createWithUrl` for appending it with the miniapp's url.
 - **Feature:** Added `MiniAppMessageBridge.requestDevicePermission` for requesting device permission e.g. Location
 - **Change:** Deprecated `MiniAppMessageBridge.requestPermission` and changed to be optional to implement.
+- **Fix:** Dialog cancel event when touch outside area.
 
 **Sample App**
 - **Change:** Replaced the implementation of `getUserName`, `getProfilePhoto` using new interfaces.

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,7 @@ ignore:
   - "miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionAdapter.kt"
   - "miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionWindow.kt"
   - "miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/analytics/MiniAppAnalytics.kt"
+  - "miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/WebViewDialog.kt"
 coverage:
   status:
     patch: off

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/WebViewDialog.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/WebViewDialog.kt
@@ -30,7 +30,10 @@ internal fun onShowDialog(
         onOkBuild(dialogBuilder, result)
 
     dialogBuilder.create()
-    dialogBuilder.show()
+    dialogBuilder.show().setOnCancelListener {
+        result?.cancel()
+        it.dismiss()
+    }
 
     return true
 }


### PR DESCRIPTION
# Description
Fix the problem cannot tap anything when close dialog by touching outside area.
Add cancel event listener to solve this problem.

Remove WebViewDialog out of test coverage when we don't support UI auto testing.

## Links
MINI-2597

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
