### PR TITLE
fix: consistent permission cache

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -193,8 +193,7 @@ internal class MiniAppDownloader(
         }
     }
 
-    fun getDownloadedMiniAppList(): List<MiniAppInfo> =
-        miniAppStatus.getDownloadedMiniAppList()
+    fun getDownloadedMiniAppList(): List<MiniAppInfo> = miniAppStatus.getDownloadedMiniAppList()
 
     @Suppress("SENSELESS_COMPARISON")
     @VisibleForTesting

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
@@ -30,9 +30,8 @@ internal class MiniAppCustomPermissionCache(context: Context) {
                     prefs.getString(miniAppId, ""),
                     object : TypeToken<MiniAppCustomPermission>() {}.type
                 )
-                cachedPermission
-//                val nonNullList = cachedPermission.pairValues.filterNot { it.first == null }
-//                cachedPermission.copy(pairValues = nonNullList)
+                val nonNullList = cachedPermission.pairValues.filterNot { it.first == null }
+                cachedPermission.copy(pairValues = nonNullList)
             } catch (e: Exception) {
                 MiniAppCustomPermission(miniAppId, emptyList())
             }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
@@ -31,6 +31,8 @@ internal class MiniAppCustomPermissionCache(context: Context) {
                     object : TypeToken<MiniAppCustomPermission>() {}.type
                 )
                 cachedPermission
+//                val nonNullList = cachedPermission.pairValues.filterNot { it.first == null }
+//                cachedPermission.copy(pairValues = nonNullList)
             } catch (e: Exception) {
                 MiniAppCustomPermission(miniAppId, emptyList())
             }
@@ -48,9 +50,7 @@ internal class MiniAppCustomPermissionCache(context: Context) {
     ) {
         val supplied = miniAppCustomPermission.pairValues.toMutableList()
         // Remove any unknown permission parameter from HostApp.
-        supplied.removeAll { (first) ->
-            first.type == MiniAppCustomPermissionType.UNKNOWN.type
-        }
+        supplied.removeAll { (first) -> first.type == MiniAppCustomPermissionType.UNKNOWN.type }
         val miniAppId = miniAppCustomPermission.miniAppId
         val allPermissions = prepareAllPermissionsToStore(miniAppId, supplied)
         applyStoringPermissions(MiniAppCustomPermission(miniAppId, allPermissions))


### PR DESCRIPTION
# Description
Null value when read custom permission cache. When gson parsing invalid enum value, it will be set to null so the sdk must remove null values which came from previous versions.

The details are added in MINI-2981 description.

## Links
MINI-2981

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
