### PR TITLE
fix: Issue with simultaneous custom permission requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Replace `getUserName`, `getProfilePhoto` with new prototypes.
 - **Change:** Support Android 7 - API 24 as minimum version.
 - **Change:** Convert `UserInfoBridgeDispatcher` into interface. Usages in your code of `object : UserInfoBridgeDispatcher()` should be changed to `object : UserInfoBridgeDispatcher`.
 - **Fix:** Load ad error when do re-try loading.
+- **Fix:** Failure when simultaneous custom permission requests are received.
 
 ### 2.8.0 (2020-01-25)
 **SDK**

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -27,8 +27,6 @@ abstract class MiniAppMessageBridge {
     private lateinit var bridgeExecutor: MiniAppBridgeExecutor
     private var miniAppViewInitialized = false
     private lateinit var customPermissionCache: MiniAppCustomPermissionCache
-    private lateinit var customPermissionBridgeDispatcher: CustomPermissionBridgeDispatcher
-    private lateinit var customPermissionWindow: MiniAppCustomPermissionWindow
     private lateinit var miniAppId: String
     private lateinit var activity: Activity
     private val userInfoBridgeWrapper = UserInfoBridge()
@@ -47,16 +45,6 @@ abstract class MiniAppMessageBridge {
         this.miniAppId = miniAppId
         this.bridgeExecutor = createBridgeExecutor(webViewListener)
         this.customPermissionCache = customPermissionCache
-        this.customPermissionBridgeDispatcher = CustomPermissionBridgeDispatcher(
-            bridgeExecutor,
-            customPermissionCache,
-            miniAppId
-        )
-        this.customPermissionWindow = MiniAppCustomPermissionWindow(
-            activity,
-            customPermissionBridgeDispatcher
-        )
-
         this.screenBridgeDispatcher = ScreenBridgeDispatcher(activity, bridgeExecutor, allowScreenOrientation)
         adBridgeDispatcher.setBridgeExecutor(bridgeExecutor)
         userInfoBridgeWrapper.setMiniAppComponents(bridgeExecutor, customPermissionCache, miniAppId)
@@ -178,8 +166,16 @@ abstract class MiniAppMessageBridge {
 
     @Suppress("SwallowedException")
     private fun onRequestCustomPermissions(jsonStr: String) {
-        // initialize required properties using jsonStr before executing operations
-        customPermissionBridgeDispatcher.initCallBackObject(jsonStr)
+        val customPermissionBridgeDispatcher = CustomPermissionBridgeDispatcher(
+            bridgeExecutor = bridgeExecutor,
+            customPermissionCache = customPermissionCache,
+            miniAppId = miniAppId,
+            jsonStr = jsonStr
+        )
+        val customPermissionWindow = MiniAppCustomPermissionWindow(
+            activity,
+            customPermissionBridgeDispatcher
+        )
 
         // check if there is any denied permission
         val deniedPermissions = customPermissionBridgeDispatcher.filterDeniedPermissions()

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcher.kt
@@ -14,28 +14,18 @@ import com.rakuten.tech.mobile.miniapp.js.MiniAppBridgeExecutor
 internal class CustomPermissionBridgeDispatcher(
     private val bridgeExecutor: MiniAppBridgeExecutor,
     private val customPermissionCache: MiniAppCustomPermissionCache,
-    private val miniAppId: String
+    private val miniAppId: String,
+    jsonStr: String
 ) {
-
-    private var callbackObj: CustomPermissionCallbackObj? = null
-    private var permissionsWithDescription: List<Pair<MiniAppCustomPermissionType, String>> = emptyList()
-
-    /**
-     * assign values to callbackObj and permissionsWithDescription properties using jsonStr data.
-     * @param [jsonStr] json string for custom permissions dispatched from MiniAppMessageBridge.
-     */
-    fun initCallBackObject(jsonStr: String) {
-        try {
-            callbackObj = Gson().fromJson(jsonStr, CustomPermissionCallbackObj::class.java)
-            val permissionObjList = arrayListOf<CustomPermissionObj>()
-            callbackObj?.param?.permissions?.forEach {
-                permissionObjList.add(CustomPermissionObj(it.name, it.description))
-            }
-            permissionsWithDescription = preparePermissionsWithDescription(permissionObjList)
-        } catch (e: Exception) {
-            e.message?.let { postCustomPermissionError(it) }
-        }
+    private var callbackObj: CustomPermissionCallbackObj? = try {
+        Gson().fromJson(jsonStr, CustomPermissionCallbackObj::class.java)
+    } catch (e: Exception) {
+        e.message?.let { postCustomPermissionError(it) }
+        null
     }
+    private var permissionsWithDescription = preparePermissionsWithDescription(
+        callbackObj?.param?.permissions ?: emptyList()
+    )
 
     /**
      * Prepares a list of custom permissions Pair with names and description.
@@ -45,7 +35,7 @@ internal class CustomPermissionBridgeDispatcher(
     @Suppress("FunctionMaxLength")
     @VisibleForTesting
     fun preparePermissionsWithDescription(
-        permissionObjList: ArrayList<CustomPermissionObj>
+        permissionObjList: List<CustomPermissionObj>
     ): List<Pair<MiniAppCustomPermissionType, String>> {
         val permissionsWithDescription =
             arrayListOf<Pair<MiniAppCustomPermissionType, String>>()

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionWindowSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionWindowSpec.kt
@@ -53,7 +53,7 @@ class MiniAppCustomPermissionWindowSpec {
         ActivityScenario.launch(TestActivity::class.java).onActivity {
             activity = it
             dispatcher =
-                CustomPermissionBridgeDispatcher(bridgeExecutor, permissionCache, miniAppId)
+                CustomPermissionBridgeDispatcher(bridgeExecutor, permissionCache, miniAppId, "")
             permissionWindow = spy(MiniAppCustomPermissionWindow(activity, dispatcher))
         }
     }


### PR DESCRIPTION
# Description
There was an issue when a Mini App tried to call MiniApp.requestCustomPermissions twice in a row without waiting for the success/failure response of the previous call. This is because the CustomPermissionBridgeDispatcher can only be initialized with a single CallbackObj. There wasn't any reason for only a single CustomPermissionBridgeDispatcher object to be used, so I moved it's instantiation inline when the custom permissions request is made.

Also refactored CustomPermissionBridgeDispatcher a little to remove the initCallbackObj as it was no longer nescessary.

This fix can be tested with the following JS code:
```
window.MiniApp.default.requestCustomPermissions([ {name: window.MiniApp.CustomPermissionName.USER_NAME, description: 'test'} ])
window.MiniApp.default.requestLocationPermission("test")
```

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
