### PR TITLE
minor refactor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     ext.mockito = '3.3.3'
     ext.okhttp = '4.9.0'
     ext.manifest_config = '0.2.0'
-    ext.nhrm_mockito_kotlin = '2.2.0'
+    ext.mockito_kotlin = '2.2.11'
     ext.sdk_utils = '0.2.0'
     ext.retrofit = '2.9.0'
     ext.robolectric = '4.3.1'

--- a/miniapp/build.gradle
+++ b/miniapp/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     testImplementation "org.mockito:mockito-android:$mockito"
     testImplementation "org.mockito:mockito-core:$mockito"
     testImplementation "org.mockito:mockito-inline:$mockito"
-    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$nhrm_mockito_kotlin"
+    testImplementation "org.mockito.kotlin:mockito-kotlin:$mockito_kotlin"
     testImplementation "org.amshove.kluent:kluent-android:$kluent_android"
 
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_coroutines"

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
@@ -104,12 +104,19 @@ internal class MiniAppCustomPermissionCache(context: Context) {
         supplied: List<Pair<MiniAppCustomPermissionType, MiniAppCustomPermissionResult>>
     ): List<Pair<MiniAppCustomPermissionType, MiniAppCustomPermissionResult>> {
         // retrieve all permissions by comparing cached and supplied (from HostApp) permissions
-        val cached = readPermissions(miniAppId).pairValues
-        val combined = (cached + supplied).toMutableList()
-        combined.removeAll { (first) ->
-            first.type in supplied.groupBy { it.first.type }
+        val set = mutableSetOf<MiniAppCustomPermissionType>()
+        val returnList = mutableListOf<Pair<MiniAppCustomPermissionType, MiniAppCustomPermissionResult>>()
+
+        supplied.forEach {
+            set.add(it.first)
+            returnList.add(it)
         }
-        return combined + supplied
+        readPermissions(miniAppId).pairValues.forEach {
+            if (!set.contains(it.first))
+                returnList.add(it)
+        }
+
+        return returnList
     }
 
     /**

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
@@ -1,8 +1,6 @@
 package com.rakuten.tech.mobile.miniapp
 
 import com.google.gson.Gson
-import com.nhaarman.mockitokotlin2.*
-import com.nhaarman.mockitokotlin2.mock
 import com.rakuten.tech.mobile.miniapp.api.*
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
 import com.rakuten.tech.mobile.miniapp.storage.CachedMiniAppVerifier
@@ -19,6 +17,7 @@ import org.amshove.kluent.*
 import org.amshove.kluent.any
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.*
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppInfoFetcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppInfoFetcherSpec.kt
@@ -1,8 +1,8 @@
 package com.rakuten.tech.mobile.miniapp
 
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.times
-import com.nhaarman.mockitokotlin2.verify
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import com.rakuten.tech.mobile.miniapp.api.ApiClient
 import com.rakuten.tech.mobile.miniapp.api.UpdatableApiClient
 import kotlinx.coroutines.test.runBlockingTest

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSpec.kt
@@ -1,9 +1,9 @@
 package com.rakuten.tech.mobile.miniapp
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.times
-import com.nhaarman.mockitokotlin2.verify
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.junit.Test
 import org.junit.runner.RunWith
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializerSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializerSpec.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.nhaarman.mockitokotlin2.mock
+import org.mockito.kotlin.mock
 import org.amshove.kluent.shouldBe
 import org.junit.Before
 import org.junit.Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -1,6 +1,6 @@
 package com.rakuten.tech.mobile.miniapp
 
-import com.nhaarman.mockitokotlin2.*
+import org.mockito.kotlin.*
 import com.rakuten.tech.mobile.miniapp.api.*
 import com.rakuten.tech.mobile.miniapp.display.Displayer
 import com.rakuten.tech.mobile.miniapp.file.MiniAppFileChooser

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/ads/AdMobDisplayerSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/ads/AdMobDisplayerSpec.kt
@@ -7,8 +7,8 @@ import com.google.android.gms.ads.InterstitialAd
 import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.rewarded.RewardItem
 import com.google.android.gms.ads.rewarded.RewardedAd
-import com.nhaarman.mockitokotlin2.spy
-import com.nhaarman.mockitokotlin2.verify
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
 import com.rakuten.tech.mobile.miniapp.TEST_AD_UNIT_ID
 import com.rakuten.tech.mobile.miniapp.TestActivity
 import org.amshove.kluent.*

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientRepositorySpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientRepositorySpec.kt
@@ -1,6 +1,6 @@
 package com.rakuten.tech.mobile.miniapp.api
 
-import com.nhaarman.mockitokotlin2.mock
+import org.mockito.kotlin.mock
 import org.amshove.kluent.shouldBe
 import org.junit.Test
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
@@ -1,7 +1,7 @@
 package com.rakuten.tech.mobile.miniapp.api
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
 import com.rakuten.tech.mobile.miniapp.*
 import com.rakuten.tech.mobile.sdkutils.AppInfo
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiCacheSpec.kt
@@ -2,7 +2,7 @@ package com.rakuten.tech.mobile.miniapp.api
 
 import android.content.Context
 import android.content.SharedPreferences
-import com.nhaarman.mockitokotlin2.*
+import org.mockito.kotlin.*
 import com.rakuten.tech.mobile.miniapp.MiniAppManifest
 import com.rakuten.tech.mobile.miniapp.TEST_ATP_LIST
 import com.rakuten.tech.mobile.miniapp.TEST_MA_ID

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtilsSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtilsSpec.kt
@@ -1,6 +1,6 @@
 package com.rakuten.tech.mobile.miniapp.api
 
-import com.nhaarman.mockitokotlin2.mock
+import org.mockito.kotlin.mock
 import com.rakuten.tech.mobile.miniapp.TEST_VALUE
 import com.rakuten.tech.mobile.sdkutils.RasSdkHeaders
 import okhttp3.mockwebserver.MockWebServer

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
@@ -1,6 +1,6 @@
 package com.rakuten.tech.mobile.miniapp.api
 
-import com.nhaarman.mockitokotlin2.mock
+import org.mockito.kotlin.mock
 import com.rakuten.tech.mobile.miniapp.*
 import com.rakuten.tech.mobile.sdkutils.AppInfo
 import junit.framework.TestCase

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerSpec.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.lifecycle.LifecycleObserver
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.nhaarman.mockitokotlin2.mock
+import org.mockito.kotlin.mock
 import com.rakuten.tech.mobile.miniapp.*
 import com.rakuten.tech.mobile.miniapp.TEST_HA_NAME
 import com.rakuten.tech.mobile.miniapp.TEST_MA

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -13,9 +13,9 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.webkit.WebViewAssetLoader
-import com.nhaarman.mockitokotlin2.*
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
+import org.mockito.kotlin.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
 import com.rakuten.tech.mobile.miniapp.*
 import com.rakuten.tech.mobile.miniapp.file.MiniAppFileChooser
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplaySpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplaySpec.kt
@@ -6,9 +6,9 @@ import android.webkit.WebView
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.times
-import com.nhaarman.mockitokotlin2.verify
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import com.rakuten.tech.mobile.miniapp.*
 import com.rakuten.tech.mobile.miniapp.TEST_HA_ID_PROJECT
 import com.rakuten.tech.mobile.miniapp.TEST_HA_NAME

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooserDefaultSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooserDefaultSpec.kt
@@ -8,7 +8,7 @@ import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.nhaarman.mockitokotlin2.*
+import org.mockito.kotlin.*
 import com.rakuten.tech.mobile.miniapp.TestActivity
 import org.junit.Before
 import org.junit.Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
@@ -3,9 +3,9 @@ package com.rakuten.tech.mobile.miniapp.js
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.gson.Gson
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.times
-import com.nhaarman.mockitokotlin2.verify
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import com.rakuten.tech.mobile.miniapp.*
 import com.rakuten.tech.mobile.miniapp.TEST_AD_UNIT_ID
 import com.rakuten.tech.mobile.miniapp.TEST_CALLBACK_ID

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
@@ -2,8 +2,8 @@ package com.rakuten.tech.mobile.miniapp.js.userinfo
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.gson.Gson
-import com.nhaarman.mockitokotlin2.*
-import com.nhaarman.mockitokotlin2.mock
+import org.mockito.kotlin.*
+import org.mockito.kotlin.mock
 import com.rakuten.tech.mobile.miniapp.*
 import com.rakuten.tech.mobile.miniapp.TEST_CALLBACK_ID
 import com.rakuten.tech.mobile.miniapp.TEST_MA_DISPLAY_NAME

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcherSpec.kt
@@ -1,7 +1,7 @@
 package com.rakuten.tech.mobile.miniapp.permission
 
 import com.google.gson.Gson
-import com.nhaarman.mockitokotlin2.*
+import org.mockito.kotlin.*
 import com.rakuten.tech.mobile.miniapp.*
 import com.rakuten.tech.mobile.miniapp.TEST_ATP_LIST
 import com.rakuten.tech.mobile.miniapp.TEST_CALLBACK_ID

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
@@ -2,7 +2,7 @@ package com.rakuten.tech.mobile.miniapp.permission
 
 import android.content.Context
 import android.content.SharedPreferences
-import com.nhaarman.mockitokotlin2.*
+import org.mockito.kotlin.*
 import com.rakuten.tech.mobile.miniapp.TEST_MA_ID
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldEqual

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionAdapterSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionAdapterSpec.kt
@@ -2,7 +2,7 @@ package com.rakuten.tech.mobile.miniapp.permission.ui
 
 import android.widget.Switch
 import android.widget.TextView
-import com.nhaarman.mockitokotlin2.*
+import org.mockito.kotlin.*
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionResult
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
 import org.junit.Before

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionWindowSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionWindowSpec.kt
@@ -6,7 +6,7 @@ import android.content.SharedPreferences
 import androidx.appcompat.app.AlertDialog
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.nhaarman.mockitokotlin2.*
+import org.mockito.kotlin.*
 import com.rakuten.tech.mobile.miniapp.TEST_CALLBACK_ID
 import com.rakuten.tech.mobile.miniapp.TestActivity
 import com.rakuten.tech.mobile.miniapp.js.MiniAppBridgeExecutor

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCacheSpec.kt
@@ -2,7 +2,7 @@ package com.rakuten.tech.mobile.miniapp.storage
 
 import android.content.Context
 import android.content.SharedPreferences
-import com.nhaarman.mockitokotlin2.*
+import org.mockito.kotlin.*
 import com.rakuten.tech.mobile.miniapp.MiniAppManifest
 import com.rakuten.tech.mobile.miniapp.TEST_ATP_LIST
 import com.rakuten.tech.mobile.miniapp.TEST_MA_ID

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageSpec.kt
@@ -1,8 +1,8 @@
 package com.rakuten.tech.mobile.miniapp.storage
 
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.times
-import com.nhaarman.mockitokotlin2.verify
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import com.rakuten.tech.mobile.miniapp.*
 import com.rakuten.tech.mobile.miniapp.TEST_BASE_PATH
 import com.rakuten.tech.mobile.miniapp.TEST_ID_MINIAPP


### PR DESCRIPTION
# Description
- Reduce the complexity of prepare permissions in `MiniAppCustomPermissionCache`.
- Using official kotlin mockito `org.mockito.kotlin:mockito-kotlin` which is based on what we're using `com.nhaarman.mockitokotlin2`.

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
