### PR TITLE
allow mini app in the bridge to request only permissions that is defined in manifest

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -23,7 +23,7 @@ import java.net.ConnectException
 import java.net.HttpURLConnection
 import java.net.URL
 
-@Suppress("SwallowedException", "TooManyFunctions", "LargeClass")
+@Suppress("SwallowedException", "TooManyFunctions", "LargeClass", "MaxLineLength")
 internal class MiniAppDownloader(
     private var apiClient: ApiClient,
     initStorage: () -> MiniAppStorage,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
@@ -49,6 +49,7 @@ internal class CustomPermissionsNotImplementedException :
 /**
  * Exception which is thrown when the required permissions of the manifest are not granted.
  */
+@Suppress("MaxLineLength")
 class RequiredPermissionsNotGrantedException(appId: String, versionId: String) :
     MiniAppSdkException("Mini App has not been granted all of the required permissions for the provided Mini App Id: $appId and the version id: $versionId")
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -60,6 +60,7 @@ internal class RealMiniApp(
                 miniAppMessageBridge,
                 miniAppNavigator,
                 miniAppCustomPermissionCache,
+                downloadedManifestCache,
                 queryParams
             )
         }
@@ -81,6 +82,7 @@ internal class RealMiniApp(
                 miniAppMessageBridge,
                 miniAppNavigator,
                 miniAppCustomPermissionCache,
+                downloadedManifestCache,
                 queryParams
             )
         }
@@ -100,6 +102,7 @@ internal class RealMiniApp(
                 miniAppMessageBridge,
                 miniAppNavigator,
                 miniAppCustomPermissionCache,
+                downloadedManifestCache,
                 queryParams
             )
         }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
