### PR TITLE
encrypt the stored MiniApp custom permissions

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
@@ -2,7 +2,6 @@ package com.rakuten.tech.mobile.miniapp.permission
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
@@ -33,13 +32,9 @@ internal class MiniAppCustomPermissionCache constructor(
     }
 
     private fun migrateToEncryptedPref() {
-        Log.d("AAAAA non1",""+nonEncryptedPreferences.all)
-        Log.d("AAAAA pref1",""+prefs.all)
         if (nonEncryptedPreferences.all.isNotEmpty()) {
             nonEncryptedPreferences.copyTo(prefs)
-            Log.d("AAAAA pref2",""+prefs.all)
             nonEncryptedPreferences.edit().clear().apply()
-            Log.d("AAAAA non2",""+nonEncryptedPreferences.all)
         }
     }
 
@@ -172,6 +167,7 @@ internal class MiniAppCustomPermissionCache constructor(
     }
 }
 
+@Suppress("TooGenericExceptionCaught", "SwallowedException")
 internal fun initEncryptedSharedPreference(context: Context) = try {
     EncryptedSharedPreferences.create(
         "com.rakuten.tech.mobile.miniapp.custom.permissions.cache.hash",

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
@@ -39,11 +39,11 @@ internal class MiniAppCustomPermissionCache constructor(
     }
 
     private fun SharedPreferences.copyTo(dest: SharedPreferences) = with(dest.edit()) {
-        for ((key, value1) in all) {
-            val value = value1 ?: continue
-            when (value) {
-                is String -> putString(key, value)
-                else -> error("Unknown type: $value")
+        for ((key, value) in all) {
+            val v = value ?: continue
+            when (v) {
+                is String -> putString(key, v)
+                else -> error("Unknown type: $v")
             }
         }
         apply()

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
@@ -41,10 +41,7 @@ internal class MiniAppCustomPermissionCache constructor(
     private fun SharedPreferences.copyTo(dest: SharedPreferences) = with(dest.edit()) {
         for ((key, value) in all) {
             val v = value ?: continue
-            when (v) {
-                is String -> putString(key, v)
-                else -> error("Unknown type: $v")
-            }
+            if (v is String) putString(key, v)
         }
         apply()
     }
@@ -170,7 +167,7 @@ internal class MiniAppCustomPermissionCache constructor(
 @Suppress("TooGenericExceptionCaught", "SwallowedException")
 internal fun initEncryptedSharedPreference(context: Context) = try {
     EncryptedSharedPreferences.create(
-        "com.rakuten.tech.mobile.miniapp.custom.permissions.cache.hash",
+        "com.rakuten.tech.mobile.miniapp.custom.permissions.cache.encrypted",
         MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
         context,
         EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
@@ -21,7 +21,6 @@ class MiniAppCustomPermissionCacheSpec {
     private lateinit var miniAppCustomPermissionCache: MiniAppCustomPermissionCache
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val prefs = context.getSharedPreferences("test-cache", Context.MODE_PRIVATE)
-    private val editor: SharedPreferences.Editor = prefs.edit()
     private val deniedPermissions =
         listOf(
             Pair(MiniAppCustomPermissionType.USER_NAME, MiniAppCustomPermissionResult.DENIED)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
@@ -2,22 +2,26 @@ package com.rakuten.tech.mobile.miniapp.permission
 
 import android.content.Context
 import android.content.SharedPreferences
-import org.mockito.kotlin.*
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.rakuten.tech.mobile.miniapp.MiniAppVerificationException
 import com.rakuten.tech.mobile.miniapp.TEST_MA_ID
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldEqual
 import org.junit.Before
 import org.junit.Test
-import org.mockito.ArgumentMatchers.anyInt
-import org.mockito.ArgumentMatchers.anyString
-import org.mockito.Mockito.`when`
+import org.junit.runner.RunWith
+import org.mockito.kotlin.*
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @Suppress("LongMethod", "LargeClass")
+@RunWith(AndroidJUnit4::class)
 class MiniAppCustomPermissionCacheSpec {
     private lateinit var miniAppCustomPermissionCache: MiniAppCustomPermissionCache
-    private val mockSharedPrefs: SharedPreferences = mock()
-    private val mockEditor: SharedPreferences.Editor = mock()
-    private val mockContext: Context = mock()
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val prefs = context.getSharedPreferences("test-cache", Context.MODE_PRIVATE)
+    private val editor: SharedPreferences.Editor = prefs.edit()
     private val deniedPermissions =
         listOf(
             Pair(MiniAppCustomPermissionType.USER_NAME, MiniAppCustomPermissionResult.DENIED)
@@ -26,13 +30,12 @@ class MiniAppCustomPermissionCacheSpec {
 
     @Before
     fun setUp() {
-        `when`(mockSharedPrefs.edit()).thenReturn(mockEditor)
-        `when`(mockContext.getSharedPreferences(anyString(), anyInt()))
-            .thenReturn(mockSharedPrefs)
-        `when`(mockEditor.putString(anyString(), anyString())).thenReturn(mockEditor)
-        `when`(mockEditor.remove(anyString())).thenReturn(mockEditor)
+        miniAppCustomPermissionCache = spy(MiniAppCustomPermissionCache(prefs, prefs))
+    }
 
-        miniAppCustomPermissionCache = spy(MiniAppCustomPermissionCache(mockContext))
+    @Test(expected = MiniAppVerificationException::class)
+    fun `initiating encrypted preferences with invalid context will throw error`() {
+        MiniAppCustomPermissionCache(context)
     }
 
     /**
@@ -57,7 +60,7 @@ class MiniAppCustomPermissionCacheSpec {
     @Test
     fun `removeId will remove all permission data from the store`() {
         miniAppCustomPermissionCache.removePermission(TEST_MA_ID)
-        verify(mockEditor, times(1)).remove(TEST_MA_ID)
+        assertFalse(prefs.all.contains(TEST_MA_ID))
     }
 
     @Test
@@ -69,10 +72,9 @@ class MiniAppCustomPermissionCacheSpec {
     }
 
     @Test
-    fun `applyStoringPermissions will invoke putString while storing custom permissions`() {
+    fun `applyStoringPermissions will invoke sortedByDefault to save value`() {
         miniAppCustomPermissionCache.applyStoringPermissions(miniAppCustomPermission)
-
-        verify(mockEditor).putString(anyString(), anyString())
+        assertTrue(prefs.all.contains(miniAppCustomPermission.miniAppId))
         verify(miniAppCustomPermissionCache).sortedByDefault(miniAppCustomPermission)
     }
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionWindowSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionWindowSpec.kt
@@ -2,9 +2,9 @@ package com.rakuten.tech.mobile.miniapp.permission.ui
 
 import android.app.Activity
 import android.content.Context
-import android.content.SharedPreferences
 import androidx.appcompat.app.AlertDialog
 import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.mockito.kotlin.*
 import com.rakuten.tech.mobile.miniapp.TEST_CALLBACK_ID
@@ -19,9 +19,6 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers.anyInt
-import org.mockito.ArgumentMatchers.anyString
-import org.mockito.Mockito.`when`
 
 @Suppress("LongMethod")
 @RunWith(AndroidJUnit4::class)
@@ -30,9 +27,8 @@ class MiniAppCustomPermissionWindowSpec {
     private lateinit var downloadedManifestCache: DownloadedManifestCache
     private lateinit var dispatcher: CustomPermissionBridgeDispatcher
     private val bridgeExecutor: MiniAppBridgeExecutor = mock()
-    private val mockSharedPrefs: SharedPreferences = mock()
-    private val mockEditor: SharedPreferences.Editor = mock()
-    private val mockContext: Context = mock()
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val prefs = context.getSharedPreferences("test-cache", Context.MODE_PRIVATE)
     private lateinit var activity: Activity
     private lateinit var permissionWindow: MiniAppCustomPermissionWindow
     private var activityScenario = ActivityScenario.launch(TestActivity::class.java)
@@ -47,12 +43,8 @@ class MiniAppCustomPermissionWindowSpec {
 
     @Before
     fun setup() {
-        `when`(mockSharedPrefs.edit()).thenReturn(mockEditor)
-        `when`(mockContext.getSharedPreferences(anyString(), anyInt())).thenReturn(mockSharedPrefs)
-        `when`(mockEditor.putString(anyString(), anyString())).thenReturn(mockEditor)
-
-        permissionCache = MiniAppCustomPermissionCache(mockContext)
-        downloadedManifestCache = DownloadedManifestCache(mockContext)
+        permissionCache = MiniAppCustomPermissionCache(prefs, prefs)
+        downloadedManifestCache = DownloadedManifestCache(context)
         cachedCustomPermission = permissionCache.readPermissions(miniAppId)
 
         activityScenario.onActivity {


### PR DESCRIPTION
# Description
SDK should encrypt the Mini App permissions before saving them to the cache.  Previously, custom permissions has been stored in a normal `SharedPreferences`, now we can migrate it to `EncryptedSharedPreferences`. This PR aims to fix this issue.

## Links
- MINI-1661

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
