### PR TITLE
sample app: implement same icon style like miniapp list in other places

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/AppHelper.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/AppHelper.kt
@@ -3,7 +3,6 @@ package com.rakuten.tech.mobile.testapp.helper
 import android.app.Activity
 import android.app.AlertDialog
 import android.content.Context
-import android.net.Uri
 import android.text.InputType
 import android.util.Patterns
 import android.view.ViewGroup
@@ -12,12 +11,12 @@ import android.widget.FrameLayout
 import android.widget.ImageView
 import androidx.appcompat.widget.AppCompatEditText
 import com.bumptech.glide.Glide
-import com.bumptech.glide.request.RequestOptions
 import com.rakuten.tech.mobile.miniapp.js.userinfo.Contact
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import java.text.ParseException
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Date
+import java.util.Locale
 
 fun isInputEmpty(input: AppCompatEditText): Boolean {
     return input.text.toString().isEmpty() || input.text.toString().isBlank()
@@ -73,13 +72,6 @@ fun ImageView.load(context: Context, res: String) = Glide.with(context)
     .load(res)
     .placeholder(R.drawable.ic_default)
     .into(this)
-
-fun setIcon(context: Context, uri: Uri, view: ImageView) {
-    Glide.with(context)
-        .load(uri).apply(RequestOptions().circleCrop())
-        .placeholder(R.drawable.ic_default)
-        .into(view)
-}
 
 fun defaultContact(id: String) = Contact(
     id = id,

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
@@ -2,7 +2,6 @@ package com.rakuten.tech.mobile.testapp.ui.display.preload
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.net.Uri
 import android.view.LayoutInflater
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
@@ -17,7 +16,7 @@ import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.MiniAppManifest
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.WindowPreloadMiniappBinding
-import com.rakuten.tech.mobile.testapp.helper.setIcon
+import com.rakuten.tech.mobile.testapp.helper.load
 
 class PreloadMiniAppWindow(
     private val context: Context,
@@ -63,7 +62,7 @@ class PreloadMiniAppWindow(
 
         // set data to ui
         if (miniAppInfo != null) {
-            setIcon(context, Uri.parse(miniAppInfo?.icon), binding.preloadAppIcon)
+            miniAppInfo?.icon?.let { binding.preloadAppIcon.load(context, it) }
             binding.preloadMiniAppName.text = miniAppInfo?.displayName.toString()
             binding.preloadMiniAppVersion.text = LABEL_VERSION + miniAppInfo?.version?.versionTag.toString()
         } else {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListFragment.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapplist/MiniAppListFragment.kt
@@ -14,6 +14,7 @@ import androidx.appcompat.widget.SearchView
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.testapp.R
@@ -62,6 +63,9 @@ class MiniAppListFragment : BaseFragment(), MiniAppListener, OnSearchListener,
         )
         binding.fragment = this
         binding.rvMiniAppList.layoutManager = LinearLayoutManager(this.context)
+        binding.rvMiniAppList.addItemDecoration(
+            DividerItemDecoration(context, DividerItemDecoration.VERTICAL)
+        )
         miniAppListAdapter = MiniAppListAdapter(ArrayList(), this)
         binding.rvMiniAppList.adapter = miniAppListAdapter
         return binding.root

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/MiniAppDownloadedListAdapter.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/MiniAppDownloadedListAdapter.kt
@@ -1,6 +1,5 @@
 package com.rakuten.tech.mobile.testapp.ui.permission
 
-import android.net.Uri
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -9,7 +8,7 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.DownloadedItemListMiniappBinding
-import com.rakuten.tech.mobile.testapp.helper.setIcon
+import com.rakuten.tech.mobile.testapp.helper.load
 
 class MiniAppDownloadedListAdapter(private val miniAppListener: MiniAppDownloadedListener) :
     RecyclerView.Adapter<MiniAppDownloadedListAdapter.ViewHolder?>() {
@@ -24,7 +23,7 @@ class MiniAppDownloadedListAdapter(private val miniAppListener: MiniAppDownloade
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        setIcon(holder.miniAppRoot.context, Uri.parse(miniApps[position].icon), holder.miniAppIcon)
+        holder.miniAppIcon.load(holder.miniAppRoot.context, miniApps[position].icon)
         holder.miniAppName.text = miniApps[position].displayName
         holder.miniAppPermissions.text = miniAppPermissions[position]
         holder.miniAppRoot.setOnClickListener {

--- a/testapp/src/main/res/layout/downloaded_item_list_miniapp.xml
+++ b/testapp/src/main/res/layout/downloaded_item_list_miniapp.xml
@@ -1,26 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout>
 
-  <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/downloaded_miniapp_root"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="@dimen/small_8"
-    android:background="?selectableItemBackground"
-    android:orientation="horizontal">
+    android:background="?selectableItemBackground">
 
     <ImageView
       android:id="@+id/downloaded_miniapp_icon"
       android:layout_width="@dimen/miniapp_icon_size"
       android:layout_height="@dimen/miniapp_icon_size"
       android:layout_marginStart="@dimen/small_8"
+      android:layout_alignParentStart="true"
+      android:layout_centerInParent="true"
       tools:src="@drawable/ic_default" />
 
     <LinearLayout
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginStart="@dimen/small_8"
+      android:layout_centerInParent="true"
+      android:layout_toEndOf="@+id/downloaded_miniapp_icon"
       android:orientation="vertical">
 
       <TextView
@@ -35,9 +38,9 @@
         android:id="@+id/downloaded_miniapp_permissions"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/small_4"
+        android:layout_marginTop="@dimen/tiny_2dp"
         android:textSize="@dimen/text_medium_14"
-        tools:text="Permissions Status" />
+        tools:text="Approved Permissions" />
     </LinearLayout>
-  </LinearLayout>
+  </RelativeLayout>
 </layout>

--- a/testapp/src/main/res/layout/downloaded_item_list_miniapp.xml
+++ b/testapp/src/main/res/layout/downloaded_item_list_miniapp.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout>
 
-  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/downloaded_miniapp_root"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/small_8"
+    android:padding="@dimen/small_4"
     android:background="?selectableItemBackground">
 
     <ImageView
@@ -14,33 +15,53 @@
       android:layout_width="@dimen/miniapp_icon_size"
       android:layout_height="@dimen/miniapp_icon_size"
       android:layout_marginStart="@dimen/small_8"
-      android:layout_alignParentStart="true"
-      android:layout_centerInParent="true"
-      tools:src="@drawable/ic_default" />
+      android:src="@drawable/ic_default"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
 
-    <LinearLayout
-      android:layout_width="wrap_content"
+    <androidx.constraintlayout.widget.ConstraintLayout
+      android:id="@+id/text_root"
+      android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:layout_marginStart="@dimen/small_8"
-      android:layout_centerInParent="true"
-      android:layout_toEndOf="@+id/downloaded_miniapp_icon"
-      android:orientation="vertical">
+      android:layout_alignParentStart="true"
+      android:paddingBottom="@dimen/small_8"
+      android:paddingStart="@dimen/small_8"
+      android:paddingEnd="@dimen/small_8"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toEndOf="@+id/downloaded_miniapp_icon"
+      app:layout_constraintTop_toTopOf="parent">
 
       <TextView
         android:id="@+id/downloaded_miniapp_name"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/small_8"
+        android:ellipsize="end"
+        android:gravity="start"
+        android:singleLine="true"
         android:textColor="@android:color/black"
-        android:textSize="@dimen/text_large_16"
+        android:textSize="@dimen/text_medium_14"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         tools:text="MiniApp Name" />
 
       <TextView
         android:id="@+id/downloaded_miniapp_permissions"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/tiny_2dp"
+        android:alpha="0.6"
+        android:gravity="start"
+        android:textColor="@android:color/black"
         android:textSize="@dimen/text_medium_14"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/downloaded_miniapp_name"
         tools:text="Approved Permissions" />
-    </LinearLayout>
-  </RelativeLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+  </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/testapp/src/main/res/layout/item_list_miniapp.xml
+++ b/testapp/src/main/res/layout/item_list_miniapp.xml
@@ -15,10 +15,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?selectableItemBackground"
-        android:padding="@dimen/small_8"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="parent">
+        android:padding="@dimen/small_4">
 
         <ImageView
             android:id="@+id/iv_app_icon"
@@ -49,7 +46,6 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/small_8"
-                android:alpha="0.6"
                 android:gravity="start"
                 android:textColor="@android:color/black"
                 android:textSize="@dimen/text_medium_14"


### PR DESCRIPTION
# Description
- MiniApp list is showing full icon instead of cropping in a circle, this PR aims to adopt the same consistency in other places as well.
- The UX of item in both regular miniapp & downloaded miniapp list can be same.

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
