### PR TITLE
network request retry on 500 response code

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -121,11 +121,7 @@ internal class RetrofitRequestExecutor(
             if (retryCount++ < TOTAL_RETRIES) {
                 retryCount++
                 Log.d(MINIAPP_NETWORK_RETRY, "Retrying in $retryCount out of $TOTAL_RETRIES times.")
-
-                // setting retrying policy about waiting time
-                val backOff = 2.0
-                val waitTime = 0.5 * backOff.pow(retryCount.toDouble())
-                delay(1000 * waitTime.toLong())
+                delay(getWaitingTime(retryCount))
                 // recall the request
                 executeRequest(call.clone(), retryCount)
             }
@@ -145,6 +141,14 @@ internal class RetrofitRequestExecutor(
             is MiniAppSdkException -> throw error
             else -> throw MiniAppSdkException(error) // when response is not Type T or malformed JSON is received
         }
+    }
+
+    @VisibleForTesting
+    internal fun getWaitingTime(retryCount: Int): Long {
+        // calculating waiting time to retry request when 500 response code
+        val backOff = 2.0
+        val waitTime = 1000 * 0.5 * backOff.pow(retryCount.toDouble())
+        return waitTime.toLong()
     }
 
     @Throws(MiniAppSdkException::class, MiniAppNotFoundException::class)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -1,6 +1,5 @@
 package com.rakuten.tech.mobile.miniapp.api
 
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.google.gson.annotations.SerializedName
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
@@ -109,22 +108,18 @@ internal class RetrofitRequestExecutor(
         retrofit.responseBodyConverter<T>(T::class.java, arrayOfNulls<Annotation>(0))
 
     @Suppress(
-        "TooGenericExceptionCaught", "ThrowsCount", "MagicNumber",
-        "LongMethod", "NestedBlockDepth", "ComplexMethod"
+        "TooGenericExceptionCaught", "ThrowsCount", "LongMethod", "MagicNumber", "FunctionParameterNaming"
     )
     suspend fun <T> executeRequest(call: Call<T>, _retryCount: Int = 0): T = try {
         val response = call.execute()
 
         // retry network request when there is 500 error code from the server
         var retryCount = _retryCount
-        if (response.code() >= 500) {
-            if (retryCount++ < TOTAL_RETRIES) {
-                retryCount++
-                Log.d(MINIAPP_NETWORK_RETRY, "Retrying in $retryCount out of $TOTAL_RETRIES times.")
-                delay(getWaitingTime(retryCount))
-                // recall the request
-                executeRequest(call.clone(), retryCount)
-            }
+        if (response.code() >= 500 && retryCount++ < TOTAL_RETRIES) {
+            retryCount++
+            delay(getWaitingTime(retryCount))
+            // recall the request
+            executeRequest(call.clone(), retryCount)
         }
 
         when {
@@ -144,6 +139,7 @@ internal class RetrofitRequestExecutor(
     }
 
     @VisibleForTesting
+    @Suppress("MagicNumber")
     internal fun getWaitingTime(retryCount: Int): Long {
         // calculating waiting time to retry request when 500 response code
         val backOff = 2.0
@@ -224,4 +220,3 @@ internal class MiniAppHttpException(
 }
 
 private const val TOTAL_RETRIES = 5
-private const val MINIAPP_NETWORK_RETRY = "MINIAPP_NETWORK_RETRY"

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -3,9 +3,18 @@ package com.rakuten.tech.mobile.miniapp.api
 import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.google.gson.annotations.SerializedName
-import com.rakuten.tech.mobile.miniapp.*
+import com.rakuten.tech.mobile.miniapp.MiniAppInfo
+import com.rakuten.tech.mobile.miniapp.MiniAppHasNoPublishedVersionException
+import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
+import com.rakuten.tech.mobile.miniapp.MiniAppNetException
+import com.rakuten.tech.mobile.miniapp.MiniAppNotFoundException
+import com.rakuten.tech.mobile.miniapp.sdkExceptionForInternalServerError
 import okhttp3.ResponseBody
-import retrofit2.*
+import retrofit2.Call
+import retrofit2.Converter
+import retrofit2.HttpException
+import retrofit2.Response
+import retrofit2.Retrofit
 import retrofit2.http.Url
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
@@ -116,7 +125,7 @@ internal class RetrofitRequestExecutor(
                 try {
                     Thread.sleep(waitTime.toLong())
                 } catch (interruptedException: InterruptedException) {
-                    Log.e(MINIAPP_NETWORK_RETRY, "intercept: ", interruptedException)
+                    Log.e(MINIAPP_NETWORK_RETRY, "", interruptedException)
                 }
                 // recall the request
                 executeRequest(call.clone())

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -9,6 +9,7 @@ import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.MiniAppNetException
 import com.rakuten.tech.mobile.miniapp.MiniAppNotFoundException
 import com.rakuten.tech.mobile.miniapp.sdkExceptionForInternalServerError
+import kotlinx.coroutines.delay
 import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.Converter
@@ -111,12 +112,8 @@ internal class RetrofitRequestExecutor(
         retrofit.responseBodyConverter<T>(T::class.java, arrayOfNulls<Annotation>(0))
 
     @Suppress(
-        "TooGenericExceptionCaught",
-        "ThrowsCount",
-        "MagicNumber",
-        "LongMethod",
-        "NestedBlockDepth",
-        "ComplexMethod"
+        "TooGenericExceptionCaught", "ThrowsCount", "MagicNumber",
+        "LongMethod", "NestedBlockDepth", "ComplexMethod"
     )
     suspend fun <T> executeRequest(call: Call<T>): T = try {
         val response = call.execute()
@@ -124,15 +121,15 @@ internal class RetrofitRequestExecutor(
         // retry network request when there is 500 error code from the server
         if (response.code() >= 500) {
             if (retryCount++ < TOTAL_RETRIES) {
-                Log.v(MINIAPP_NETWORK_RETRY, "Retrying in $retryCount out of $TOTAL_RETRIES times.")
+                Log.d(MINIAPP_NETWORK_RETRY, "Retrying in $retryCount out of $TOTAL_RETRIES times.")
 
                 // setting retrying policy about waiting time
                 val backOff = 2.0
                 val waitTime = 0.5 * backOff.pow(retryCount.toDouble())
                 try {
-                    Thread.sleep(waitTime.toLong())
+                    delay(waitTime.toLong())
                 } catch (interruptedException: InterruptedException) {
-                    Log.e(MINIAPP_NETWORK_RETRY, "", interruptedException)
+                    Log.d(MINIAPP_NETWORK_RETRY, "", interruptedException)
                 }
                 // recall the request
                 executeRequest(call.clone())

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -110,7 +110,14 @@ internal class RetrofitRequestExecutor(
     private inline fun <reified T : ErrorResponse> createErrorConverter(retrofit: Retrofit) =
         retrofit.responseBodyConverter<T>(T::class.java, arrayOfNulls<Annotation>(0))
 
-    @Suppress("TooGenericExceptionCaught", "ThrowsCount")
+    @Suppress(
+        "TooGenericExceptionCaught",
+        "ThrowsCount",
+        "MagicNumber",
+        "LongMethod",
+        "NestedBlockDepth",
+        "ComplexMethod"
+    )
     suspend fun <T> executeRequest(call: Call<T>): T = try {
         val response = call.execute()
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
@@ -70,8 +70,7 @@ open class RetrofitRequestExecutorNormalSpec : RetrofitRequestExecutorSpec() {
     fun `should return the body`() = runBlockingTest {
         mockServer.enqueue(createTestApiResponse(testValue = TEST_VALUE))
 
-        val response = createRequestExecutor()
-            .executeRequest(createApi().fetch())
+        val response = createRequestExecutor().executeRequest(createApi().fetch())
 
         response.testKey shouldEqual TEST_VALUE
     }
@@ -92,8 +91,7 @@ open class RetrofitRequestExecutorErrorSpec : RetrofitRequestExecutorSpec() {
     fun `should throw exception when the response returned by server is not of type T`() =
         runBlockingTest {
             mockServer.enqueue(createInvalidTestApiResponse())
-            createRequestExecutor()
-                .executeRequest(createApi().fetch())
+            createRequestExecutor().executeRequest(createApi().fetch())
         }
 
     @Test
@@ -101,8 +99,7 @@ open class RetrofitRequestExecutorErrorSpec : RetrofitRequestExecutorSpec() {
         mockServer.enqueue(createErrorResponse(message = TEST_ERROR_MSG))
 
         try {
-            createRequestExecutor()
-                .executeRequest(createApi().fetch())
+            createRequestExecutor().executeRequest(createApi().fetch())
 
             TestCase.fail("Should have thrown ErrorResponseException.")
         } catch (exception: MiniAppSdkException) {
@@ -115,8 +112,7 @@ open class RetrofitRequestExecutorErrorSpec : RetrofitRequestExecutorSpec() {
         mockServer.enqueue(createErrorResponse(message = TEST_ERROR_MSG))
 
         try {
-            createRequestExecutor()
-                .executeRequest(createApi().fetch())
+            createRequestExecutor().executeRequest(createApi().fetch())
 
             TestCase.fail("Should have thrown ErrorResponseException.")
         } catch (exception: MiniAppSdkException) {
@@ -127,15 +123,10 @@ open class RetrofitRequestExecutorErrorSpec : RetrofitRequestExecutorSpec() {
     @Test
     fun `should append default message when server doesn't return error message`() =
         runBlockingTest {
-            mockServer.enqueue(
-                MockResponse()
-                    .setResponseCode(400)
-                    .setBody("{}")
-            )
+            mockServer.enqueue(MockResponse().setResponseCode(400).setBody("{}"))
 
             try {
-                createRequestExecutor()
-                    .executeRequest(createApi().fetch())
+                createRequestExecutor().executeRequest(createApi().fetch())
 
                 TestCase.fail("Should have thrown ErrorResponseException.")
             } catch (exception: MiniAppSdkException) {
@@ -150,8 +141,10 @@ open class RetrofitRequestExecutorErrorSpec : RetrofitRequestExecutorSpec() {
 
             try {
                 createRequestExecutor().executeRequest(createApi().fetch())
+                advanceTimeBy(1000)
+                advanceTimeBy(2000)
             } catch (exception: MiniAppNetException) {
-                exception.message.toString() shouldContain "Found some problem"
+                exception.message.toString() shouldContain "Found some problem, timeout"
             }
         }
 
@@ -185,12 +178,9 @@ open class RetrofitRequestExecutorErrorSpec : RetrofitRequestExecutorSpec() {
 
     @Test(expected = MiniAppNotFoundException::class)
     fun `should throw MiniAppNotFoundException when the server returns 404`() = runBlockingTest {
-        mockServer.enqueue(
-            MockResponse().setResponseCode(404)
-        )
+        mockServer.enqueue(MockResponse().setResponseCode(404))
 
-        createRequestExecutor()
-            .executeRequest(createApi().fetch())
+        createRequestExecutor().executeRequest(createApi().fetch())
     }
 
     private val standardErrorBody = { code: Int, message: String ->

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
@@ -15,6 +15,8 @@ import org.amshove.kluent.shouldEqual
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -137,9 +139,8 @@ open class RetrofitRequestExecutorErrorSpec : RetrofitRequestExecutorSpec() {
     @Test
     fun `should append default message when server returns 500 response code`() =
         runBlockingTest {
-            mockServer.enqueue(MockResponse().setResponseCode(500).setBody("{}"))
-
             try {
+                mockServer.enqueue(MockResponse().setResponseCode(500))
                 createRequestExecutor().executeRequest(createApi().fetch())
                 advanceTimeBy(1000)
                 advanceTimeBy(2000)
@@ -147,6 +148,13 @@ open class RetrofitRequestExecutorErrorSpec : RetrofitRequestExecutorSpec() {
                 exception.message.toString() shouldContain "Found some problem, timeout"
             }
         }
+
+    @Test
+    fun `should return the correct value for waiting time`() {
+        val executor = spyRetrofitExecutor()
+        val actual = executor.getWaitingTime(4)
+        actual shouldEqual 8000
+    }
 
     @Test(expected = MiniAppSdkException::class)
     fun `should throw exception when there is authentication errors`() = runBlockingTest {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
@@ -15,6 +15,7 @@ import org.amshove.kluent.shouldEqual
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
+import org.mockito.kotlin.verify
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -80,6 +81,8 @@ open class RetrofitRequestExecutorNormalSpec : RetrofitRequestExecutorSpec() {
         val executor = Mockito.spy(mockRequestExecutor)
         val request: Call<String> = SuccessfulResponseCall()
         executor.executeRequest(request)
+
+        verify(executor).executeWithRetry(request)
     }
 }
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
@@ -143,6 +143,18 @@ open class RetrofitRequestExecutorErrorSpec : RetrofitRequestExecutorSpec() {
             }
         }
 
+    @Test
+    fun `should append default message when server returns 500 response code`() =
+        runBlockingTest {
+            mockServer.enqueue(MockResponse().setResponseCode(500).setBody("{}"))
+
+            try {
+                createRequestExecutor().executeRequest(createApi().fetch())
+            } catch (exception: MiniAppNetException) {
+                exception.message.toString() shouldContain "Found some problem"
+            }
+        }
+
     @Test(expected = MiniAppSdkException::class)
     fun `should throw exception when there is authentication errors`() = runBlockingTest {
         val executor = spyRetrofitExecutor()

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
@@ -15,8 +15,6 @@ import org.amshove.kluent.shouldEqual
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
-import org.mockito.kotlin.times
-import org.mockito.kotlin.verify
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response


### PR DESCRIPTION
# Description
Implement request retries in the SDK for the `500` response code. The SDK should retry 5 times, with a backoff multiplier of 2. For example:

Initial Request --> failed --> wait 0.5 seconds --> First retry --> failed --> wait 1 second --> Second retry --> failed --> wait 2 seconds --> etc...

## Links
- MINI-1639

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
