### PR TITLE
refactor: check canonical path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # See https://help.github.com/en/articles/about-code-owners
 
-* @Climbatize @corycaywood @gopi-karmakar @khairul-alam-licon @minh-rakuten @ts-leojoseph-r
+* @Climbatize @corycaywood @gopi-karmakar @khairul-alam-licon @minh-rakuten @munir-rakuten @rleojoseph

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/FileWriter.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/FileWriter.kt
@@ -1,6 +1,5 @@
 package com.rakuten.tech.mobile.miniapp.storage
 
-import com.rakuten.tech.mobile.miniapp.BuildConfig
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -20,11 +19,12 @@ internal class FileWriter(private val coroutineDispatcher: CoroutineDispatcher =
 
 internal fun ZipInputStream.decompress(zipPath: String) = use { input ->
     val outputFilePath = File(zipPath).apply { parentFile?.mkdirs() }
+    val basePath = outputFilePath.canonicalPath.substringBeforeLast(File.separator)
     var entry: ZipEntry?
 
     while (input.nextEntry.also { entry = it } != null) {
         val newFile = File(outputFilePath.parentFile, entry!!.name)
-        if (newFile.canonicalPath.contains(BuildConfig.LIBRARY_PACKAGE_NAME))
+        if (newFile.canonicalPath.startsWith(basePath))
             createData(newFile, entry!!, input)
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/FileWriter.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/FileWriter.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.miniapp.storage
 
+import com.rakuten.tech.mobile.miniapp.BuildConfig
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -23,12 +24,17 @@ internal fun ZipInputStream.decompress(zipPath: String) = use { input ->
 
     while (input.nextEntry.also { entry = it } != null) {
         val newFile = File(outputFilePath.parentFile, entry!!.name)
-        newFile.parentFile?.mkdirs()
-        if (entry!!.isDirectory)
-            newFile.mkdir()
-        else
-            writeFile(newFile, input)
+        if (newFile.canonicalPath.contains(BuildConfig.LIBRARY_PACKAGE_NAME))
+            createData(newFile, entry!!, input)
     }
+}
+
+private fun createData(newFile: File, entry: ZipEntry, input: ZipInputStream) {
+    newFile.parentFile?.mkdirs()
+    if (entry.isDirectory)
+        newFile.mkdir()
+    else
+        writeFile(newFile, input)
 }
 
 @Suppress("MagicNumber")

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
@@ -144,7 +144,6 @@ open class RetrofitRequestExecutorErrorSpec : RetrofitRequestExecutorSpec() {
                 mockServer.enqueue(MockResponse().setResponseCode(500))
                 createRequestExecutor().executeRequest(createApi().fetch())
                 advanceTimeBy(1000)
-                advanceTimeBy(2000)
             } catch (exception: MiniAppNetException) {
                 exception.message.toString() shouldContain "Found some problem, timeout"
             }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageSpec.kt
@@ -102,22 +102,16 @@ class MiniAppStorageSpec {
     @Test
     fun `should unzip file without exception`() = runBlockingTest {
         val file = tempFolder.newFile()
-        val folder = tempFolder.newFolder(BuildConfig.LIBRARY_PACKAGE_NAME)
-        var containerPath = file.parent
+        val filePath = file.path
+        val folder = tempFolder.newFolder()
+        val folderPath = folder.path
+        val containerPath = file.parent
 
         val fileWriter = FileWriter(TestCoroutineDispatcher())
-        zipFiles(containerPath, arrayOf(file.path, folder.path))
+        zipFiles(containerPath, arrayOf(filePath, folderPath))
         val inputStream = File("$containerPath${File.separator}$zipFile").inputStream()
-        fileWriter.unzip(inputStream, containerPath)
 
-        // unzip file under miniapp package name
-        val childFolder = File(folder.path + File.separator + BuildConfig.LIBRARY_PACKAGE_NAME)
-        childFolder.mkdir()
-        val file2 = File.createTempFile("prefix_val", "suffix_val", childFolder)
-        containerPath = file2.parent
-        zipFiles(containerPath, arrayOf(file2.path))
-        val inputStream2 = File("$containerPath${File.separator}$zipFile").inputStream()
-        fileWriter.unzip(inputStream2, containerPath)
+        fileWriter.unzip(inputStream, containerPath)
     }
 
     @Test(expected = MiniAppSdkException::class)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppStorageSpec.kt
@@ -102,16 +102,22 @@ class MiniAppStorageSpec {
     @Test
     fun `should unzip file without exception`() = runBlockingTest {
         val file = tempFolder.newFile()
-        val filePath = file.path
-        val folder = tempFolder.newFolder()
-        val folderPath = folder.path
-        val containerPath = file.parent
+        val folder = tempFolder.newFolder(BuildConfig.LIBRARY_PACKAGE_NAME)
+        var containerPath = file.parent
 
         val fileWriter = FileWriter(TestCoroutineDispatcher())
-        zipFiles(containerPath, arrayOf(filePath, folderPath))
+        zipFiles(containerPath, arrayOf(file.path, folder.path))
         val inputStream = File("$containerPath${File.separator}$zipFile").inputStream()
-
         fileWriter.unzip(inputStream, containerPath)
+
+        // unzip file under miniapp package name
+        val childFolder = File(folder.path + File.separator + BuildConfig.LIBRARY_PACKAGE_NAME)
+        childFolder.mkdir()
+        val file2 = File.createTempFile("prefix_val", "suffix_val", childFolder)
+        containerPath = file2.parent
+        zipFiles(containerPath, arrayOf(file2.path))
+        val inputStream2 = File("$containerPath${File.separator}$zipFile").inputStream()
+        fileWriter.unzip(inputStream2, containerPath)
     }
 
     @Test(expected = MiniAppSdkException::class)


### PR DESCRIPTION
# Description
Check canonical path as google security suggestion.

In my perspective, we pass the path for a zip to be extracted so I don't think there is any real issue here. The only possibility is someone can do reverse engineering and modify android runtime execution.

## Links
MINI-3204

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
