### PR TITLE
sample: remove prompt dialog for access token

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -184,20 +184,7 @@ class MiniAppDisplayActivity : BaseActivity() {
                 miniAppId: String,
                 onSuccess: (tokenData: TokenData) -> Unit,
                 onError: (message: String) -> Unit
-            ) {
-                AlertDialog.Builder(this@MiniAppDisplayActivity)
-                    .setMessage("Allow $miniAppId to get access token?")
-                    .setPositiveButton(android.R.string.yes) { dialog, _ ->
-                        onSuccess(AppSettings.instance.tokenData)
-                        dialog.dismiss()
-                    }
-                    .setNegativeButton("No") { dialog, _ ->
-                        onError("$miniAppId not allowed to get access token")
-                        dialog.dismiss()
-                    }
-                    .create()
-                    .show()
-            }
+            ) = onSuccess(AppSettings.instance.tokenData)
 
             override fun getContacts(
                 onSuccess: (contacts: ArrayList<Contact>) -> Unit,


### PR DESCRIPTION
# Description
Remove the prompt dialog for access token in a demo app to match ios.

## Links
QA raised ticket: MINI-2677
MINI-2866, 2867

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
