### PR TITLE
doc: localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ HOST_PROJECT_PROD_ID=test-host-project-id
 HOST_APP_PROD_SUBSCRIPTION_KEY=test-subs-key
 HOST_APP_PROD_UA_INFO=MiniAppDemoApp/1.0.0
 HOST_APP_PROD_VERSION=test-host-app-version
+PROD_ADMOB_APP_ID=test-admob-id
 ```
 
 Finally, you can build the release config for the Sample App.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ HOST_PROJECT_ID=test-host-project-id
 HOST_APP_SUBSCRIPTION_KEY=test-subs-key
 HOST_APP_UA_INFO=MiniAppDemoApp/1.0.0-SNAPSHOT
 HOST_APP_VERSION=test-host-app-version
+ADMOB_APP_ID=test-admob-id
 ```
 
 Finally, you can build the project via Gradle:

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -993,7 +993,8 @@ fun createMiniAppAsync(
 ```
 </detail>
 
-<details><summary markdown="span"><b>How to override text for localization purpose?</b></summary>
+<details><summary markdown="span"><b>How to override text for localization purpose?</b>
+</summary>
 
 The MiniApp SDK provides the default UI (i.e custom permission window) when your app does not have own UI implementation.
 
@@ -1006,7 +1007,6 @@ Example: We want to change `<string name="miniapp_custom_permission_save">Save</
 
 <string name="miniapp_custom_permission_save">セーブ</string>
 ```
-
 </detail>
 
 ## Changelog

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -991,7 +991,7 @@ fun createMiniAppAsync(
     }
 }
 ```
-</detail>
+</details>
 
 <details><summary markdown="span"><b>How to override text for localization purpose?</b>
 </summary>
@@ -1003,11 +1003,12 @@ Just need to place them in your app `strings.xml` with the same key. You can als
 
 Example: We want to change `<string name="miniapp_custom_permission_save">Save</string>` in another locale text.
 
-```src/main/res/values-ja/strings.xml
+```xml
+<!--src/main/res/values-ja/strings.xml-->
 
 <string name="miniapp_custom_permission_save">セーブ</string>
 ```
-</detail>
+</details>
 
 ## Changelog
 

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -993,6 +993,22 @@ fun createMiniAppAsync(
 ```
 </detail>
 
+<details><summary markdown="span"><b>How to override text for localization purpose?</b></summary>
+
+The MiniApp SDK provides the default UI (i.e custom permission window) when your app does not have own UI implementation.
+
+In case you want to use the default UI and only change text display, you can override the string values in [here](https://github.com/rakutentech/android-miniapp/blob/master/miniapp/src/main/res/values/strings.xml).
+Just need to place them in your app `strings.xml` with the same key. You can also put them in different localization resource directory.
+
+Example: We want to change `<string name="miniapp_custom_permission_save">Save</string>` in another locale text.
+
+```src/main/res/values-ja/strings.xml
+
+<string name="miniapp_custom_permission_save">セーブ</string>
+```
+
+</detail>
+
 ## Changelog
 
 See the full [CHANGELOG](https://github.com/rakutentech/android-miniapp/blob/master/CHANGELOG.md).

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -1001,12 +1001,12 @@ The MiniApp SDK provides the default UI (i.e custom permission window) when your
 In case you want to use the default UI and only change text display, you can override the string values in [here](https://github.com/rakutentech/android-miniapp/blob/master/miniapp/src/main/res/values/strings.xml).
 Just need to place them in your app `strings.xml` with the same key. You can also put them in different localization resource directory.
 
-Example: We want to change `<string name="miniapp_sdk_all_save">Save</string>` in another locale text.
+Example: We want to change `<string name="miniapp_sdk_android_save">Save</string>` in another locale text.
 
 ```xml
 <!--src/main/res/values-ja/strings.xml-->
 
-<string name="miniapp_sdk_all_save">セーブ</string>
+<string name="miniapp_sdk_android_save">セーブ</string>
 ```
 </details>
 

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -1001,12 +1001,12 @@ The MiniApp SDK provides the default UI (i.e custom permission window) when your
 In case you want to use the default UI and only change text display, you can override the string values in [here](https://github.com/rakutentech/android-miniapp/blob/master/miniapp/src/main/res/values/strings.xml).
 Just need to place them in your app `strings.xml` with the same key. You can also put them in different localization resource directory.
 
-Example: We want to change `<string name="miniapp_custom_permission_save">Save</string>` in another locale text.
+Example: We want to change `<string name="miniapp_sdk_all_save">Save</string>` in another locale text.
 
 ```xml
 <!--src/main/res/values-ja/strings.xml-->
 
-<string name="miniapp_custom_permission_save">セーブ</string>
+<string name="miniapp_sdk_all_save">セーブ</string>
 ```
 </details>
 

--- a/miniapp/src/main/res/layout/window_custom_permission.xml
+++ b/miniapp/src/main/res/layout/window_custom_permission.xml
@@ -21,7 +21,7 @@
       android:layout_height="wrap_content"
       android:layout_alignParentStart="true"
       android:padding="@dimen/small_8"
-      android:text="@string/miniapp_sdk_all_close"
+      android:text="@string/miniapp_sdk_android_close"
       android:textColor="@android:color/holo_red_dark" />
 
     <TextView
@@ -31,7 +31,7 @@
       android:layout_height="wrap_content"
       android:layout_alignParentEnd="true"
       android:padding="@dimen/small_8"
-      android:text="@string/miniapp_sdk_all_save"
+      android:text="@string/miniapp_sdk_android_save"
       android:textColor="@android:color/black" />
 
   </RelativeLayout>

--- a/miniapp/src/main/res/layout/window_custom_permission.xml
+++ b/miniapp/src/main/res/layout/window_custom_permission.xml
@@ -21,7 +21,7 @@
       android:layout_height="wrap_content"
       android:layout_alignParentStart="true"
       android:padding="@dimen/small_8"
-      android:text="@string/miniapp_custom_permission_close"
+      android:text="@string/miniapp_sdk_all_close"
       android:textColor="@android:color/holo_red_dark" />
 
     <TextView
@@ -31,7 +31,7 @@
       android:layout_height="wrap_content"
       android:layout_alignParentEnd="true"
       android:padding="@dimen/small_8"
-      android:text="@string/miniapp_custom_permission_save"
+      android:text="@string/miniapp_sdk_all_save"
       android:textColor="@android:color/black" />
 
   </RelativeLayout>
@@ -45,7 +45,7 @@
     android:paddingStart="@dimen/medium_16"
     android:paddingEnd="@dimen/medium_16"
     android:background="@color/colorCustomPermissionTop"
-    android:text="@string/miniapp_custom_permission_tutorial"
+    android:text="@string/miniapp_sdk_android_permission_tutorial"
     app:layout_constraintBottom_toTopOf="@id/listCustomPermission"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"

--- a/miniapp/src/main/res/values/strings.xml
+++ b/miniapp/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <!-- Custom permission resources -->
-    <string name="miniapp_custom_permission_save">Save</string>
-    <string name="miniapp_custom_permission_close">Close</string>
-    <string name="miniapp_custom_permission_tutorial">MiniApp wants to access the following permissions. Please choose your preference accordingly.</string>
+    <string name="miniapp_sdk_all_save">Save</string>
+    <string name="miniapp_sdk_all_close">Close</string>
+    <!-- Permission resources -->
+    <string name="miniapp_sdk_android_permission_tutorial">MiniApp wants to access the following permissions. Please choose your preference accordingly.</string>
 </resources>

--- a/miniapp/src/main/res/values/strings.xml
+++ b/miniapp/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="miniapp_sdk_all_save">Save</string>
-    <string name="miniapp_sdk_all_close">Close</string>
+    <string name="miniapp_sdk_android_save">Save</string>
+    <string name="miniapp_sdk_android_close">Close</string>
     <!-- Permission resources -->
     <string name="miniapp_sdk_android_permission_tutorial">MiniApp wants to access the following permissions. Please choose your preference accordingly.</string>
 </resources>


### PR DESCRIPTION
# Description
- Guidance on how to override miniapp sdk text for supporting different locale languages.
- Add `ADMOB_APP_ID` to project build tutorial.

## Links
MINI-2836

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
