### PR TITLE
Set `null` to file path callback 

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooser.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooser.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import android.util.Log
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
+import androidx.annotation.VisibleForTesting
 
 /**
  * The file chooser of a miniapp with `onShowFileChooser` function.
@@ -43,6 +44,7 @@ class MiniAppFileChooserDefault(var requestCode: Int) : MiniAppFileChooser {
         context: Context
     ): Boolean {
         try {
+            resetCallback()
             this.callback = filePathCallback
             val intent = fileChooserParams?.createIntent()
             if (fileChooserParams?.mode == WebChromeClient.FileChooserParams.MODE_OPEN_MULTIPLE) {
@@ -50,6 +52,7 @@ class MiniAppFileChooserDefault(var requestCode: Int) : MiniAppFileChooser {
             }
             (context as Activity).startActivityForResult(intent, requestCode)
         } catch (e: Exception) {
+            resetCallback()
             Log.e(MiniAppFileChooser::class.java.simpleName, e.message.toString())
             return false
         }
@@ -66,7 +69,7 @@ class MiniAppFileChooserDefault(var requestCode: Int) : MiniAppFileChooser {
         val clipData = intent.clipData
         when {
             data != null -> {
-                callback?.onReceiveValue((arrayOf(data)))
+                this.callback?.onReceiveValue((arrayOf(data)))
             }
             clipData != null -> {
                 val uriList = mutableListOf<Uri>()
@@ -74,20 +77,25 @@ class MiniAppFileChooserDefault(var requestCode: Int) : MiniAppFileChooser {
                     uriList.add(clipData.getItemAt(i).uri)
                 }
 
-                callback?.onReceiveValue((uriList.toTypedArray()))
+                this.callback?.onReceiveValue((uriList.toTypedArray()))
             }
             else -> {
-                callback?.onReceiveValue(null)
+                this.callback?.onReceiveValue(null)
             }
         }
-        callback = null
+        resetCallback()
     }
 
     /**
      * Can be used when HostApp wants to cancel the file choosing operation.
      */
     fun onCancel() {
-        callback?.onReceiveValue(null)
-        callback = null
+        this.callback?.onReceiveValue(null)
+        resetCallback()
+    }
+
+    @VisibleForTesting
+    fun resetCallback() {
+        this.callback = null
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooser.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooser.kt
@@ -44,7 +44,7 @@ class MiniAppFileChooserDefault(var requestCode: Int) : MiniAppFileChooser {
         context: Context
     ): Boolean {
         try {
-            this.callback = filePathCallback
+            callback = filePathCallback
             val intent = fileChooserParams?.createIntent()
             if (fileChooserParams?.mode == WebChromeClient.FileChooserParams.MODE_OPEN_MULTIPLE) {
                 intent?.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
@@ -68,7 +68,7 @@ class MiniAppFileChooserDefault(var requestCode: Int) : MiniAppFileChooser {
         val clipData = intent.clipData
         when {
             data != null -> {
-                this.callback?.onReceiveValue((arrayOf(data)))
+                callback?.onReceiveValue((arrayOf(data)))
             }
             clipData != null -> {
                 val uriList = mutableListOf<Uri>()
@@ -76,10 +76,10 @@ class MiniAppFileChooserDefault(var requestCode: Int) : MiniAppFileChooser {
                     uriList.add(clipData.getItemAt(i).uri)
                 }
 
-                this.callback?.onReceiveValue((uriList.toTypedArray()))
+                callback?.onReceiveValue((uriList.toTypedArray()))
             }
             else -> {
-                this.callback?.onReceiveValue(null)
+                callback?.onReceiveValue(null)
             }
         }
         resetCallback()
@@ -89,12 +89,12 @@ class MiniAppFileChooserDefault(var requestCode: Int) : MiniAppFileChooser {
      * Can be used when HostApp wants to cancel the file choosing operation.
      */
     fun onCancel() {
-        this.callback?.onReceiveValue(null)
+        callback?.onReceiveValue(null)
         resetCallback()
     }
 
     @VisibleForTesting
     internal fun resetCallback() {
-        this.callback = null
+        callback = null
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooser.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooser.kt
@@ -80,6 +80,7 @@ class MiniAppFileChooserDefault(var requestCode: Int) : MiniAppFileChooser {
                 callback?.onReceiveValue(null)
             }
         }
+        callback = null
     }
 
     /**
@@ -87,5 +88,6 @@ class MiniAppFileChooserDefault(var requestCode: Int) : MiniAppFileChooser {
      */
     fun onCancel() {
         callback?.onReceiveValue(null)
+        callback = null
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooser.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooser.kt
@@ -44,7 +44,6 @@ class MiniAppFileChooserDefault(var requestCode: Int) : MiniAppFileChooser {
         context: Context
     ): Boolean {
         try {
-            resetCallback()
             this.callback = filePathCallback
             val intent = fileChooserParams?.createIntent()
             if (fileChooserParams?.mode == WebChromeClient.FileChooserParams.MODE_OPEN_MULTIPLE) {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooser.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooser.kt
@@ -37,7 +37,7 @@ class MiniAppFileChooserDefault(var requestCode: Int) : MiniAppFileChooser {
 
     internal var callback: ValueCallback<Array<Uri>>? = null
 
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    @Suppress("TooGenericExceptionCaught", "SwallowedException", "LongMethod")
     override fun onShowFileChooser(
         filePathCallback: ValueCallback<Array<Uri>>?,
         fileChooserParams: WebChromeClient.FileChooserParams?,
@@ -95,7 +95,7 @@ class MiniAppFileChooserDefault(var requestCode: Int) : MiniAppFileChooser {
     }
 
     @VisibleForTesting
-    fun resetCallback() {
+    internal fun resetCallback() {
         this.callback = null
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooserDefaultSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooserDefaultSpec.kt
@@ -78,7 +78,7 @@ class MiniAppFileChooserDefaultSpec {
         When calling intent.data itReturns uri
         miniAppFileChooser.onShowFileChooser(callback, fileChooserParams, context)
         miniAppFileChooser.onReceivedFiles(intent)
-        verify(miniAppFileChooser, times(2)).resetCallback()
+        verify(miniAppFileChooser).resetCallback()
         verify(callback)?.onReceiveValue(arrayOf(uri))
     }
 
@@ -90,7 +90,7 @@ class MiniAppFileChooserDefaultSpec {
         When calling intent.clipData itReturns clipData
         miniAppFileChooser.onShowFileChooser(callback, fileChooserParams, context)
         miniAppFileChooser.onReceivedFiles(intent)
-        verify(miniAppFileChooser, times(2)).resetCallback()
+        verify(miniAppFileChooser).resetCallback()
         verify(callback)?.onReceiveValue(uriList.toTypedArray())
     }
 
@@ -99,14 +99,13 @@ class MiniAppFileChooserDefaultSpec {
         val intent: Intent = mock()
         miniAppFileChooser.onShowFileChooser(callback, fileChooserParams, context)
         miniAppFileChooser.onReceivedFiles(intent)
-        verify(miniAppFileChooser, times(2)).resetCallback()
+        verify(miniAppFileChooser).resetCallback()
         verify(callback)?.onReceiveValue(null)
     }
 
     @Test
     fun `onReceivedFiles should not invoke onReceiveValue of file path callback is null`() {
         miniAppFileChooser.onShowFileChooser(null, fileChooserParams, context)
-        verify(miniAppFileChooser).resetCallback()
         verify(callback, times(0))?.onReceiveValue(arrayOf())
     }
 
@@ -115,6 +114,6 @@ class MiniAppFileChooserDefaultSpec {
         miniAppFileChooser.onShowFileChooser(callback, fileChooserParams, context)
         miniAppFileChooser.onCancel()
         verify(callback)?.onReceiveValue(null)
-        verify(miniAppFileChooser, times(2)).resetCallback()
+        verify(miniAppFileChooser).resetCallback()
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooserDefaultSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooserDefaultSpec.kt
@@ -35,7 +35,7 @@ class MiniAppFileChooserDefaultSpec {
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
             context = spy(activity)
             whenever(fileChooserParams?.createIntent()).thenReturn(intent)
-            miniAppFileChooser = MiniAppFileChooserDefault(requestCode)
+            miniAppFileChooser = spy(MiniAppFileChooserDefault(requestCode))
         }
     }
 
@@ -78,6 +78,7 @@ class MiniAppFileChooserDefaultSpec {
         When calling intent.data itReturns uri
         miniAppFileChooser.onShowFileChooser(callback, fileChooserParams, context)
         miniAppFileChooser.onReceivedFiles(intent)
+        verify(miniAppFileChooser, times(2)).resetCallback()
         verify(callback)?.onReceiveValue(arrayOf(uri))
     }
 
@@ -89,6 +90,7 @@ class MiniAppFileChooserDefaultSpec {
         When calling intent.clipData itReturns clipData
         miniAppFileChooser.onShowFileChooser(callback, fileChooserParams, context)
         miniAppFileChooser.onReceivedFiles(intent)
+        verify(miniAppFileChooser, times(2)).resetCallback()
         verify(callback)?.onReceiveValue(uriList.toTypedArray())
     }
 
@@ -97,12 +99,14 @@ class MiniAppFileChooserDefaultSpec {
         val intent: Intent = mock()
         miniAppFileChooser.onShowFileChooser(callback, fileChooserParams, context)
         miniAppFileChooser.onReceivedFiles(intent)
+        verify(miniAppFileChooser, times(2)).resetCallback()
         verify(callback)?.onReceiveValue(null)
     }
 
     @Test
     fun `onReceivedFiles should not invoke onReceiveValue of file path callback is null`() {
         miniAppFileChooser.onShowFileChooser(null, fileChooserParams, context)
+        verify(miniAppFileChooser).resetCallback()
         verify(callback, times(0))?.onReceiveValue(arrayOf())
     }
 
@@ -111,5 +115,6 @@ class MiniAppFileChooserDefaultSpec {
         miniAppFileChooser.onShowFileChooser(callback, fileChooserParams, context)
         miniAppFileChooser.onCancel()
         verify(callback)?.onReceiveValue(null)
+        verify(miniAppFileChooser, times(2)).resetCallback()
     }
 }


### PR DESCRIPTION
# Description
File path callback should be `null` after being used once. This PR aims to add this fix.

## Links
- MINI-3179

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
