### PR TITLE
refactor: no save storage in preview mode

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -102,7 +102,7 @@ internal class MiniAppDownloader(
     private fun retrieveDownloadedVersionPath(miniAppInfo: MiniAppInfo): String? {
         val versionPath = storage.getMiniAppVersionPath(miniAppInfo.id, miniAppInfo.version.versionId)
 
-        if (miniAppStatus.isVersionDownloaded(miniAppInfo.id, miniAppInfo.version.versionId, versionPath)) {
+        if (!apiClient.isPreviewMode && miniAppStatus.isVersionDownloaded(miniAppInfo.id, miniAppInfo.version.versionId, versionPath)) {
             return if (verifier.verify(miniAppInfo.version.versionId, File(versionPath)))
                 versionPath
             else {
@@ -140,7 +140,8 @@ internal class MiniAppDownloader(
             else {
                 val apiResponse = apiClient.fetchMiniAppManifest(appId, versionId)
                 val latestManifest = prepareMiniAppManifest(apiResponse, versionId)
-                manifestApiCache.storeManifest(appId, versionId, latestManifest)
+                if (!apiClient.isPreviewMode)
+                    manifestApiCache.storeManifest(appId, versionId, latestManifest)
                 latestManifest
             }
         }


### PR DESCRIPTION
# Description
Support loading new uploaded codebase by not saving storage in preview mode.

## Links
MINI-3120

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
