### PR TITLE
Expose "version id" in MiniAppManifest

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -139,7 +139,7 @@ internal class MiniAppDownloader(
             if (cachedLatestManifest != null) cachedLatestManifest
             else {
                 val apiResponse = apiClient.fetchMiniAppManifest(appId, versionId)
-                val latestManifest = prepareMiniAppManifest(apiResponse)
+                val latestManifest = prepareMiniAppManifest(apiResponse, versionId)
                 manifestApiCache.storeManifest(appId, versionId, latestManifest)
                 latestManifest
             }
@@ -147,13 +147,13 @@ internal class MiniAppDownloader(
     }
 
     @VisibleForTesting
-    fun prepareMiniAppManifest(metadataEntity: MetadataEntity): MiniAppManifest {
+    fun prepareMiniAppManifest(metadataEntity: MetadataEntity, versionId: String): MiniAppManifest {
         val requiredPermissions = listOfPermissions(metadataEntity.metadata?.requiredPermissions ?: emptyList())
         val optionalPermissions = listOfPermissions(metadataEntity.metadata?.optionalPermissions ?: emptyList())
         val customMetadata = metadataEntity.metadata?.customMetaData ?: emptyMap()
         val accessTokenPermission = metadataEntity.metadata?.accessTokenPermissions ?: emptyList()
 
-        return MiniAppManifest(requiredPermissions, optionalPermissions, accessTokenPermission, customMetadata)
+        return MiniAppManifest(requiredPermissions, optionalPermissions, accessTokenPermission, customMetadata, versionId)
     }
 
     @VisibleForTesting

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -153,7 +153,8 @@ internal class MiniAppDownloader(
         val customMetadata = metadataEntity.metadata?.customMetaData ?: emptyMap()
         val accessTokenPermission = metadataEntity.metadata?.accessTokenPermissions ?: emptyList()
 
-        return MiniAppManifest(requiredPermissions, optionalPermissions, accessTokenPermission, customMetadata, versionId)
+        return MiniAppManifest(requiredPermissions, optionalPermissions,
+            accessTokenPermission, customMetadata, versionId)
     }
 
     @VisibleForTesting

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppManifest.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppManifest.kt
@@ -10,11 +10,13 @@ import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
  * @property optionalPermissions List of optional permissions requested by Mini App.
  * @property accessTokenPermissions List of audiences and scopes requested by Mini App.
  * @property customMetaData Custom metadata set by Mini App.
+ * @property versionId the version id for the Mini App.
  */
 @Keep
 data class MiniAppManifest(
     val requiredPermissions: List<Pair<MiniAppCustomPermissionType, String>>,
     val optionalPermissions: List<Pair<MiniAppCustomPermissionType, String>>,
     val accessTokenPermissions: List<AccessTokenScope>,
-    val customMetaData: Map<String, String>
+    val customMetaData: Map<String, String>,
+    val versionId: String
 )

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
@@ -36,6 +36,12 @@ class MiniAppDownloaderSpec {
         id = TEST_ID_MINIAPP,
         version = Version(versionTag = TEST_MA_VERSION_TAG, versionId = TEST_ID_MINIAPP_VERSION)
     )
+
+    private val dummyManifest = MiniAppManifest(
+        listOf(Pair(MiniAppCustomPermissionType.USER_NAME, "")),
+        listOf(Pair(MiniAppCustomPermissionType.PROFILE_PHOTO, "")),
+        TEST_ATP_LIST, emptyMap(), TEST_MA_VERSION_ID
+    )
     private val requiredPermissionObj =
         MetadataPermissionObj("rakuten.miniapp.user.USER_NAME", "reason")
     private val optionalPermissionObj =
@@ -296,23 +302,16 @@ class MiniAppDownloaderSpec {
                     listOf(requiredPermissionObj), listOf(optionalPermissionObj), TEST_ATP_LIST, hashMapOf()
                 )
             )
-            val apiManifest = MiniAppManifest(
-                listOf(Pair(MiniAppCustomPermissionType.USER_NAME, "")),
-                listOf(Pair(MiniAppCustomPermissionType.PROFILE_PHOTO, "")),
-                TEST_ATP_LIST,
-                emptyMap(),
-                TEST_MA_VERSION_ID
-            )
 
             When calling manifestApiCache.readManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID) itReturns null
