### PR TITLE
fix: ad map & post message error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 Replace `getUserName`, `getProfilePhoto` with new prototypes.
 
 - **Change:** Support Android 7 - API 24 as minimum version.
+- **Fix:** Load ad error when do re-try loading.
 
 ### 2.8.0 (2020-01-25)
 **SDK**

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/ads/AdMobDisplayer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/ads/AdMobDisplayer.kt
@@ -55,6 +55,7 @@ class AdMobDisplayer(private val context: Activity) : MiniAppAdDisplayer, Corout
                     }
 
                     override fun onAdFailedToLoad(adError: LoadAdError) {
+                        interstitialAdMap.remove(adUnitId)
                         onFailed.invoke(adError.message)
                     }
                 }
@@ -92,7 +93,7 @@ class AdMobDisplayer(private val context: Activity) : MiniAppAdDisplayer, Corout
                 val ad = RewardedAd(context, adUnitId)
                 rewardedAdMap[adUnitId] = ad
 
-                val adLoadCallback = createRewardedAdLoadCallback(onLoaded, onFailed)
+                val adLoadCallback = createRewardedAdLoadCallback(adUnitId, onLoaded, onFailed)
 
                 ad.loadAd(AdRequest.Builder().build(), adLoadCallback)
             }
@@ -118,6 +119,7 @@ class AdMobDisplayer(private val context: Activity) : MiniAppAdDisplayer, Corout
 
     @VisibleForTesting
     internal fun createRewardedAdLoadCallback(
+        adUnitId: String,
         onLoaded: () -> Unit,
         onFailed: (String) -> Unit
     ): RewardedAdLoadCallback = object : RewardedAdLoadCallback() {
@@ -127,6 +129,7 @@ class AdMobDisplayer(private val context: Activity) : MiniAppAdDisplayer, Corout
         }
 
         override fun onRewardedAdFailedToLoad(adError: LoadAdError) {
+            rewardedAdMap.remove(adUnitId)
             onFailed.invoke(adError.message)
         }
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/ads/AdMobDisplayer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/ads/AdMobDisplayer.kt
@@ -25,7 +25,8 @@ class AdMobDisplayer(private val context: Activity) : MiniAppAdDisplayer, Corout
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Main
     private val interstitialAdMap = HashMap<String, InterstitialAd>()
-    private val rewardedAdMap = HashMap<String, RewardedAd>()
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    internal val rewardedAdMap = HashMap<String, RewardedAd>()
 
     @VisibleForTesting
     internal fun initAdMap(

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -134,7 +134,7 @@ internal open class MiniAppWebView(
     override fun runErrorCallback(callbackId: String, errorMessage: String) {
         post {
             evaluateJavascript(
-                "MiniAppBridge.execErrorCallback(\"$callbackId\", \"$errorMessage\")"
+                "MiniAppBridge.execErrorCallback(`$callbackId`, `${errorMessage.replace("'", "\\'")}`)"
             ) {}
         }
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -134,7 +134,7 @@ internal open class MiniAppWebView(
     override fun runErrorCallback(callbackId: String, errorMessage: String) {
         post {
             evaluateJavascript(
-                "MiniAppBridge.execErrorCallback(`$callbackId`, `${errorMessage.replace("'", "\\'")}`)"
+                "MiniAppBridge.execErrorCallback(`$callbackId`, `${errorMessage.replace("`", "\\`")}`)"
             ) {}
         }
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -13,7 +13,12 @@ import com.rakuten.tech.mobile.miniapp.ads.MiniAppAdDisplayer
 import com.rakuten.tech.mobile.miniapp.display.WebViewListener
 import com.rakuten.tech.mobile.miniapp.js.userinfo.UserInfoBridge
 import com.rakuten.tech.mobile.miniapp.js.userinfo.UserInfoBridgeDispatcher
-import com.rakuten.tech.mobile.miniapp.permission.*
+import com.rakuten.tech.mobile.miniapp.permission.CustomPermissionBridgeDispatcher
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppDevicePermissionType
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionResult
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppDevicePermissionResult
 import com.rakuten.tech.mobile.miniapp.permission.ui.MiniAppCustomPermissionWindow
 
 @Suppress("TooGenericExceptionCaught", "TooManyFunctions", "LongMethod", "LargeClass", "ComplexMethod")

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/ads/AdMobDisplayerSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/ads/AdMobDisplayerSpec.kt
@@ -88,7 +88,7 @@ class AdMobDisplayerSpec {
 
     @Test
     fun `should invoke sdk callbacks without error`() {
-        val rewardedAdLoadCallback = adDisplayer.createRewardedAdLoadCallback(spy(), spy())
+        val rewardedAdLoadCallback = adDisplayer.createRewardedAdLoadCallback(TEST_AD_UNIT_ID, spy(), spy())
         val rewardedAdShowCallback = adDisplayer.createRewardedAdShowCallback(TEST_AD_UNIT_ID, spy(), spy())
         val rewardItem = object : RewardItem {
             override fun getType(): String = ""

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/ads/AdMobDisplayerSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/ads/AdMobDisplayerSpec.kt
@@ -123,4 +123,18 @@ class AdMobDisplayerSpec {
 
         adDisplayer.loadRewardedAd(TEST_AD_UNIT_ID, {}, onError)
     }
+
+    @Test
+    fun `should not have ad in queue when it loads failed`() {
+        val map = HashMap<String, RewardedAd>()
+        val ad = Mockito.spy(RewardedAd(context, TEST_AD_UNIT_ID))
+        map[TEST_AD_UNIT_ID] = ad
+        adDisplayer.initAdMap(interstitialAdMap = mutableMapOf(), rewardedAdMap = map)
+
+        val rewardedAdLoadCallback = adDisplayer.createRewardedAdLoadCallback(TEST_AD_UNIT_ID, spy(), spy())
+        rewardedAdLoadCallback.onRewardedAdLoaded()
+        rewardedAdLoadCallback.onRewardedAdFailedToLoad(LoadAdError(0, "", "", null, null))
+
+        adDisplayer.rewardedAdMap.containsKey(TEST_AD_UNIT_ID) shouldBe false
+    }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -241,10 +241,14 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
     @Test
     fun `should send response with escaped backtick characters`() {
         val spyMiniAppWebView = spy(miniAppWebView)
-        spyMiniAppWebView.runSuccessCallback("test_id", "`test response`")
 
+        spyMiniAppWebView.runSuccessCallback("test_id", "`test response`")
         Verify on spyMiniAppWebView that spyMiniAppWebView.evaluateJavascript(
             argWhere { it.contains("""`\`test response\``""") }, any())
+
+        spyMiniAppWebView.runErrorCallback("test_id", "`error response`")
+        Verify on spyMiniAppWebView that spyMiniAppWebView.evaluateJavascript(
+            argWhere { it.contains("""`\`error response\``""") }, any())
     }
 }
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.util.AndroidRuntimeException
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.GeolocationPermissions


### PR DESCRIPTION
# Description
- Remove ad unit id in map when ad loads failed -> user can able to call load ad again.
- Escape character for bridge post error.

## Links
MINI-2706
MINI-2707

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
