### PR TITLE
bugfix: preload screen scrolling 

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
@@ -81,10 +81,8 @@ class PreloadMiniAppWindow(
             ViewModelProvider.NewInstanceFactory().create(PreloadMiniAppViewModel::class.java)
                 .apply {
                     miniAppManifest.observe(lifecycleOwner, Observer { apiManifest ->
-                        if (apiManifest != null)
-                            onShowManifest(apiManifest)
-                        else
-                            preloadMiniAppLaunchListener.onPreloadMiniAppResponse(true)
+                        if (apiManifest != null) onShowManifest(apiManifest)
+                        else onAccept()
                     })
 
                     manifestErrorData.observe(lifecycleOwner, Observer {
@@ -97,12 +95,14 @@ class PreloadMiniAppWindow(
         // set action listeners
         binding.preloadAccept.setOnClickListener {
             viewModel.storeManifestPermission(miniAppId, permissionAdapter.manifestPermissionPairs)
-            preloadMiniAppLaunchListener.onPreloadMiniAppResponse(true)
-            preloadMiniAppAlertDialog.dismiss()
+            onAccept()
         }
         binding.preloadCancel.setOnClickListener {
-            preloadMiniAppLaunchListener.onPreloadMiniAppResponse(false)
-            preloadMiniAppAlertDialog.dismiss()
+            onCancel()
+        }
+
+        preloadMiniAppAlertDialog.setOnCancelListener {
+            onCancel()
         }
     }
 
@@ -124,6 +124,16 @@ class PreloadMiniAppWindow(
             LABEL_CUSTOM_METADATA + toPrettyMetadata(manifest.customMetaData)
 
         launchScreen()
+    }
+
+    private fun onAccept() {
+        preloadMiniAppLaunchListener.onPreloadMiniAppResponse(true)
+        preloadMiniAppAlertDialog.dismiss()
+    }
+
+    private fun onCancel() {
+        preloadMiniAppLaunchListener.onPreloadMiniAppResponse(false)
+        preloadMiniAppAlertDialog.dismiss()
     }
 
     private fun toPrettyMetadata(metadata: Map<String, String>) =

--- a/testapp/src/main/res/layout/window_preload_miniapp.xml
+++ b/testapp/src/main/res/layout/window_preload_miniapp.xml
@@ -60,25 +60,28 @@
         tools:text="Dummy MiniApp Version" />
     </LinearLayout>
 
-    <ScrollView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_above="@id/lnAction"
-        android:layout_below="@id/topView">
-      <LinearLayout
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:background="@android:color/white"
-          android:gravity="center_horizontal"
-          android:orientation="vertical">
+    <androidx.core.widget.NestedScrollView
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:layout_above="@id/lnAction"
+      android:layout_below="@id/topView"
+      android:descendantFocusability="blocksDescendants">
 
-      <androidx.recyclerview.widget.RecyclerView
+      <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/white"
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
+
+        <androidx.recyclerview.widget.RecyclerView
           android:id="@+id/listPreloadPermission"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
+          android:nestedScrollingEnabled="false"
           tools:listitem="@layout/item_list_custom_permission" />
 
-      <TextView
+        <TextView
           android:id="@+id/preloadMiniAppMetaData"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
@@ -89,7 +92,7 @@
           android:background="@color/window_top_bar"
           android:textColor="@android:color/black" />
       </LinearLayout>
-    </ScrollView>
+    </androidx.core.widget.NestedScrollView>
 
     <LinearLayout
       android:id="@+id/lnAction"


### PR DESCRIPTION
# Description
- "Send Message" permission is not showing in demo app's preload screen, this PR aims to fix this ui in `window_preload_miniapp.xml `
- Sorry, I have merged MINI-3261 fix in master, so I have cherry-picked that commit for candidate branch.

## Links
- MINI-3264

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