-            When calling downloader.prepareMiniAppManifest(metadataEntity, TEST_MA_VERSION_ID) itReturns apiManifest
+            When calling downloader.prepareMiniAppManifest(metadataEntity, TEST_MA_VERSION_ID) itReturns dummyManifest
             When calling apiClient.fetchMiniAppManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID) itReturns metadataEntity
 
             val actual = downloader.fetchMiniAppManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID)
 
-            assertEquals(apiManifest, actual)
+            assertEquals(dummyManifest, actual)
             verify(manifestApiCache).readManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID)
-            verify(manifestApiCache).storeManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID, apiManifest)
+            verify(manifestApiCache).storeManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID, dummyManifest)
         }
 
     @Test
@@ -326,22 +325,15 @@ class MiniAppDownloaderSpec {
                     hashMapOf()
                 )
             )
-            val cachedManifest = MiniAppManifest(
-                listOf(Pair(MiniAppCustomPermissionType.USER_NAME, "")),
-                listOf(Pair(MiniAppCustomPermissionType.PROFILE_PHOTO, "")),
-                TEST_ATP_LIST,
-                emptyMap(),
-                TEST_MA_VERSION_ID
-            )
 
-            When calling manifestApiCache.readManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID) itReturns cachedManifest
+            When calling manifestApiCache.readManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID) itReturns dummyManifest
             val actual = downloader.fetchMiniAppManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID)
 
-            assertEquals(cachedManifest, actual)
+            assertEquals(dummyManifest, actual)
             verify(manifestApiCache).readManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID)
             verify(downloader, times(0)).prepareMiniAppManifest(metadataEntity, TEST_MA_VERSION_ID)
             verify(apiClient, times(0)).fetchMiniAppManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID)
-            verify(manifestApiCache, times(0)).storeManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID, cachedManifest)
+            verify(manifestApiCache, times(0)).storeManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID, dummyManifest)
         }
 
     @Test(expected = MiniAppSdkException::class)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
@@ -300,11 +300,12 @@ class MiniAppDownloaderSpec {
                 listOf(Pair(MiniAppCustomPermissionType.USER_NAME, "")),
                 listOf(Pair(MiniAppCustomPermissionType.PROFILE_PHOTO, "")),
                 TEST_ATP_LIST,
-                emptyMap()
+                emptyMap(),
+                TEST_MA_VERSION_ID
             )
 
             When calling manifestApiCache.readManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID) itReturns null
-            When calling downloader.prepareMiniAppManifest(metadataEntity) itReturns apiManifest
+            When calling downloader.prepareMiniAppManifest(metadataEntity, TEST_MA_VERSION_ID) itReturns apiManifest
             When calling apiClient.fetchMiniAppManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID) itReturns metadataEntity
 
             val actual = downloader.fetchMiniAppManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID)
@@ -329,7 +330,8 @@ class MiniAppDownloaderSpec {
                 listOf(Pair(MiniAppCustomPermissionType.USER_NAME, "")),
                 listOf(Pair(MiniAppCustomPermissionType.PROFILE_PHOTO, "")),
                 TEST_ATP_LIST,
-                emptyMap()
+                emptyMap(),
+                TEST_MA_VERSION_ID
             )
 
             When calling manifestApiCache.readManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID) itReturns cachedManifest
@@ -337,7 +339,7 @@ class MiniAppDownloaderSpec {
 
             assertEquals(cachedManifest, actual)
             verify(manifestApiCache).readManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID)
-            verify(downloader, times(0)).prepareMiniAppManifest(metadataEntity)
+            verify(downloader, times(0)).prepareMiniAppManifest(metadataEntity, TEST_MA_VERSION_ID)
             verify(apiClient, times(0)).fetchMiniAppManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID)
             verify(manifestApiCache, times(0)).storeManifest(TEST_ID_MINIAPP, TEST_MA_VERSION_ID, cachedManifest)
         }
