### PR TITLE
Add custom permission to send messages to contact id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Deprecated:** Old `getUniqueId`interface.
 - **Feature:** Added `getUniqueId` new interface for invoking data using `onSuccess` and `onError`.
 - **Feature:** Support `mailto` uri address. See [this](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a).
+- **Feature:** Added `rakuten.miniapp.user.SEND_MESSAGE` custom permission and applied to `ChatBridgeDispatcher.sendMessageToContactId`.
 
 **Sample App**
 - **Change:** Replaced the implementation of `getUniqueId` using new interface.
@@ -14,7 +15,7 @@
 - **Feature:** Added several chatting interfaces e.g. `sendMessageToContact`, `sendMessageToContactId` and `sendMessageToMultipleContacts` in `ChatBridgeDispatcher` for sending message to single or multiple contacts, even to a specific contact id. HostApp can get the message using `MessageToContact` object.
 
 **Sample App**
-- **Feature:** Added implementations of `ChatMessageBridgeDispatcher.sendMessageToContact`, `ChatMessageBridgeDispatcher.sendMessageToContactId` and `ChatMessageBridgeDispatcher.sendMessageToMultipleContacts` with the demo UI.
+- **Feature:** Added implementations of `ChatBridgeDispatcher.sendMessageToContact`, `ChatBridgeDispatcher.sendMessageToContactId` and `ChatBridgeDispatcher.sendMessageToMultipleContacts` with the demo UI.
 
 ### 3.1.0 (2021-04-02)
 **SDK**

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -583,7 +583,8 @@ In Host App, we can get the downloaded manifest information as following:
 **API Docs:** [ChatBridgeDispatcher](api/com.rakuten.tech.mobile.miniapp.js.chat/-chat-bridge-dispatcher/)
 
 Send a message to a single contact, multiple contacts or to a specific contact id by using the following three methods can be triggered by the Mini App, and here are the recommended behaviors for each one:
