### PR TITLE
fix: back icon while showing first time UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### X.X.X (In progress)
+**Sample App**
+- **Feature:** Added first-time launching screen before downloading any miniapp.
+
 ### 2.8.0 (2020-01-25)
 **SDK**
 - **Feature:** Added `getUserName`, `getProfilePhoto` new interfaces for invoking data using `onSuccess` and `onError`.
@@ -16,7 +20,6 @@
 - **Feature:** Added crash reports integration with [app-center diagnostics](https://docs.microsoft.com/en-us/appcenter/diagnostics/).
 - **Fix:** Correct the group and order display of miniapp list.
 - **Change:** Added the usage of `MiniAppMessageBridge.requestDevicePermission`.
-- **Feature:** Added first-time launching screen before downloading any miniapp.
 
 ### 2.7.1 (2020-12-23)
 **SDK**

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/firsttime/FirstTimeWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/firsttime/FirstTimeWindow.kt
@@ -5,6 +5,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.SharedPreferences
 import android.net.Uri
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.Button
@@ -83,6 +84,13 @@ class FirstTimeWindow(
         firstTimeLayout.findViewById<Button>(R.id.firstTimeCancel).setOnClickListener {
             firstTimeLaunchListener.onFirstTimeAccept(false, miniAppInfo, miniAppId)
             firstTimeAlertDialog.dismiss()
+        }
+        firstTimeAlertDialog.setOnKeyListener { _, keyCode, event ->
+            if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {
+                firstTimeLaunchListener.onFirstTimeAccept(false, miniAppInfo, miniAppId)
+                firstTimeAlertDialog.dismiss()
+                true
+            } else false
         }
     }
 


### PR DESCRIPTION
# Description
- I forgot to add the listener of back icon in first time UI. This PR aims to fix this issue.
- Changelog adjusted for the first time UI in sample app.

## Links
- MINI-2663

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
