### PR TITLE
feature: retrieve audience scope for access token from bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### 3.1.X (In progress)
+- **Deprecated:** `getAccessToken` with only miniapp id verfication.
+- **Feature:** Add a new `getAccessToken` function under custom permission and support audience/scope validation.
+
 ### 3.X.X (In progress)
 **SDK**
 - **Removed:** Cleanup deprecated components before v3.0.0. Please replace usages in your code as follows:

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -294,11 +294,12 @@ val userInfoBridgeDispatcher = object : UserInfoBridgeDispatcher {
 
     override fun getAccessToken(
         miniAppId: String,
+        accessTokenPermission: AccessTokenPermission,
         onSuccess: (tokenData: TokenData) -> Unit,
         onError: (message: String) -> Unit
     ) {
         var allowToken: Boolean = false
-        // Check if you want to allow this Mini App ID to use the Access Token
+        // Check if you want to allow this Mini App ID to use the Access Token based on AccessTokenPermission.
         // .. .. ..
         if (allowToken)
             onSuccess(tokenData) // allow miniapp to get token and return TokenData value.
@@ -365,7 +366,7 @@ The following user data types are supported. If your App does not support a cert
 
 - User name: string representing the user's name. See [UserInfoBridgeDispatcher.getUserName](api/com.rakuten.tech.mobile.miniapp.js.userinfo/-user-info-bridge-dispatcher/get-user-name.html)
 - Profile photo: URL pointing to a photo. This can also be a Base64 data string. See [UserInfoBridgeDispatcher.getProfilePhoto](api/com.rakuten.tech.mobile.miniapp.js.userinfo/-user-info-bridge-dispatcher/get-profile-photo.html)
-- Access Token (does not currenlty have a custom permission type): OAuth 1.0 token including token data and expiration date. Your App will be provided with the ID of the mini app which is requesting the Access Token, so you should verify that this mini app is allowed to use the access token. See See [UserInfoBridgeDispatcher.getAccessToken](api/com.rakuten.tech.mobile.miniapp.js.userinfo/-user-info-bridge-dispatcher/get-access-token.html)
+- Access Token: OAuth 1.0 token including token data and expiration date. Your App will be provided with the ID of the mini app and [AccessTokenPermission]((api/com.rakuten.tech.mobile.miniapp.permission/-access-token-permission)) which is requesting the Access Token, so you should verify that this mini app is allowed to use the access token. See [UserInfoBridgeDispatcher.getAccessToken](api/com.rakuten.tech.mobile.miniapp.js.userinfo/-user-info-bridge-dispatcher/get-access-token.html)
 
 
 ### Ads Integration

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -119,7 +119,7 @@ abstract class MiniAppMessageBridge {
             ActionType.SHOW_AD.action -> adBridgeDispatcher.onShowAd(callbackObj.id, jsonStr)
             ActionType.GET_USER_NAME.action -> userInfoBridge.onGetUserName(callbackObj.id)
             ActionType.GET_PROFILE_PHOTO.action -> userInfoBridge.onGetProfilePhoto(callbackObj.id)
-            ActionType.GET_ACCESS_TOKEN.action -> userInfoBridge.onGetAccessToken(callbackObj.id)
+            ActionType.GET_ACCESS_TOKEN.action -> userInfoBridge.onGetAccessToken(callbackObj)
             ActionType.SET_SCREEN_ORIENTATION.action -> screenBridgeDispatcher.onScreenRequest(callbackObj)
             ActionType.GET_CONTACTS.action -> userInfoBridge.onGetContacts(callbackObj.id)
         }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridge.kt
@@ -3,6 +3,7 @@ package com.rakuten.tech.mobile.miniapp.js.userinfo
 import androidx.annotation.VisibleForTesting
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.js.CallbackObj
 import com.rakuten.tech.mobile.miniapp.js.ErrorBridgeMessage.NO_IMPL
 import com.rakuten.tech.mobile.miniapp.js.MiniAppBridgeExecutor
@@ -99,7 +100,14 @@ internal class UserInfoBridge {
             bridgeExecutor.postError(callbackObj.id, "$ERR_GET_ACCESS_TOKEN $message")
         }
 
-        userInfoBridgeDispatcher.getAccessToken(miniAppId, tokenPermission, successCallback, errorCallback)
+        try {
+            userInfoBridgeDispatcher.getAccessToken(miniAppId, tokenPermission, successCallback, errorCallback)
+        } catch (e: MiniAppSdkException) {
+            if (e.message == "The `UserInfoBridgeDispatcher.getAccessToken` $NO_IMPL")
+                userInfoBridgeDispatcher.getAccessToken(miniAppId, successCallback, errorCallback)
+            else
+                throw e
+        }
     }
 
     private fun parseAccessTokenPermission(callbackObj: CallbackObj) = Gson().fromJson<AccessTokenPermission>(

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridge.kt
@@ -2,8 +2,11 @@ package com.rakuten.tech.mobile.miniapp.js.userinfo
 
 import androidx.annotation.VisibleForTesting
 import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.rakuten.tech.mobile.miniapp.js.CallbackObj
 import com.rakuten.tech.mobile.miniapp.js.ErrorBridgeMessage.NO_IMPL
 import com.rakuten.tech.mobile.miniapp.js.MiniAppBridgeExecutor
+import com.rakuten.tech.mobile.miniapp.permission.AccessTokenPermission
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
 import java.util.ArrayList
@@ -75,23 +78,34 @@ internal class UserInfoBridge {
         }
     }
 
-    internal fun onGetAccessToken(callbackId: String) = whenReady(callbackId) {
+    internal fun onGetAccessToken(callbackObj: CallbackObj) = whenReady(callbackObj.id) {
         try {
             if (customPermissionCache.hasPermission(miniAppId, MiniAppCustomPermissionType.ACCESS_TOKEN)) {
-                val successCallback = { accessToken: TokenData ->
-                    bridgeExecutor.postValue(callbackId, Gson().toJson(accessToken))
-                }
-                val errorCallback = { message: String ->
-                    bridgeExecutor.postError(callbackId, "$ERR_GET_ACCESS_TOKEN $message")
-                }
-
-                userInfoBridgeDispatcher.getAccessToken(miniAppId, successCallback, errorCallback)
+                onHasAccessTokenPermission(callbackObj)
             } else
-                bridgeExecutor.postError(callbackId, "$ERR_GET_ACCESS_TOKEN $ERR_ACCESS_TOKEN_NO_PERMISSION")
+                bridgeExecutor.postError(callbackObj.id, "$ERR_GET_ACCESS_TOKEN $ERR_ACCESS_TOKEN_NO_PERMISSION")
         } catch (e: Exception) {
-            bridgeExecutor.postError(callbackId, "$ERR_GET_ACCESS_TOKEN ${e.message}")
+            bridgeExecutor.postError(callbackObj.id, "$ERR_GET_ACCESS_TOKEN ${e.message}")
         }
     }
+
+    private fun onHasAccessTokenPermission(callbackObj: CallbackObj) {
+        val tokenPermission = parseAccessTokenPermission(callbackObj)
+
+        val successCallback = { accessToken: TokenData ->
+            bridgeExecutor.postValue(callbackObj.id, Gson().toJson(accessToken))
+        }
+        val errorCallback = { message: String ->
+            bridgeExecutor.postError(callbackObj.id, "$ERR_GET_ACCESS_TOKEN $message")
+        }
+
+        userInfoBridgeDispatcher.getAccessToken(miniAppId, tokenPermission, successCallback, errorCallback)
+    }
+
+    private fun parseAccessTokenPermission(callbackObj: CallbackObj) = Gson().fromJson<AccessTokenPermission>(
+            callbackObj.param.toString(),
+            object : TypeToken<AccessTokenPermission>() {}.type
+    ) ?: AccessTokenPermission("", emptyList())
 
     fun onGetContacts(callbackId: String) = whenReady(callbackId) {
         try {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
@@ -2,6 +2,7 @@ package com.rakuten.tech.mobile.miniapp.js.userinfo
 
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.js.ErrorBridgeMessage.NO_IMPL
+import com.rakuten.tech.mobile.miniapp.permission.AccessTokenPermission
 import java.util.ArrayList
 
 /**
@@ -34,6 +35,7 @@ interface UserInfoBridgeDispatcher {
     /** Get access token from host app. **/
     fun getAccessToken(
         miniAppId: String,
+        accessTokenPermission: AccessTokenPermission,
         onSuccess: (tokenData: TokenData) -> Unit,
         onError: (message: String) -> Unit
     ) {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
@@ -33,6 +33,19 @@ interface UserInfoBridgeDispatcher {
     }
 
     /** Get access token from host app. **/
+    @Deprecated("This function has been deprecated.")
+    fun getAccessToken(
+        miniAppId: String,
+        onSuccess: (tokenData: TokenData) -> Unit,
+        onError: (message: String) -> Unit
+    ) {
+        throw MiniAppSdkException("The `UserInfoBridgeDispatcher.getAccessToken` $NO_IMPL")
+    }
+
+    /**
+     * Get access token from host app.
+     * @param accessTokenPermission contains audience and scope for permission validation.
+     **/
     fun getAccessToken(
         miniAppId: String,
         accessTokenPermission: AccessTokenPermission,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/AccessTokenPermission.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/AccessTokenPermission.kt
@@ -10,6 +10,6 @@ import androidx.annotation.Keep
 @Keep
 data class AccessTokenPermission(val audience: String, val scopes: List<String>) {
 
-    fun contains(accessTokenPermission: AccessTokenPermission): Boolean =
-        this.audience == accessTokenPermission.audience && this.scopes.containsAll(accessTokenPermission.scopes)
+//    fun contains(accessTokenPermission: AccessTokenPermission): Boolean =
+//        this.audience == accessTokenPermission.audience && this.scopes.containsAll(accessTokenPermission.scopes)
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/AccessTokenPermission.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/AccessTokenPermission.kt
@@ -1,4 +1,15 @@
 package com.rakuten.tech.mobile.miniapp.permission
 
-class AccessTokenPermission {
+import androidx.annotation.Keep
+
+/**
+ *  Contains the components which need to be validated when access token is granted.
+ *  @property audience The service of access token.
+ *  @property scopes List of areas that token can access.
+ */
+@Keep
+data class AccessTokenPermission(val audience: String, val scopes: List<String>) {
+
+    fun contains(accessTokenPermission: AccessTokenPermission): Boolean =
+        this.audience == accessTokenPermission.audience && this.scopes.containsAll(accessTokenPermission.scopes)
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/AccessTokenPermission.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/AccessTokenPermission.kt
@@ -1,0 +1,4 @@
+package com.rakuten.tech.mobile.miniapp.permission
+
+class AccessTokenPermission {
+}

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
@@ -43,11 +43,6 @@ class UserInfoBridgeSpec {
         param = null,
         id = TEST_CALLBACK_ID
     )
-    private val tokenCallbackObj = CallbackObj(
-        action = ActionType.GET_ACCESS_TOKEN.action,
-        param = null,
-        id = TEST_CALLBACK_ID
-    )
     private val contactsCallbackObj = CallbackObj(
         action = ActionType.GET_CONTACTS.action,
         param = null,
@@ -256,6 +251,16 @@ class UserInfoBridgeSpec {
 
     /** start region: access token */
     private val testToken = TokenData("test_token", 0)
+    private val testAccessTokenPermission = AccessTokenPermission(
+            audience = "API-C",
+            scopes = mutableListOf("point", "user_info")
+    )
+    private val tokenCallbackObj = CallbackObj(
+            action = ActionType.GET_ACCESS_TOKEN.action,
+            param = Gson().toJson(testAccessTokenPermission),
+            id = TEST_CALLBACK_ID
+    )
+
     private fun createAccessTokenImpl(
         hasAccessToken: Boolean,
         canGetToken: Boolean
@@ -264,6 +269,7 @@ class UserInfoBridgeSpec {
             object : UserInfoBridgeDispatcher {
                 override fun getAccessToken(
                     miniAppId: String,
+                    accessTokenPermission: AccessTokenPermission,
                     onSuccess: (tokenData: TokenData) -> Unit,
                     onError: (message: String) -> Unit
                 ) {
@@ -294,7 +300,12 @@ class UserInfoBridgeSpec {
         val userInfoBridgeDispatcher = Mockito.spy(createAccessTokenImpl(true, false))
         val userInfoBridgeWrapper = Mockito.spy(createUserInfoBridgeWrapper(userInfoBridgeDispatcher))
 
-        userInfoBridgeWrapper.onGetAccessToken(tokenCallbackObj.id)
+        val tokenCallbackObj = CallbackObj(
+                action = ActionType.GET_ACCESS_TOKEN.action,
+                param = null,
+                id = TEST_CALLBACK_ID
+        )
+        userInfoBridgeWrapper.onGetAccessToken(tokenCallbackObj)
 
         verify(bridgeExecutor).postError(tokenCallbackObj.id, errMsg)
     }
@@ -309,7 +320,7 @@ class UserInfoBridgeSpec {
             miniAppInfo.id, MiniAppCustomPermissionType.ACCESS_TOKEN)
         ).thenReturn(false)
 
-        userInfoBridgeWrapper.onGetAccessToken(tokenCallbackObj.id)
+        userInfoBridgeWrapper.onGetAccessToken(tokenCallbackObj)
 
         verify(bridgeExecutor).postError(tokenCallbackObj.id, errMsg)
     }
@@ -319,7 +330,7 @@ class UserInfoBridgeSpec {
         val userInfoBridgeDispatcher = Mockito.spy(createAccessTokenImpl(true, true))
         val userInfoBridgeWrapper = Mockito.spy(createUserInfoBridgeWrapper(userInfoBridgeDispatcher))
 
-        userInfoBridgeWrapper.onGetAccessToken(tokenCallbackObj.id)
+        userInfoBridgeWrapper.onGetAccessToken(tokenCallbackObj)
 
         verify(bridgeExecutor).postValue(tokenCallbackObj.id, Gson().toJson(testToken))
     }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
@@ -334,6 +334,24 @@ class UserInfoBridgeSpec {
 
         verify(bridgeExecutor).postValue(tokenCallbackObj.id, Gson().toJson(testToken))
     }
+
+    @Test
+    fun `will call deprecated function to get token when still using old implementation`() {
+        val userInfoBridgeDispatcher = Mockito.spy(object : UserInfoBridgeDispatcher {
+            override fun getAccessToken(
+                miniAppId: String,
+                onSuccess: (tokenData: TokenData) -> Unit,
+                onError: (message: String) -> Unit
+            ) {
+                onSuccess.invoke(testToken)
+            }
+        })
+        val userInfoBridgeWrapper = Mockito.spy(createUserInfoBridgeWrapper(userInfoBridgeDispatcher))
+
+        userInfoBridgeWrapper.onGetAccessToken(tokenCallbackObj)
+
+        verify(bridgeExecutor).postValue(tokenCallbackObj.id, Gson().toJson(testToken))
+    }
     /** end region */
 
     /** start region: get contacts */

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -23,6 +23,7 @@ import com.rakuten.tech.mobile.miniapp.js.userinfo.TokenData
 import com.rakuten.tech.mobile.miniapp.js.userinfo.UserInfoBridgeDispatcher
 import com.rakuten.tech.mobile.miniapp.navigator.ExternalResultHandler
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
+import com.rakuten.tech.mobile.miniapp.permission.AccessTokenPermission
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppDevicePermissionType
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.MiniAppDisplayActivityBinding
@@ -182,16 +183,19 @@ class MiniAppDisplayActivity : BaseActivity() {
 
             override fun getAccessToken(
                 miniAppId: String,
+                accessTokenPermission: AccessTokenPermission,
                 onSuccess: (tokenData: TokenData) -> Unit,
                 onError: (message: String) -> Unit
             ) {
                 AlertDialog.Builder(this@MiniAppDisplayActivity)
-                    .setMessage("Allow $miniAppId to get access token?")
+                    .setTitle("Access token for $miniAppId ?")
+                    .setMessage("Audience: ${accessTokenPermission.audience}" + System.lineSeparator() +
+                    "Scope: ${accessTokenPermission.scopes.joinToString()}")
                     .setPositiveButton(android.R.string.yes) { dialog, _ ->
                         onSuccess(AppSettings.instance.tokenData)
                         dialog.dismiss()
                     }
-                    .setNegativeButton("No") { dialog, _ ->
+                    .setNegativeButton(android.R.string.no) { dialog, _ ->
                         onError("$miniAppId not allowed to get access token")
                         dialog.dismiss()
                     }


### PR DESCRIPTION
# Description
1/ Retrieve audience/scope from bridge for access token => We have two options here for js miniapp side:
- Define `audience: String` and `scope: List<String>`
- Define the class which is similar to `AccessTokenPermission` (android) or `MASDKAccessTokenPermission` (ios).

2/ Update signature of function `getAccessToken(miniAppId, accessTokenPermission, onSuccess, onError)`.

Note: Checking audience/scope from `MiniAppManifest` belongs to MINI-2680. 

## Links
MINI-2251

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