-| |[ChatBridgeDispatcher.sendMessageToContact](api/com.rakuten.tech.mobile.miniapp.js.chat/-chat-bridge-dispatcher/send-message-to-contact.html)|[ChatBridgeDispatcher.sendMessageToContactId](api/com.rakuten.tech.mobile.miniapp.js.chat/-chat-bridge-dispatcher/send-message-to-contact-id.html)|[ChatBridgeDispatcher.sendMessageToMultipleContacts](api/com.rakuten.tech.mobile.miniapp.js.chat/-chat-bridge-dispatcher/send-message-to-multiple-contacts.html)|
+
+| |`ChatBridgeDispatcher.sendMessageToContact`|`ChatBridgeDispatcher.sendMessageToContactId`|`ChatBridgeDispatcher.sendMessageToMultipleContacts`|
 |---|---|---|---|
 |**Triggered when**|Mini App wants to send a message to a contact.|Triggered when Mini App wants to send a message to a specific contact.|Triggered when Mini App wants to send a message to multiple contacts. |
 | **Contact chooser needed** | single contact | None | multiple contacts |

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -56,7 +56,7 @@ open class MiniAppMessageBridge {
         this.screenBridgeDispatcher = ScreenBridgeDispatcher(activity, bridgeExecutor, allowScreenOrientation)
         adBridgeDispatcher.setBridgeExecutor(bridgeExecutor)
         userInfoBridge.setMiniAppComponents(bridgeExecutor, customPermissionCache, downloadedManifestCache, miniAppId)
-        chatBridge.setMiniAppComponents(bridgeExecutor, miniAppId)
+        chatBridge.setMiniAppComponents(bridgeExecutor, customPermissionCache, miniAppId)
 
         miniAppViewInitialized = true
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppPermission.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppPermission.kt
@@ -20,6 +20,7 @@ enum class MiniAppCustomPermissionType(val type: String) {
     PROFILE_PHOTO("rakuten.miniapp.user.PROFILE_PHOTO"),
     CONTACT_LIST("rakuten.miniapp.user.CONTACT_LIST"),
     ACCESS_TOKEN("rakuten.miniapp.user.ACCESS_TOKEN"),
+    SEND_MESSAGE("rakuten.miniapp.user.SEND_MESSAGE"),
     LOCATION("rakuten.miniapp.device.LOCATION"),
     UNKNOWN("UNKNOWN");
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/chat/ChatBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/chat/ChatBridgeDispatcherSpec.kt
@@ -9,8 +9,10 @@ import com.rakuten.tech.mobile.miniapp.TEST_ERROR_MSG
 import com.rakuten.tech.mobile.miniapp.TEST_MA
 import com.rakuten.tech.mobile.miniapp.display.WebViewListener
 import com.rakuten.tech.mobile.miniapp.js.*
+import com.rakuten.tech.mobile.miniapp.js.chat.ChatBridge.Companion.ERR_NO_PERMISSION_CONTACT_ID
 import com.rakuten.tech.mobile.miniapp.js.chat.ChatBridge.Companion.ERR_SEND_MESSAGE
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
 import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
 import org.amshove.kluent.When
 import org.amshove.kluent.calling
@@ -20,7 +22,7 @@ import org.junit.Test
 import org.mockito.Mockito
 
 open class BaseChatBridgeDispatcherSpec {
-    internal lateinit var miniAppBridge: MiniAppMessageBridge
+    private lateinit var miniAppBridge: MiniAppMessageBridge
     internal val singleChatCallbackObj = CallbackObj(
         action = ActionType.SEND_MESSAGE_TO_CONTACT.action,
         param = null,
@@ -37,8 +39,8 @@ open class BaseChatBridgeDispatcherSpec {
         id = TEST_CALLBACK_ID
     )
     internal val customPermissionCache: MiniAppCustomPermissionCache = mock()
-    internal val downloadedManifestCache: DownloadedManifestCache = mock()
-    internal val webViewListener: WebViewListener = mock()
+    private val downloadedManifestCache: DownloadedManifestCache = mock()
+    private val webViewListener: WebViewListener = mock()
     internal val bridgeExecutor = Mockito.spy(MiniAppBridgeExecutor(webViewListener))
 
     @Before
@@ -101,21 +103,21 @@ open class BaseChatBridgeDispatcherSpec {
         }
     }
 
-    protected val messageToContact = MessageToContact("", "", "", "")
+    private val messageToContact = MessageToContact("", "", "", "")
 
     internal fun createChatBridge(
         chatBridgeDispatcher: ChatBridgeDispatcher,
         isImplement: Boolean
     ): ChatBridge {
         val chatBridge = ChatBridge()
-        chatBridge.setMiniAppComponents(bridgeExecutor, TEST_MA.id)
+        chatBridge.setMiniAppComponents(bridgeExecutor, customPermissionCache, TEST_MA.id)
         if (isImplement)
             chatBridge.setChatBridgeDispatcher(chatBridgeDispatcher)
 
         return chatBridge
     }
 
-    protected fun createMessageBridge(): MiniAppMessageBridge =
+    private fun createMessageBridge(): MiniAppMessageBridge =
         object : MiniAppMessageBridge() {
             override fun getUniqueId() = TEST_CALLBACK_VALUE
         }
@@ -253,6 +255,7 @@ class ChatBridgeDispatcherSpec : BaseChatBridgeDispatcherSpec() {
     fun `postValue should be called when hostapp wants to cancel sending message to specific contact id`() {
         val dispatcher = Mockito.spy(createChatMessageBridgeDispatcher(false, false, true, false, false))
         val chatBridge = Mockito.spy(createChatBridge(dispatcher, true))
+        setSendMessagePermission(true)
         chatBridge.onSendMessageToContactId(specificIdCallbackObj.id, specificMessageJsonStr)
         verify(bridgeExecutor).postValue(specificIdCallbackObj.id, "null")
     }
@@ -271,7 +274,22 @@ class ChatBridgeDispatcherSpec : BaseChatBridgeDispatcherSpec() {
     fun `postValue should be called with null when hostapp wants to send a different specific contact id`() {
         val dispatcher = Mockito.spy(createChatMessageBridgeDispatcher(false, false, false, true, false))
         val chatBridge = Mockito.spy(createChatBridge(dispatcher, true))
+        setSendMessagePermission(true)
         chatBridge.onSendMessageToContactId(specificIdCallbackObj.id, specificMessageJsonStr)
         verify(bridgeExecutor).postValue(specificIdCallbackObj.id, "null")
     }
+
+    @Test
+    fun `postError should be called when send message permission hasn't been allowed for specific contact id`() {
+        val dispatcher = Mockito.spy(createChatMessageBridgeDispatcher(false, false, false, true, false))
+        val chatBridge = Mockito.spy(createChatBridge(dispatcher, true))
+        val errMsg = "$ERR_SEND_MESSAGE $ERR_NO_PERMISSION_CONTACT_ID"
+        setSendMessagePermission(false)
+        chatBridge.onSendMessageToContactId(specificIdCallbackObj.id, specificMessageJsonStr)
+        verify(bridgeExecutor).postError(specificIdCallbackObj.id, errMsg)
+    }
+
+    private fun setSendMessagePermission(isAllowed: Boolean) = whenever(
+        customPermissionCache.hasPermission(TEST_MA.id, MiniAppCustomPermissionType.SEND_MESSAGE)
+    ).thenReturn(isAllowed)
 }


### PR DESCRIPTION
# Description
Sending messages to a specific Contact ID via the JS SDK requires that a permission should be allowed. This PR aims to add this spec.

## Links
- MINI-3184

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