@@ -387,12 +389,15 @@ class MiniAppDownloaderSpec {
             When calling downloader.listOfPermissions(listOf(requiredPermissionObj)) itReturns requiredPermission
             When calling downloader.listOfPermissions(listOf(optionalPermissionObj)) itReturns optionalPermission
 
-            val actual = downloader.prepareMiniAppManifest(metadataEntity)
+            val actual = downloader.prepareMiniAppManifest(metadataEntity, TEST_MA_VERSION_ID)
             val requiredPermissions =
                 listOf(Pair(MiniAppCustomPermissionType.USER_NAME, "reason for user name"))
             val optionalPermissions =
                 listOf(Pair(MiniAppCustomPermissionType.PROFILE_PHOTO, "reason for profile photo"))
-            val expected = MiniAppManifest(requiredPermissions, optionalPermissions, TEST_ATP_LIST, hashMapOf())
+            val expected = MiniAppManifest(
+                requiredPermissions, optionalPermissions,
+                TEST_ATP_LIST, hashMapOf(), TEST_MA_VERSION_ID
+            )
 
             assertEquals(expected, actual)
         }
@@ -408,8 +413,8 @@ class MiniAppDownloaderSpec {
                 TEST_ID_MINIAPP_VERSION
             ) itReturns metadataEntity
 