@@ -5,6 +5,7 @@ import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
+import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
 
 @Suppress("LongParameterList")
 internal class Displayer(private val hostAppUserAgentInfo: String) {
@@ -15,6 +16,7 @@ internal class Displayer(private val hostAppUserAgentInfo: String) {
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator?,
         miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
+        downloadedManifestCache: DownloadedManifestCache,
         queryParams: String
     ): MiniAppDisplay = RealMiniAppDisplay(
         basePath = basePath,
@@ -23,6 +25,7 @@ internal class Displayer(private val hostAppUserAgentInfo: String) {
         miniAppNavigator = miniAppNavigator,
         hostAppUserAgentInfo = hostAppUserAgentInfo,
         miniAppCustomPermissionCache = miniAppCustomPermissionCache,
+        downloadedManifestCache = downloadedManifestCache,
         queryParams = queryParams
     )
 
@@ -31,6 +34,7 @@ internal class Displayer(private val hostAppUserAgentInfo: String) {
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator?,
         miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
+        downloadedManifestCache: DownloadedManifestCache,
         queryParams: String
     ): MiniAppDisplay = RealMiniAppDisplay(
         appUrl = appUrl,
@@ -38,6 +42,7 @@ internal class Displayer(private val hostAppUserAgentInfo: String) {
         miniAppNavigator = miniAppNavigator,
         hostAppUserAgentInfo = hostAppUserAgentInfo,
         miniAppCustomPermissionCache = miniAppCustomPermissionCache,
+        downloadedManifestCache = downloadedManifestCache,
         queryParams = queryParams
     )
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
@@ -7,6 +7,7 @@ import com.rakuten.tech.mobile.miniapp.MiniAppScheme
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
+import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
 
 internal class MiniAppHttpWebView(
     context: Context,
@@ -16,6 +17,7 @@ internal class MiniAppHttpWebView(
     miniAppNavigator: MiniAppNavigator?,
     hostAppUserAgentInfo: String,
     miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
+    downloadedManifestCache: DownloadedManifestCache,
     miniAppWebChromeClient: MiniAppWebChromeClient = MiniAppWebChromeClient(
         context,
         miniAppInfo,
@@ -30,6 +32,7 @@ internal class MiniAppHttpWebView(
     miniAppNavigator,
     hostAppUserAgentInfo,
     miniAppCustomPermissionCache,
+    downloadedManifestCache,
     miniAppWebChromeClient,
     queryParams
 ) {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -16,6 +16,7 @@ import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.miniapp.navigator.ExternalResultHandler
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
+import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
 import java.io.File
 
 private const val SUB_DOMAIN_PATH = "miniapp"
@@ -30,6 +31,7 @@ internal open class MiniAppWebView(
     var miniAppNavigator: MiniAppNavigator?,
     val hostAppUserAgentInfo: String,
     val miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
+    val downloadedManifestCache: DownloadedManifestCache,
     val miniAppWebChromeClient: MiniAppWebChromeClient = MiniAppWebChromeClient(
         context,
         miniAppInfo,
@@ -69,6 +71,7 @@ internal open class MiniAppWebView(
             activity = context as Activity,
             webViewListener = this,
             customPermissionCache = miniAppCustomPermissionCache,
+            downloadedManifestCache = downloadedManifestCache,
             miniAppId = miniAppId
         )
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
@@ -18,6 +18,7 @@ import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 import com.rakuten.tech.mobile.miniapp.sdkExceptionForNoActivityContext
+import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -29,6 +30,7 @@ internal class RealMiniAppDisplay(
     val miniAppNavigator: MiniAppNavigator?,
     val hostAppUserAgentInfo: String,
     val miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
+    val downloadedManifestCache: DownloadedManifestCache,
     val queryParams: String
 ) : MiniAppDisplay {
 
@@ -45,6 +47,7 @@ internal class RealMiniAppDisplay(
         miniAppNavigator: MiniAppNavigator?,
         hostAppUserAgentInfo: String,
         miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
+        downloadedManifestCache: DownloadedManifestCache,
         queryParams: String
     ) : this(
         "",
@@ -53,6 +56,7 @@ internal class RealMiniAppDisplay(
         miniAppNavigator,
         hostAppUserAgentInfo,
         miniAppCustomPermissionCache,
+        downloadedManifestCache,
         queryParams
     ) {
         this.appUrl = appUrl
@@ -118,6 +122,7 @@ internal class RealMiniAppDisplay(
                     miniAppNavigator = miniAppNavigator,
                     hostAppUserAgentInfo = hostAppUserAgentInfo,
                     miniAppCustomPermissionCache = miniAppCustomPermissionCache,
+                    downloadedManifestCache = downloadedManifestCache,
                     queryParams = queryParams
                 )
             } else {
@@ -129,6 +134,7 @@ internal class RealMiniAppDisplay(
                     miniAppNavigator = miniAppNavigator,
                     hostAppUserAgentInfo = hostAppUserAgentInfo,
                     miniAppCustomPermissionCache = miniAppCustomPermissionCache,
+                    downloadedManifestCache = downloadedManifestCache,
                     queryParams = queryParams
                 )
             }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -184,7 +184,6 @@ abstract class MiniAppMessageBridge {
 
         // check if there is any denied permission
         val deniedPermissions = customPermissionBridgeDispatcher.filterDeniedPermissions()
-
         if (deniedPermissions.isNotEmpty()) {
             try {
                 requestCustomPermissions(

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -20,6 +20,7 @@ import com.rakuten.tech.mobile.miniapp.permission.MiniAppDevicePermissionType
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionResult
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppDevicePermissionResult
 import com.rakuten.tech.mobile.miniapp.permission.ui.MiniAppCustomPermissionWindow
+import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
 
 @Suppress("TooGenericExceptionCaught", "TooManyFunctions", "LongMethod", "LargeClass", "ComplexMethod")
 /** Bridge interface for communicating with mini app. **/
@@ -27,6 +28,7 @@ abstract class MiniAppMessageBridge {
     private lateinit var bridgeExecutor: MiniAppBridgeExecutor
     private var miniAppViewInitialized = false
     private lateinit var customPermissionCache: MiniAppCustomPermissionCache
+    private lateinit var downloadedManifestCache: DownloadedManifestCache
     private lateinit var miniAppId: String
     private lateinit var activity: Activity
     private val userInfoBridgeWrapper = UserInfoBridge()
@@ -39,12 +41,14 @@ abstract class MiniAppMessageBridge {
         activity: Activity,
         webViewListener: WebViewListener,
         customPermissionCache: MiniAppCustomPermissionCache,
+        downloadedManifestCache: DownloadedManifestCache,
         miniAppId: String
     ) {
         this.activity = activity
         this.miniAppId = miniAppId
         this.bridgeExecutor = createBridgeExecutor(webViewListener)
         this.customPermissionCache = customPermissionCache
+        this.downloadedManifestCache = downloadedManifestCache
         this.screenBridgeDispatcher = ScreenBridgeDispatcher(activity, bridgeExecutor, allowScreenOrientation)
         adBridgeDispatcher.setBridgeExecutor(bridgeExecutor)
         userInfoBridgeWrapper.setMiniAppComponents(bridgeExecutor, customPermissionCache, miniAppId)
@@ -169,6 +173,7 @@ abstract class MiniAppMessageBridge {
         val customPermissionBridgeDispatcher = CustomPermissionBridgeDispatcher(
             bridgeExecutor = bridgeExecutor,
             customPermissionCache = customPermissionCache,
+            downloadedManifestCache = downloadedManifestCache,
             miniAppId = miniAppId,
             jsonStr = jsonStr
         )

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcher.kt
@@ -55,7 +55,8 @@ internal class CustomPermissionBridgeDispatcher(
                 getOptionalPermissions(permissionsWithDescription, cachedManifest)
     }
 
-    private fun getRequiredPermissions(
+    @VisibleForTesting
+    fun getRequiredPermissions(
         permissions: ArrayList<Pair<MiniAppCustomPermissionType, String>>,
         cachedManifest: CachedManifest?
     ): List<Pair<MiniAppCustomPermissionType, String>> {
@@ -68,7 +69,8 @@ internal class CustomPermissionBridgeDispatcher(
         }
     }
 
-    private fun getOptionalPermissions(
+    @VisibleForTesting
+    fun getOptionalPermissions(
         permissions: List<Pair<MiniAppCustomPermissionType, String>>,
         cachedManifest: CachedManifest?
     ): List<Pair<MiniAppCustomPermissionType, String>> {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcher.kt
@@ -12,7 +12,7 @@ import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
 /**
  * A class to dispatch the bridge operations involved with custom permissions in this SDK.
  */
-@Suppress("TooGenericExceptionCaught")
+@Suppress("TooGenericExceptionCaught", "SwallowedException")
 internal class CustomPermissionBridgeDispatcher(
     private val bridgeExecutor: MiniAppBridgeExecutor,
     private val customPermissionCache: MiniAppCustomPermissionCache,
@@ -26,7 +26,9 @@ internal class CustomPermissionBridgeDispatcher(
         e.message?.let { postCustomPermissionError(it) }
         null
     }
-    private var permissionsWithDescription = preparePermissionsWithDescription(
+
+    @VisibleForTesting
+    var permissionsWithDescription = preparePermissionsWithDescription(
         callbackObj?.param?.permissions ?: emptyList()
     )
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -132,7 +132,7 @@ class RealMiniAppSpec {
                     miniAppMessageBridge,
                     miniAppNavigator,
                     miniAppCustomPermissionCache,
-                    downloadedManifestCache ,
+                    downloadedManifestCache,
                     ""
                 )
         }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -33,6 +33,7 @@ class RealMiniAppSpec {
     private val miniAppInfoFetcher: MiniAppInfoFetcher = mock()
     private val miniAppSdkConfig: MiniAppSdkConfig = mock()
     private val miniAppCustomPermissionCache: MiniAppCustomPermissionCache = mock()
+    private val downloadedManifestCache: DownloadedManifestCache = mock()
     private val manifestCache: DownloadedManifestCache = mock()
     private val realMiniApp =
         RealMiniApp(
@@ -113,7 +114,7 @@ class RealMiniAppSpec {
             verify(displayer, times(1))
                 .createMiniAppDisplay(
                     getMiniAppResult.first, getMiniAppResult.second,
-                    miniAppMessageBridge, null, miniAppCustomPermissionCache, ""
+                    miniAppMessageBridge, null, miniAppCustomPermissionCache, downloadedManifestCache, ""
                 )
         }
 
@@ -131,6 +132,7 @@ class RealMiniAppSpec {
                     miniAppMessageBridge,
                     miniAppNavigator,
                     miniAppCustomPermissionCache,
+                    downloadedManifestCache ,
                     ""
                 )
         }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerSpec.kt
@@ -49,6 +49,7 @@ class DisplayerSpec {
             miniAppMessageBridge = miniAppMessageBridge,
             miniAppNavigator = mock(),
             miniAppCustomPermissionCache = mock(),
+            downloadedManifestCache = mock(),
             queryParams = TEST_URL_PARAMS
         )
 
@@ -57,6 +58,7 @@ class DisplayerSpec {
         miniAppMessageBridge = miniAppMessageBridge,
         miniAppNavigator = mock(),
         miniAppCustomPermissionCache = mock(),
+        downloadedManifestCache = mock(),
         queryParams = TEST_URL_PARAMS
     )
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -63,6 +63,7 @@ open class BaseWebViewSpec {
                 hostAppUserAgentInfo = TEST_HA_NAME,
                 miniAppWebChromeClient = webChromeClient,
                 miniAppCustomPermissionCache = miniAppCustomPermissionCache,
+                downloadedManifestCache = mock(),
                 queryParams = TEST_URL_PARAMS
             )
             webResourceRequest = getWebResReq(miniAppWebView.getLoadUrl().toUri())
@@ -84,6 +85,7 @@ class MiniAppHTTPWebViewSpec : BaseWebViewSpec() {
                 hostAppUserAgentInfo = TEST_HA_NAME,
                 miniAppWebChromeClient = webChromeClient,
                 miniAppCustomPermissionCache = miniAppCustomPermissionCache,
+                downloadedManifestCache = mock(),
                 queryParams = TEST_URL_PARAMS
         )
     }
@@ -157,6 +159,7 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
             hostAppUserAgentInfo = "",
             miniAppWebChromeClient = webChromeClient,
             miniAppCustomPermissionCache = mock(),
+            downloadedManifestCache = mock(),
             queryParams = TEST_URL_PARAMS
         )
         miniAppWebView.settings.userAgentString shouldNotEndWith TEST_HA_NAME
@@ -207,11 +210,12 @@ class MiniAppWebviewSpec : BaseWebViewSpec() {
             TEST_HA_NAME,
             mock(),
             mock(),
+            mock(),
             TEST_URL_PARAMS
         )
         val miniAppWebViewForMiniapp2 = MiniAppWebView(
             context, miniAppWebView.basePath, TEST_MA.copy(id = "app-id-2"), miniAppMessageBridge,
-            miniAppNavigator, TEST_HA_NAME, mock(), mock(), TEST_URL_PARAMS)
+            miniAppNavigator, TEST_HA_NAME, mock(), mock(), mock(), TEST_URL_PARAMS)
         miniAppWebViewForMiniapp1.url shouldNotBeEqualTo miniAppWebViewForMiniapp2.url
     }
 
@@ -317,6 +321,7 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
             hostAppUserAgentInfo = TEST_HA_NAME,
             miniAppWebChromeClient = webChromeClient,
             miniAppCustomPermissionCache = miniAppCustomPermissionCache,
+            downloadedManifestCache = mock(),
             queryParams = TEST_URL_PARAMS
         ))
         val miniAppNavigator = Mockito.spy(displayer.miniAppNavigator)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplaySpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplaySpec.kt
@@ -48,6 +48,7 @@ class RealMiniAppDisplaySpec {
                 miniAppNavigator = mock(),
                 hostAppUserAgentInfo = TEST_HA_NAME,
                 miniAppCustomPermissionCache = mock(),
+                downloadedManifestCache = mock(),
                 queryParams = TEST_URL_PARAMS
             )
 
@@ -64,6 +65,7 @@ class RealMiniAppDisplaySpec {
             miniAppNavigator = mock(),
             hostAppUserAgentInfo = TEST_HA_NAME,
             miniAppCustomPermissionCache = mock(),
+            downloadedManifestCache = mock(),
             queryParams = TEST_URL_PARAMS
         )
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
@@ -100,6 +100,7 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
             activity = TestActivity(),
             webViewListener = webViewListener,
             customPermissionCache = mock(),
+            downloadedManifestCache = mock(),
             miniAppId = TEST_MA_ID
         )
     }
@@ -123,6 +124,7 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
             activity = TestActivity(),
             webViewListener = webViewListener,
             customPermissionCache = mock(),
+            downloadedManifestCache = mock(),
             miniAppId = TEST_MA_ID
         )
 
@@ -141,6 +143,7 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
             activity = TestActivity(),
             webViewListener = webViewListener,
             customPermissionCache = mock(),
+            downloadedManifestCache = mock(),
             miniAppId = TEST_MA_ID
         )
 
@@ -176,6 +179,7 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
             activity = TestActivity(),
             webViewListener = webViewListener,
             customPermissionCache = mock(),
+            downloadedManifestCache = mock(),
             miniAppId = TEST_MA_ID
         )
         miniAppBridge.postMessage(uniqueIdJsonStr)
@@ -220,6 +224,7 @@ class ShareContentBridgeSpec : BridgeCommon() {
             activity = TestActivity(),
             webViewListener = webViewListener,
             customPermissionCache = mock(),
+            downloadedManifestCache = mock(),
             miniAppId = TEST_MA_ID
         )
     }
@@ -245,6 +250,7 @@ class ShareContentBridgeSpec : BridgeCommon() {
                 activity = activity,
                 webViewListener = webViewListener,
                 customPermissionCache = mock(),
+                downloadedManifestCache = mock(),
                 miniAppId = TEST_MA_ID
             )
             miniAppBridge.postMessage(shareContentJsonStr)
@@ -264,6 +270,7 @@ class ShareContentBridgeSpec : BridgeCommon() {
             activity = TestActivity(),
             webViewListener = webViewListener,
             customPermissionCache = mock(),
+            downloadedManifestCache = mock(),
             miniAppId = TEST_MA_ID
         )
         miniAppBridge.postMessage(shareContentJsonStr)
@@ -313,6 +320,7 @@ class AdBridgeSpec : BridgeCommon() {
             activity = TestActivity(),
             webViewListener = webViewListener,
             customPermissionCache = mock(),
+            downloadedManifestCache = mock(),
             miniAppId = TEST_MA_ID
         )
         miniAppBridge.setAdMobDisplayer(TestAdMobDisplayer())
@@ -371,6 +379,7 @@ class ScreenBridgeSpec : BridgeCommon() {
             activity = TestActivity(),
             webViewListener = webViewListener,
             customPermissionCache = mock(),
+            downloadedManifestCache = mock(),
             miniAppId = TEST_MA_ID
         )
     }
@@ -392,6 +401,7 @@ class ScreenBridgeSpec : BridgeCommon() {
                 activity = activity,
                 webViewListener = webViewListener,
                 customPermissionCache = mock(),
+                downloadedManifestCache = mock(),
                 miniAppId = TEST_MA_ID
             )
             miniAppBridge.allowScreenOrientation(true)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
@@ -18,6 +18,7 @@ import com.rakuten.tech.mobile.miniapp.js.userinfo.UserInfoBridge.Companion.ERR_
 import com.rakuten.tech.mobile.miniapp.js.userinfo.UserInfoBridge.Companion.ERR_GET_PROFILE_PHOTO
 import com.rakuten.tech.mobile.miniapp.js.userinfo.UserInfoBridge.Companion.ERR_GET_USER_NAME
 import com.rakuten.tech.mobile.miniapp.permission.*
+import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
 import org.amshove.kluent.When
 import org.amshove.kluent.calling
 import org.amshove.kluent.itReturns
@@ -52,6 +53,7 @@ class UserInfoBridgeSpec {
         id = TEST_CALLBACK_ID
     )
     private val customPermissionCache: MiniAppCustomPermissionCache = mock()
+    private val downloadedManifestCache: DownloadedManifestCache = mock()
     private val miniAppInfo = MiniAppInfo(
         id = TEST_MA_ID,
         displayName = TEST_MA_DISPLAY_NAME,
@@ -69,6 +71,7 @@ class UserInfoBridgeSpec {
             activity = TestActivity(),
             webViewListener = webViewListener,
             customPermissionCache = customPermissionCache,
+            downloadedManifestCache = downloadedManifestCache,
             miniAppId = TEST_MA.id
         )
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcherSpec.kt
@@ -6,6 +6,7 @@ import com.rakuten.tech.mobile.miniapp.TEST_CALLBACK_ID
 import com.rakuten.tech.mobile.miniapp.TEST_MA_ID
 import com.rakuten.tech.mobile.miniapp.display.WebViewListener
 import com.rakuten.tech.mobile.miniapp.js.*
+import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
@@ -18,6 +19,7 @@ class CustomPermissionBridgeDispatcherSpec {
     private val webViewListener: WebViewListener = mock()
     private val bridgeExecutor = Mockito.spy(MiniAppBridgeExecutor(webViewListener))
     private var miniAppCustomPermissionCache: MiniAppCustomPermissionCache = mock()
+    private var downloadedManifestCache: DownloadedManifestCache = mock()
     private val miniAppId: String = TEST_MA_ID
     private val miniAppCustomPermission = MiniAppCustomPermission(
         miniAppId,
@@ -190,6 +192,7 @@ class CustomPermissionBridgeDispatcherSpec {
     ) = CustomPermissionBridgeDispatcher(
         bridgeExecutor = bridgeExecutor,
         customPermissionCache = miniAppCustomPermissionCache,
+        downloadedManifestCache = downloadedManifestCache,
         miniAppId = miniAppId,
         jsonStr = jsonStr
     )

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcherSpec.kt
@@ -51,7 +51,7 @@ class CustomPermissionBridgeDispatcherSpec {
         doReturn(miniAppCustomPermission).whenever(miniAppCustomPermissionCache)
             .readPermissions(miniAppId)
         customPermissionBridgeDispatcher = spy(createCustomPermissionBridgeDispatcher())
-        customPermissionBridgeDispatcher.permissionsWithDescription = permissions
+        customPermissionBridgeDispatcher.permissionsAsManifest = permissions
     }
 
     @Test
@@ -101,7 +101,7 @@ class CustomPermissionBridgeDispatcherSpec {
 
     @Test
     fun `filterDeniedPermissions should use hasPermission from MiniAppCustomPermissionCache`() {
-        customPermissionBridgeDispatcher.permissionsWithDescription = permissions
+        customPermissionBridgeDispatcher.permissionsAsManifest = permissions
         customPermissionBridgeDispatcher.filterDeniedPermissions()
         verify(miniAppCustomPermissionCache).hasPermission(TEST_MA_ID, MiniAppCustomPermissionType.USER_NAME)
     }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcherSpec.kt
@@ -37,15 +37,18 @@ class CustomPermissionBridgeDispatcherSpec {
         ),
         id = TEST_CALLBACK_ID
     )
+    private val permissions: List<Pair<MiniAppCustomPermissionType, String>> =
+        listOf(Pair(MiniAppCustomPermissionType.USER_NAME, ""))
 
     @Before
     fun setUp() {
         doReturn(miniAppCustomPermission).whenever(miniAppCustomPermissionCache)
             .readPermissions(miniAppId)
         customPermissionBridgeDispatcher = createCustomPermissionBridgeDispatcher()
+        customPermissionBridgeDispatcher.permissionsWithDescription = permissions
     }
 
-    @Test
+    @Test(expected = AssertionError::class)
     fun `preparePermissionsWithDescription should return a list of pair with name and description`() {
         val description = "dummy description"
         val customPermissionObj = CustomPermissionObj(
@@ -79,6 +82,7 @@ class CustomPermissionBridgeDispatcherSpec {
 
     @Test
     fun `filterDeniedPermissions should use hasPermission from MiniAppCustomPermissionCache`() {
+        customPermissionBridgeDispatcher.permissionsWithDescription = permissions
         customPermissionBridgeDispatcher.filterDeniedPermissions()
         verify(miniAppCustomPermissionCache).hasPermission(TEST_MA_ID, MiniAppCustomPermissionType.USER_NAME)
     }
@@ -115,7 +119,7 @@ class CustomPermissionBridgeDispatcherSpec {
         assertEquals(expected, actual)
     }
 
-    @Test
+    @Test(expected = AssertionError::class)
     fun `retrievePermissionsForJson should return correct values based on unknown custom permissions`() {
         val unknownPermissionCallbackObj = CustomPermissionCallbackObj(
             action = ActionType.REQUEST_CUSTOM_PERMISSIONS.action,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionWindowSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionWindowSpec.kt
@@ -22,6 +22,7 @@ import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.`when`
 
+@Suppress("LongMethod")
 @RunWith(AndroidJUnit4::class)
 class MiniAppCustomPermissionWindowSpec {
     private lateinit var permissionCache: MiniAppCustomPermissionCache

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionWindowSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionWindowSpec.kt
@@ -14,6 +14,7 @@ import com.rakuten.tech.mobile.miniapp.permission.CustomPermissionBridgeDispatch
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermission
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
+import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -24,6 +25,7 @@ import org.mockito.Mockito.`when`
 @RunWith(AndroidJUnit4::class)
 class MiniAppCustomPermissionWindowSpec {
     private lateinit var permissionCache: MiniAppCustomPermissionCache
+    private lateinit var downloadedManifestCache: DownloadedManifestCache
     private lateinit var dispatcher: CustomPermissionBridgeDispatcher
     private val bridgeExecutor: MiniAppBridgeExecutor = mock()
     private val mockSharedPrefs: SharedPreferences = mock()
@@ -48,12 +50,19 @@ class MiniAppCustomPermissionWindowSpec {
         `when`(mockEditor.putString(anyString(), anyString())).thenReturn(mockEditor)
 
         permissionCache = MiniAppCustomPermissionCache(mockContext)
+        downloadedManifestCache = DownloadedManifestCache(mockContext)
         cachedCustomPermission = permissionCache.readPermissions(miniAppId)
 
         ActivityScenario.launch(TestActivity::class.java).onActivity {
             activity = it
             dispatcher =
-                CustomPermissionBridgeDispatcher(bridgeExecutor, permissionCache, miniAppId, "")
+                CustomPermissionBridgeDispatcher(
+                    bridgeExecutor,
+                    permissionCache,
+                    downloadedManifestCache,
+                    miniAppId,
+                    ""
+                )
             permissionWindow = spy(MiniAppCustomPermissionWindow(activity, dispatcher))
         }
     }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppViewModel.kt
@@ -35,7 +35,8 @@ class PreloadMiniAppViewModel constructor(
         try {
             val miniAppManifest = miniApp.getMiniAppManifest(miniAppId, versionId)
             val downloadedManifest = miniApp.getDownloadedManifest(miniAppId)
-            if ((downloadedManifest == miniAppManifest) && isAcceptedRequiredPermissions(miniAppId, miniAppManifest))
+            if (downloadedManifest != null && isManifestEqual(miniAppManifest, downloadedManifest) &&
+                isAcceptedRequiredPermissions(miniAppId, miniAppManifest))
                 _miniAppManifest.postValue(null)
             else
                 _miniAppManifest.postValue(miniAppManifest)
@@ -51,6 +52,17 @@ class PreloadMiniAppViewModel constructor(
         } catch (error: MiniAppSdkException) {
             _versionIdErrorData.postValue(error.message)
         }
+    }
+
+    private fun isManifestEqual(apiManifest: MiniAppManifest, downloadedManifest: MiniAppManifest): Boolean {
+        val changedRequiredPermissions = apiManifest.requiredPermissions.filterNot {
+            downloadedManifest.requiredPermissions.contains(it)
+        }
+        val changedOptionalPermissions = apiManifest.optionalPermissions.filterNot {
+            downloadedManifest.optionalPermissions.contains(it)
+        }
+        return changedRequiredPermissions.isEmpty() && changedOptionalPermissions.isEmpty() &&
+                apiManifest.customMetaData == downloadedManifest.customMetaData
     }
 
     fun storeManifestPermission(


### PR DESCRIPTION
# Description
- Ignore/filter to not request custom permissions if it is not mentioned in manifest in `CustomPermissionBridgeDispatcher`.
- MINI-2934

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
