### PR TITLE
fix: return permissions only included by manifest from custom permission cache while reading

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
@@ -1,6 +1,5 @@
 package com.rakuten.tech.mobile.miniapp.permission
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
@@ -18,20 +17,14 @@ internal class MiniAppCustomPermissionCache(context: Context) {
         "com.rakuten.tech.mobile.miniapp.custom.permissions.cache", Context.MODE_PRIVATE
     )
 
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun doesDataExist(miniAppId: String) = prefs.contains(miniAppId)
-
     /**
      * Reads the grant results from SharedPreferences.
      * @param [miniAppId] the key provided to find the stored results per MiniApp
      * @return [MiniAppCustomPermission] an object to contain the results per MiniApp
-     * if data has been stored in cache, otherwise default value.
+     * if data has been stored in cache, otherwise empty value.
      */
-    @SuppressLint("RestrictedApi")
-    @SuppressWarnings("NestedBlockDepth")
     fun readPermissions(miniAppId: String): MiniAppCustomPermission {
-        val defaultValue = defaultDeniedList(miniAppId)
-        return if (doesDataExist(miniAppId)) {
+        return if (prefs.contains(miniAppId)) {
             try {
                 val cachedPermission: MiniAppCustomPermission = Gson().fromJson(
                     prefs.getString(miniAppId, ""),
@@ -39,11 +32,10 @@ internal class MiniAppCustomPermissionCache(context: Context) {
                 )
                 cachedPermission
             } catch (e: Exception) {
-                // if there is any exception, just return the default value
-                defaultValue
+                MiniAppCustomPermission(miniAppId, emptyList())
             }
         } else {
-            defaultValue
+            MiniAppCustomPermission(miniAppId, emptyList())
         }
     }
 
@@ -124,34 +116,5 @@ internal class MiniAppCustomPermissionCache(context: Context) {
         }?.let { isPermissionGranted = true }
 
         return isPermissionGranted
-    }
-
-    /**
-     * Note: Update this default list when adding or removing a custom permission,
-     * [MiniAppCustomPermissionCache] should automatically handle the value.
-     */
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun defaultDeniedList(miniAppId: String): MiniAppCustomPermission {
-        return MiniAppCustomPermission(
-            miniAppId,
-            listOf(
-                Pair(
-                    MiniAppCustomPermissionType.USER_NAME,
-                    MiniAppCustomPermissionResult.DENIED
-                ),
-                Pair(
-                    MiniAppCustomPermissionType.PROFILE_PHOTO,
-                    MiniAppCustomPermissionResult.DENIED
-                ),
-                Pair(
-                    MiniAppCustomPermissionType.CONTACT_LIST,
-                    MiniAppCustomPermissionResult.DENIED
-                ),
-                Pair(
-                    MiniAppCustomPermissionType.LOCATION,
-                    MiniAppCustomPermissionResult.DENIED
-                )
-            )
-        )
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
@@ -3,7 +3,6 @@ package com.rakuten.tech.mobile.miniapp.permission
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -73,7 +72,6 @@ internal class MiniAppCustomPermissionCache(context: Context) {
         val newPermissions = cachedPermissions.mapNotNull { (first) ->
             permissions.find { it.first == first }
         }
-        Log.d("AAAAA",""+MiniAppCustomPermission(miniAppId, newPermissions))
         applyStoringPermissions(MiniAppCustomPermission(miniAppId, newPermissions))
     }
 
@@ -88,9 +86,7 @@ internal class MiniAppCustomPermissionCache(context: Context) {
     @VisibleForTesting
     fun applyStoringPermissions(miniAppCustomPermission: MiniAppCustomPermission) {
         val jsonToStore: String = Gson().toJson(sortedByDefault(miniAppCustomPermission))
-        Log.d("AAAAA1",""+jsonToStore)
         prefs.edit().putString(miniAppCustomPermission.miniAppId, jsonToStore).apply()
-
     }
 
     // Sort the `pairValues` by ordinal of [MiniAppCustomPermissionType].

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCache.kt
@@ -15,9 +15,7 @@ import kotlin.Exception
  * A caching class to read and store the [CachedManifest] per MiniApp using [SharedPreferences].
  */
 @Suppress("TooGenericExceptionCaught", "SwallowedException")
-internal class DownloadedManifestCache(
-    context: Context
-) {
+internal class DownloadedManifestCache(context: Context) {
     private val prefs: SharedPreferences = context.getSharedPreferences(
         "com.rakuten.tech.mobile.miniapp.manifest.cache.downloaded", Context.MODE_PRIVATE
     )

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
@@ -53,7 +53,6 @@ class MiniAppCustomPermissionCacheSpec {
         val actual = miniAppCustomPermissionCache.readPermissions(TEST_MA_ID)
         val expected = miniAppCustomPermissionCache.defaultDeniedList(TEST_MA_ID)
 
-        verify(miniAppCustomPermissionCache).applyStoringPermissions(expected)
         actual shouldEqual expected
     }
 
@@ -100,7 +99,7 @@ class MiniAppCustomPermissionCacheSpec {
         miniAppCustomPermissionCache.storePermissions(miniAppCustomPermission)
 
         verify(miniAppCustomPermissionCache).prepareAllPermissionsToStore(TEST_MA_ID, list)
-        verify(miniAppCustomPermissionCache, times(2)).applyStoringPermissions(miniAppCustomPermission)
+        verify(miniAppCustomPermissionCache).applyStoringPermissions(miniAppCustomPermission)
     }
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
@@ -30,58 +30,16 @@ class MiniAppCustomPermissionCacheSpec {
         miniAppCustomPermissionCache = spy(MiniAppCustomPermissionCache(mockContext))
     }
 
-    @Test
-    fun `isDataExist should return false when miniAppId is not stored`() {
-        val actual = miniAppCustomPermissionCache.doesDataExist(TEST_MA_ID)
-
-        actual shouldEqual false
-    }
-
-    @Test
-    fun `isDataExist should return true when miniAppId is stored`() {
-        doReturn(true).whenever(mockSharedPrefs).contains(TEST_MA_ID)
-        val actual = miniAppCustomPermissionCache.doesDataExist(TEST_MA_ID)
-
-        actual shouldEqual true
-    }
-
     /**
      * region: readPermissions
      */
     @Test
-    fun `readPermissions should return default value when it hasn't stored any data yet`() {
+    fun `readPermissions should return empty value when it hasn't stored any data yet`() {
         val actual = miniAppCustomPermissionCache.readPermissions(TEST_MA_ID)
-        val expected = miniAppCustomPermissionCache.defaultDeniedList(TEST_MA_ID)
+        val expected = MiniAppCustomPermission(TEST_MA_ID, emptyList())
 
         actual shouldEqual expected
     }
-
-    @Test
-    fun `readPermissions should return actual value when it has stored data`() {
-        doReturn(true).whenever(miniAppCustomPermissionCache).doesDataExist(TEST_MA_ID)
-        val actual = miniAppCustomPermissionCache.readPermissions(TEST_MA_ID)
-        val expected = miniAppCustomPermissionCache.defaultDeniedList(TEST_MA_ID)
-
-        actual shouldEqual expected
-    }
-
-    @Test
-    fun `readPermissions will not apply data to be stored when exception`() {
-        val default = MiniAppCustomPermission(
-            TEST_MA_ID, listOf(
-                Pair(MiniAppCustomPermissionType.USER_NAME, MiniAppCustomPermissionResult.DENIED)
-            )
-        )
-
-        doReturn(true).whenever(miniAppCustomPermissionCache).doesDataExist(TEST_MA_ID)
-        doReturn(default).whenever(miniAppCustomPermissionCache).defaultDeniedList(TEST_MA_ID)
-
-        val actual = miniAppCustomPermissionCache.readPermissions(TEST_MA_ID)
-
-        verify(miniAppCustomPermissionCache, times(0)).applyStoringPermissions(default)
-        actual shouldEqual default
-    }
-
     /** end region */
 
     @Test
@@ -94,7 +52,6 @@ class MiniAppCustomPermissionCacheSpec {
     fun `storePermissions will invoke necessary functions to save value`() {
         val list = listOf(Pair(MiniAppCustomPermissionType.USER_NAME, MiniAppCustomPermissionResult.DENIED))
         val miniAppCustomPermission = MiniAppCustomPermission(TEST_MA_ID, list)
-        doReturn(miniAppCustomPermission).whenever(miniAppCustomPermissionCache).defaultDeniedList(TEST_MA_ID)
 
         miniAppCustomPermissionCache.storePermissions(miniAppCustomPermission)
 
@@ -204,37 +161,6 @@ class MiniAppCustomPermissionCacheSpec {
         )
 
         actual shouldBe true
-    }
-    /** end region */
-
-    /**
-     * region: defaultDeniedList.
-     * Update the values in the following tests when adding or removing a custom permission.
-     */
-    @Test
-    fun `check the size of the default denied list`() {
-        val actual = miniAppCustomPermissionCache.defaultDeniedList(TEST_MA_ID).pairValues
-
-        actual.size shouldBe 4
-    }
-
-    @Test
-    fun `check MiniAppCustomPermissionType of the default denied list`() {
-        val actual = miniAppCustomPermissionCache.defaultDeniedList(TEST_MA_ID)
-
-        actual.pairValues[0].first shouldEqual MiniAppCustomPermissionType.USER_NAME
-        actual.pairValues[1].first shouldEqual MiniAppCustomPermissionType.PROFILE_PHOTO
-        actual.pairValues[2].first shouldEqual MiniAppCustomPermissionType.CONTACT_LIST
-        actual.pairValues[3].first shouldEqual MiniAppCustomPermissionType.LOCATION
-    }
-
-    @Test
-    fun `check MiniAppCustomPermissionResult of the default denied list`() {
-        val actual = miniAppCustomPermissionCache.defaultDeniedList(TEST_MA_ID)
-
-        actual.pairValues.forEach {
-            it.second shouldEqual MiniAppCustomPermissionResult.DENIED
-        }
     }
     /** end region */
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/MiniAppPermissionSettingsActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/MiniAppPermissionSettingsActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -17,7 +18,6 @@ import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.ListCustomPermissionBinding
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
-import kotlinx.coroutines.launch
 
 class MiniAppPermissionSettingsActivity(private val miniapp: MiniApp) : BaseActivity() {
 
@@ -26,6 +26,7 @@ class MiniAppPermissionSettingsActivity(private val miniapp: MiniApp) : BaseActi
     private lateinit var permissionSettingsAdapter: MiniAppPermissionSettingsAdapter
     private lateinit var miniAppId: String
     private lateinit var binding: ListCustomPermissionBinding
+    private val namesForAdapter: ArrayList<MiniAppCustomPermissionType> = arrayListOf()
 
     companion object {
         const val REQ_CODE_PERMISSIONS_UPDATE = 10101
@@ -51,15 +52,12 @@ class MiniAppPermissionSettingsActivity(private val miniapp: MiniApp) : BaseActi
         miniAppId = intent.getStringExtra(miniAppIdTag) ?: ""
 
         initAdapter()
-        val namesForAdapter: ArrayList<MiniAppCustomPermissionType> = arrayListOf()
         val resultsForAdapter: ArrayList<MiniAppCustomPermissionResult> = arrayListOf()
 
         miniapp.getCustomPermissions(miniAppId).pairValues.forEach {
             namesForAdapter.add(it.first)
             resultsForAdapter.add(it.second)
         }
-
-
 
         Log.d("AAAAA2",""+miniapp.getCustomPermissions(miniAppId).pairValues)
 
@@ -68,6 +66,9 @@ class MiniAppPermissionSettingsActivity(private val miniapp: MiniApp) : BaseActi
             resultsForAdapter,
             arrayListOf()
         )
+
+        if (namesForAdapter.isEmpty()) binding.emptyView.visibility = View.VISIBLE
+        else binding.emptyView.visibility = View.GONE
     }
 
     private fun initAdapter() {
@@ -82,6 +83,11 @@ class MiniAppPermissionSettingsActivity(private val miniapp: MiniApp) : BaseActi
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.settings_menu, menu)
         return true
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
+        menu?.findItem(R.id.settings_menu_save)?.isEnabled = namesForAdapter.isNotEmpty()
+        return super.onPrepareOptionsMenu(menu)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/MiniAppPermissionSettingsActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/MiniAppPermissionSettingsActivity.kt
@@ -3,6 +3,7 @@ package com.rakuten.tech.mobile.testapp.ui.permission
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import androidx.databinding.DataBindingUtil
@@ -16,6 +17,7 @@ import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.ListCustomPermissionBinding
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
+import kotlinx.coroutines.launch
 
 class MiniAppPermissionSettingsActivity(private val miniapp: MiniApp) : BaseActivity() {
 
@@ -56,6 +58,10 @@ class MiniAppPermissionSettingsActivity(private val miniapp: MiniApp) : BaseActi
             namesForAdapter.add(it.first)
             resultsForAdapter.add(it.second)
         }
+
+
+
+        Log.d("AAAAA2",""+miniapp.getCustomPermissions(miniAppId).pairValues)
 
         permissionSettingsAdapter.addPermissionList(
             namesForAdapter,

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/MiniAppPermissionSettingsActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/MiniAppPermissionSettingsActivity.kt
@@ -3,7 +3,6 @@ package com.rakuten.tech.mobile.testapp.ui.permission
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
@@ -58,8 +57,6 @@ class MiniAppPermissionSettingsActivity(private val miniapp: MiniApp) : BaseActi
             namesForAdapter.add(it.first)
             resultsForAdapter.add(it.second)
         }
-
-        Log.d("AAAAA2",""+miniapp.getCustomPermissions(miniAppId).pairValues)
 
         permissionSettingsAdapter.addPermissionList(
             namesForAdapter,

--- a/testapp/src/main/res/layout/list_custom_permission.xml
+++ b/testapp/src/main/res/layout/list_custom_permission.xml
@@ -1,10 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout>
-  <androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/listCustomPermission"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:padding="@dimen/small_8"
-    tools:listitem="@layout/item_list_custom_permission" />
+    android:layout_height="match_parent">
+
+    <androidx.appcompat.widget.AppCompatTextView
+      android:id="@+id/emptyView"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:layout_margin="@dimen/large_24"
+      android:gravity="top|center"
+      android:text="@string/message_empty_permissions"
+      android:textSize="@dimen/text_large_18"
+      android:visibility="gone"
+      tools:visibility="visible" />
+
+    <androidx.recyclerview.widget.RecyclerView
+      android:id="@+id/listCustomPermission"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:padding="@dimen/small_8"
+      tools:listitem="@layout/item_list_custom_permission" />
+  </RelativeLayout>
 </layout>

--- a/testapp/src/main/res/layout/list_custom_permission.xml
+++ b/testapp/src/main/res/layout/list_custom_permission.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:app="http://schemas.android.com/apk/res-auto">
+<layout>
 
   <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">

--- a/testapp/src/main/res/layout/list_custom_permission.xml
+++ b/testapp/src/main/res/layout/list_custom_permission.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout>
+<layout xmlns:app="http://schemas.android.com/apk/res-auto">
 
-  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -22,6 +22,9 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:padding="@dimen/small_8"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
       tools:listitem="@layout/item_list_custom_permission" />
-  </RelativeLayout>
+  </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="error_invalid_input">Invalid Input</string>
 
     <string name="message_empty_miniapps">There is no Mini App found!</string>
+    <string name="message_empty_permissions">There is no permission found!</string>
 
     <string name="tut_setting">This is the first time you launch the MiniApp Demo application on this device. You need to provide your own Host Project ID and Subscription Key from &lt;font color="#BF0000">&lt;b>Rakuten&lt;/b>&lt;/font> &lt;b>App Studio&lt;/b></string>
 </resources>


### PR DESCRIPTION
# Description
Android is showing up all the permissions inside the demo app permission settings rather than the only one's present in Manifest. This is a fix belongs to SDK side, this PR aims to fix this issue. When there is no permission, the permissions settings screen in demo app will show a message about this emptiness. 

## Links
- MINI-2937

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
