### PR TITLE
build: minimum version 24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGELOG
 
+### 3.x.x (In progress)
+- **Change:** Support Android 7 - API 24 as minimum version.
+
 ### 2.8.0 (2020-01-25)
 **SDK**
 - **Feature:** Added `getUserName`, `getProfilePhoto` new interfaces for invoking data using `onSuccess` and `onError`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@
 ### 3.X.X (In progress)
 
 - **Removed:** Cleanup deprecated components before v3.0.0. Please replace usages in your code as follows:
+
 `isTestMode` -> `isPreviewMode`.
+
 `rasAppId` -> `rasProjectId`.
+
 `MiniAppMessageBridge.requestPermission` -> `MiniAppMessageBridge.requestDevicePermission`.
+
 Replace `getUserName`, `getProfilePhoto` with new prototypes.
 
 - **Change:** Support Android 7 - API 24 as minimum version.

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext.androidBuildTool = '29.0.2'
     ext.androidx_appcompat = '1.2.0'
-    ext.androidx_constraintLayout = '1.1.3'
+    ext.androidx_constraintLayout = '2.0.4'
     ext.androidx_coreKtx = '1.3.0'
     ext.androidx_lifecycle = '2.2.0'
     ext.androidx_crypto = '1.0.0-rc03'
@@ -16,7 +16,7 @@ buildscript {
     ext.kluent_android = '1.48'
     ext.kotlin_coroutines = '1.3.3'
     ext.kotlin_version = '1.3.50'
-    ext.material = '1.1.0-rc02'
+    ext.material = '1.3.0'
     ext.mockito = '3.3.3'
     ext.mockwebserver = '4.7.2'
     ext.manifest_config = '0.1.0'
@@ -35,7 +35,7 @@ buildscript {
 
 //  Build Config.
     apply from: 'config/index.gradle'
-    CONFIG.versions.android.sdk.min = 23
+    CONFIG.versions.android.sdk.min = 24
 
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -15,7 +15,7 @@ Mini App SDK also facilitates communication between a mini app and the host app 
 
 ## Requirements
 
-- **Minimum Android Version**: This SDK supports Android 6.0+ (API level 23+).
+- **Minimum Android Version**: This SDK supports Android 7.0+ (API level 24+).
 - **Base URL, App ID, Subscription Key**: We don't currently provide a public API for use with this SDK. You must provide a URL for your API as well as an App ID and Subscription Key for the API.
 
 ## Getting Started

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
@@ -26,15 +26,15 @@ internal class MiniAppWebViewClient(
         return response
     }
 
-    // ToDo When the minimum support is upgraded to android 24, replace this function.
-    override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
-        var shouldCancelLoading = super.shouldOverrideUrlLoading(view, url)
-        if (url != null) {
-            if (url.startsWith("tel:")) {
-                miniAppScheme.openPhoneDialer(context, url)
+    override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+        var shouldCancelLoading = super.shouldOverrideUrlLoading(view, request)
+        if (request.url != null) {
+            val requestUrl = request.url.toString()
+            if (requestUrl.startsWith("tel:")) {
+                miniAppScheme.openPhoneDialer(context, requestUrl)
                 shouldCancelLoading = true
-            } else if (!miniAppScheme.isMiniAppUrl(url)) {
-                miniAppNavigator.openExternalUrl(url, externalResultHandler)
+            } else if (!miniAppScheme.isMiniAppUrl(requestUrl)) {
+                miniAppNavigator.openExternalUrl(requestUrl, externalResultHandler)
                 shouldCancelLoading = true
             }
         }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -297,13 +297,8 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
             externalResultHandler, miniAppScheme))
         val displayer = Mockito.spy(miniAppWebView)
 
-        try {
-            webViewClient.shouldOverrideUrlLoading(view = displayer, url = null)
-            webViewClient.shouldOverrideUrlLoading(displayer, miniAppWebView.getLoadUrl())
-            webViewClient.shouldOverrideUrlLoading(displayer, TEST_PHONE_URI)
-        } catch (e: AndroidRuntimeException) {
-            // context here is not activity
-        }
+        webViewClient.shouldOverrideUrlLoading(displayer, webResourceRequest)
+        webViewClient.shouldOverrideUrlLoading(displayer, getWebResReq(TEST_PHONE_URI.toUri()))
 
         verify(miniAppScheme, times(1)).openPhoneDialer(context, TEST_PHONE_URI)
     }
@@ -326,11 +321,7 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
         val webViewClient = Mockito.spy(MiniAppWebViewClient(context, webAssetLoader, miniAppNavigator!!,
             externalResultHandler, miniAppScheme))
 
-        try {
-            webViewClient.shouldOverrideUrlLoading(displayer, TEST_URL_HTTPS_1)
-        } catch (e: AndroidRuntimeException) {
-            // context here is not activity
-        }
+        webViewClient.shouldOverrideUrlLoading(displayer, getWebResReq(TEST_URL_HTTPS_1.toUri()))
 
         miniAppNavigator shouldNotBe null
         verify(miniAppNavigator).openExternalUrl(TEST_URL_HTTPS_1, externalResultHandler)
@@ -343,11 +334,7 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
             externalResultHandler, miniAppScheme))
         val displayer = Mockito.spy(miniAppWebView)
 
-        try {
-            webViewClient.shouldOverrideUrlLoading(displayer, TEST_URL_HTTPS_1)
-        } catch (e: AndroidRuntimeException) {
-            // context here is not activity
-        }
+        webViewClient.shouldOverrideUrlLoading(displayer, getWebResReq(TEST_URL_HTTPS_1.toUri()))
 
         verify(miniAppNavigator).openExternalUrl(TEST_URL_HTTPS_1, externalResultHandler)
     }


### PR DESCRIPTION
# Description
Set android 7 as minimum version for miniapp sdk.
Using the latest function `shouldOverrideUrlLoading`, no need to use deprecated function supported android 6 anymore.

## Links
MINI-2648

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
