### PR TITLE
fix: Demo App display of meta data

### DIFF
--- a/testapp/src/main/res/drawable/bg_metadata.xml
+++ b/testapp/src/main/res/drawable/bg_metadata.xml
@@ -1,7 +1,0 @@
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-  android:shape="rectangle">
-  <solid android:color="@android:color/white" />
-  <stroke
-    android:color="@color/bg_section"
-    android:width="0.5dp" />
-</shape>

--- a/testapp/src/main/res/layout/window_preload_miniapp.xml
+++ b/testapp/src/main/res/layout/window_preload_miniapp.xml
@@ -60,6 +60,37 @@
         tools:text="Dummy MiniApp Version" />
     </LinearLayout>
 
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_above="@id/lnAction"
+        android:layout_below="@id/topView">
+      <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:background="@android:color/white"
+          android:gravity="center_horizontal"
+          android:orientation="vertical">
+
+      <androidx.recyclerview.widget.RecyclerView
+          android:id="@+id/listPreloadPermission"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          tools:listitem="@layout/item_list_custom_permission" />
+
+      <TextView
+          android:id="@+id/preloadMiniAppMetaData"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:paddingTop="@dimen/small_8"
+          android:paddingBottom="@dimen/small_8"
+          android:paddingStart="@dimen/medium_16"
+          android:paddingEnd="@dimen/medium_16"
+          android:background="@color/window_top_bar"
+          android:textColor="@android:color/black" />
+      </LinearLayout>
+    </ScrollView>
+
     <LinearLayout
       android:id="@+id/lnAction"
       android:layout_width="match_parent"
@@ -72,17 +103,6 @@
       android:background="@android:color/white"
       android:gravity="center_horizontal"
       android:orientation="vertical">
-
-      <TextView
-        android:id="@+id/preloadMiniAppMetaData"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:padding="@dimen/small_8"
-        android:background="@drawable/bg_metadata"
-        android:gravity="center"
-        android:text="@string/action_first_time_accept"
-        android:textColor="@android:color/black"
-        tools:text="Dummy MiniApp Metadata" />
 
       <TextView
         android:id="@+id/preloadAccept"
@@ -108,13 +128,5 @@
         android:textColor="@color/colorPrimary"
         android:textSize="@dimen/text_large_16" />
     </LinearLayout>
-
-    <androidx.recyclerview.widget.RecyclerView
-      android:id="@+id/listPreloadPermission"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_above="@id/lnAction"
-      android:layout_below="@id/topView"
-      tools:listitem="@layout/item_list_custom_permission" />
   </RelativeLayout>
 </layout>


### PR DESCRIPTION
# Description
Manifests with long meta data were causing the permissions to not be viewable. This change moves the meta data into scroll view beneath the permissions

<img src="https://user-images.githubusercontent.com/15662659/113555661-40883200-9636-11eb-8bed-f75b3a158c76.png" width="300" />    <img src="https://user-images.githubusercontent.com/15662659/113555664-4251f580-9636-11eb-9485-f2d52ba53dcc.png" width="300" />

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