-            val actual = downloader.prepareMiniAppManifest(metadataEntity)
-            val expected = MiniAppManifest(emptyList(), emptyList(), emptyList(), emptyMap())
+            val actual = downloader.prepareMiniAppManifest(metadataEntity, "")
+            val expected = MiniAppManifest(emptyList(), emptyList(), emptyList(), emptyMap(), "")
 
             assertEquals(expected, actual)
         }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -36,7 +36,7 @@ open class BaseRealMiniAppSpec {
     val miniAppMessageBridge: MiniAppMessageBridge = mock()
     val miniAppNavigator: MiniAppNavigator = mock()
     val miniAppFileChooser: MiniAppFileChooser = mock()
-    val demoManifest: MiniAppManifest = MiniAppManifest(
+    val dummyManifest: MiniAppManifest = MiniAppManifest(
         listOf(Pair(MiniAppCustomPermissionType.USER_NAME, "reason")), listOf(),
         TEST_ATP_LIST, mapOf(), TEST_MA_VERSION_ID
     )
@@ -95,7 +95,7 @@ class RealMiniAppSpec : BaseRealMiniAppSpec() {
 
     private fun onGettingManifestWhileCreate() = runBlockingTest {
 
-        val cachedManifest = CachedManifest(TEST_MA_VERSION_ID, demoManifest)
+        val cachedManifest = CachedManifest(TEST_MA_VERSION_ID, dummyManifest)
         When calling downloadedManifestCache.readDownloadedManifest(TEST_MA_ID) itReturns cachedManifest
     }
 
@@ -246,7 +246,7 @@ class RealMiniAppSpec : BaseRealMiniAppSpec() {
 @Suppress("LongMethod")
 @ExperimentalCoroutinesApi
 class RealMiniAppManifestSpec : BaseRealMiniAppSpec() {
-    private val cachedManifest = CachedManifest(TEST_MA_VERSION_ID, demoManifest)
+    private val cachedManifest = CachedManifest(TEST_MA_VERSION_ID, dummyManifest)
     private val deniedPermission = MiniAppCustomPermission(
         TEST_MA_ID,
         listOf(Pair(MiniAppCustomPermissionType.USER_NAME, MiniAppCustomPermissionResult.DENIED))
@@ -297,8 +297,8 @@ class RealMiniAppManifestSpec : BaseRealMiniAppSpec() {
     fun `verifyManifest will store api manifest when version ids are different`() =
         runBlockingTest {
             val differentVersionId = "another_version_id"
-            val manifestToStore = CachedManifest(differentVersionId, demoManifest)
-            When calling realMiniApp.getMiniAppManifest(TEST_MA_ID, differentVersionId) itReturns demoManifest
+            val manifestToStore = CachedManifest(differentVersionId, dummyManifest)
+            When calling realMiniApp.getMiniAppManifest(TEST_MA_ID, differentVersionId) itReturns dummyManifest
             When calling miniAppCustomPermissionCache.readPermissions(TEST_MA_ID) itReturns deniedPermission
             When calling downloadedManifestCache.getAllPermissions(deniedPermission) itReturns
                     deniedPermission.pairValues

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -36,6 +36,10 @@ open class BaseRealMiniAppSpec {
     val miniAppMessageBridge: MiniAppMessageBridge = mock()
     val miniAppNavigator: MiniAppNavigator = mock()
     val miniAppFileChooser: MiniAppFileChooser = mock()
+    val demoManifest: MiniAppManifest = MiniAppManifest(
+        listOf(Pair(MiniAppCustomPermissionType.USER_NAME, "reason")), listOf(),
+        TEST_ATP_LIST, mapOf(), TEST_MA_VERSION_ID
+    )
 
     @Before
     fun setup() {
@@ -90,13 +94,7 @@ class RealMiniAppSpec : BaseRealMiniAppSpec() {
         }
 
     private fun onGettingManifestWhileCreate() = runBlockingTest {
-        val demoManifest =
-            MiniAppManifest(
-                listOf(Pair(MiniAppCustomPermissionType.USER_NAME, "reason")),
-                listOf(),
-                TEST_ATP_LIST,
-                mapOf()
-            )
+
         val cachedManifest = CachedManifest(TEST_MA_VERSION_ID, demoManifest)
         When calling downloadedManifestCache.readDownloadedManifest(TEST_MA_ID) itReturns cachedManifest
     }
@@ -248,9 +246,6 @@ class RealMiniAppSpec : BaseRealMiniAppSpec() {
 @Suppress("LongMethod")
 @ExperimentalCoroutinesApi
 class RealMiniAppManifestSpec : BaseRealMiniAppSpec() {
-    private val demoManifest = MiniAppManifest(
-        listOf(Pair(MiniAppCustomPermissionType.USER_NAME, "reason")), listOf(), TEST_ATP_LIST, mapOf()
-    )
     private val cachedManifest = CachedManifest(TEST_MA_VERSION_ID, demoManifest)
     private val deniedPermission = MiniAppCustomPermission(
         TEST_MA_ID,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiCacheSpec.kt
@@ -41,7 +41,8 @@ internal class ManifestApiCacheSpec {
     @Test
     fun `readManifest will return expected values`() {
         val cachedManifest = MiniAppManifest(
-            listOf(Pair(MiniAppCustomPermissionType.USER_NAME, "reason")), listOf(), TEST_ATP_LIST, mapOf()
+            listOf(Pair(MiniAppCustomPermissionType.USER_NAME, "reason")), listOf(),
+            TEST_ATP_LIST, mapOf(), TEST_MA_VERSION_ID
         )
         doReturn(cachedManifest).whenever(manifestCache)
             .readManifest(TEST_MA_ID, TEST_MA_VERSION_ID)
@@ -52,7 +53,8 @@ internal class ManifestApiCacheSpec {
     @Test
     fun `storeManifes will invoke putString while storing the latest manifest`() {
         val newManifest = MiniAppManifest(
-            listOf(Pair(MiniAppCustomPermissionType.USER_NAME, "reason")), listOf(), TEST_ATP_LIST, mapOf()
+            listOf(Pair(MiniAppCustomPermissionType.USER_NAME, "reason")), listOf(),
+            TEST_ATP_LIST, mapOf(), TEST_MA_VERSION_ID
         )
         Mockito.`when`(mockEditor.clear()).thenReturn(mockEditor)
         manifestCache.storeManifest(TEST_MA_ID, TEST_MA_VERSION_ID, newManifest)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/chat/ChatBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/chat/ChatBridgeDispatcherSpec.kt
@@ -267,6 +267,33 @@ class ChatBridgeDispatcherSpec : BaseChatBridgeDispatcherSpec() {
 
     /** end region */
 
+    /** region: postError when exception */
+    @Test
+    fun `postError should be called when for exception when sending message to single contact`() {
+        val dispatcher = Mockito.spy(createChatMessageBridgeDispatcher(false, true, false, false, false))
+        val chatBridge = Mockito.spy(createChatBridge(dispatcher, true))
+        chatBridge.onSendMessageToContact(singleChatCallbackObj.id, "")
+        verify(bridgeExecutor).postError(singleChatCallbackObj.id, "Cannot send message: null")
+    }
+
+    @Test
+    fun `postError should be called when for exception when sending message to specific contact id`() {
+        val dispatcher = Mockito.spy(createChatMessageBridgeDispatcher(false, false, true, false, false))
+        val chatBridge = Mockito.spy(createChatBridge(dispatcher, true))
+        chatBridge.onSendMessageToContactId(specificIdCallbackObj.id, "")
+        verify(bridgeExecutor).postError(specificIdCallbackObj.id, "Cannot send message: ")
+    }
+
+    @Test
+    fun `postError should be called when for exception when sending message to multiple contacts`() {
+        val dispatcher = Mockito.spy(createChatMessageBridgeDispatcher(false, false, false, false, true))
+        val chatBridge = Mockito.spy(createChatBridge(dispatcher, true))
+        chatBridge.onSendMessageToMultipleContacts(multipleChatCallbackObj.id, "")
+        verify(bridgeExecutor).postError(multipleChatCallbackObj.id, "Cannot send message: ")
+    }
+
+    /** end region */
+
     @Test
     fun `postValue should be called with null when hostapp wants to send a different specific contact id`() {
         val dispatcher = Mockito.spy(createChatMessageBridgeDispatcher(false, false, false, true, false))

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcherSpec.kt
@@ -172,7 +172,8 @@ class CustomPermissionBridgeDispatcherSpec {
         )
         val manifest = CachedManifest(
             TEST_MA_VERSION_ID,
-            MiniAppManifest(listOf(Pair(MiniAppCustomPermissionType.UNKNOWN, "")), emptyList(),
+            MiniAppManifest(
+                listOf(Pair(MiniAppCustomPermissionType.UNKNOWN, "")), emptyList(),
                 TEST_ATP_LIST, emptyMap(), TEST_MA_VERSION_ID
             )
         )

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/CustomPermissionBridgeDispatcherSpec.kt
@@ -51,8 +51,7 @@ class CustomPermissionBridgeDispatcherSpec {
         MiniAppManifest(
             listOf(Pair(MiniAppCustomPermissionType.USER_NAME, "")),
             listOf(Pair(MiniAppCustomPermissionType.LOCATION, "")),
-            TEST_ATP_LIST,
-            emptyMap()
+            TEST_ATP_LIST, emptyMap(), TEST_MA_VERSION_ID
         )
     )
 
@@ -173,8 +172,8 @@ class CustomPermissionBridgeDispatcherSpec {
         )
         val manifest = CachedManifest(
             TEST_MA_VERSION_ID,
-            MiniAppManifest(
-                listOf(Pair(MiniAppCustomPermissionType.UNKNOWN, "")), emptyList(), TEST_ATP_LIST, emptyMap()
+            MiniAppManifest(listOf(Pair(MiniAppCustomPermissionType.UNKNOWN, "")), emptyList(),
+                TEST_ATP_LIST, emptyMap(), TEST_MA_VERSION_ID
             )
         )
         When calling downloadedManifestCache.readDownloadedManifest(miniAppId) itReturns manifest

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCacheSpec.kt
@@ -27,10 +27,8 @@ class DownloadedManifestCacheSpec {
     private val mockContext: Context = mock()
     private val demoManifest =
         MiniAppManifest(
-            listOf(Pair(MiniAppCustomPermissionType.USER_NAME, "reason")),
-            listOf(),
-            TEST_ATP_LIST,
-            mapOf()
+            listOf(Pair(MiniAppCustomPermissionType.USER_NAME, "reason")), listOf(),
+            TEST_ATP_LIST, mapOf(), TEST_MA_VERSION_ID
         )
     private val cachedManifest = CachedManifest(TEST_MA_VERSION_ID, demoManifest)
 
@@ -137,10 +135,8 @@ class DownloadedManifestCacheSpec {
         )
         val demoOptionalManifest =
             MiniAppManifest(
-                listOf(),
-                listOf(Pair(MiniAppCustomPermissionType.PROFILE_PHOTO, "reason")),
-                TEST_ATP_LIST,
-                mapOf()
+                listOf(), listOf(Pair(MiniAppCustomPermissionType.PROFILE_PHOTO, "reason")),
+                TEST_ATP_LIST, mapOf(), TEST_MA_VERSION_ID
             )
         val cachedPermission = MiniAppCustomPermission(TEST_MA_ID, expected)
         val cachedManifest = CachedManifest(TEST_MA_VERSION_ID, demoOptionalManifest)


### PR DESCRIPTION
# Description
- Add a "version id" field in MiniAppManifest. This should be appended to the manifest data.
- Note: 1: Existing cached mini-app manifest will return `null` for versionId, `MiniAppManifest` which will be newly stored will return the versionId.
- Note: 2: I have tried to remove `CachedManifest` because `MiniAppManifest` is going to have the version id from now on, but it seems a breaking change for the host app which has been applied the previous implementation already. But, there is a chance to do that when addressing MINI-2945.

## Links
- MINI-2935

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
