### PR TITLE
fix: return null when file is not found from downloaded manifest cache

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -99,7 +99,7 @@ internal class MiniAppDownloader(
         miniAppStatus.saveDownloadedMiniApp(miniAppInfo)
     }
 
-    @SuppressWarnings("MaximumLineLength")
+    @SuppressWarnings("MaximumLineLength", "LongMethod")
     private fun retrieveDownloadedVersionPath(miniAppInfo: MiniAppInfo): String? {
         val versionPath = storage.getMiniAppVersionPath(miniAppInfo.id, miniAppInfo.version.versionId)
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/analytics/MiniAppAnalytics.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/analytics/MiniAppAnalytics.kt
@@ -75,6 +75,7 @@ internal class MiniAppAnalytics(
         }
     }
 
+    @Suppress("LongMethod")
     internal fun sendAnalytics(eType: Etype, actype: Actype, miniAppInfo: MiniAppInfo?) = try {
         // Send to this acc/aid
         val params = createParams(

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridge.kt
@@ -83,6 +83,7 @@ internal class UserInfoBridge {
             bridgeExecutor.postError(callbackId, "$ERR_GET_PROFILE_PHOTO ${e.message}")
         }
     }
+
     @Suppress("LongMethod")
     internal fun onGetAccessToken(callbackObj: CallbackObj) = whenReady(callbackObj.id) {
         try {
@@ -108,6 +109,7 @@ internal class UserInfoBridge {
             )
         }
     }
+
     @Suppress("LongMethod")
     private fun onHasAccessTokenPermission(callbackObj: CallbackObj) {
         val tokenPermission = parseAccessTokenPermission(callbackObj)
@@ -139,14 +141,15 @@ internal class UserInfoBridge {
             }
         }
     }
+
     @Suppress("LongMethod", "ComplexMethod")
     private fun doesAccessTokenMatch(
         tokenScope: AccessTokenScope,
         callback: (Boolean, MiniAppAccessTokenError?) -> Unit
     ) {
         if (tokenScope.scopes.isNotEmpty()) {
-            var listOfAccessTokenScopesCached = downloadedManifestCache.getAccessTokenPermissions(miniAppId)
-            var audience: AccessTokenScope? =
+            val listOfAccessTokenScopesCached = downloadedManifestCache.getAccessTokenPermissions(miniAppId)
+            val audience: AccessTokenScope? =
                 listOfAccessTokenScopesCached.firstOrNull { it.audience == tokenScope.audience }
                     ?: return callback(false, MiniAppAccessTokenError.audienceNotSupportedError)
             if (audience?.scopes?.containsAll(tokenScope.scopes) != true) {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCache.kt
@@ -127,13 +127,15 @@ internal class DownloadedManifestCache(context: Context) {
     }
 
     @VisibleForTesting
-    fun readFromCachedFile(miniAppId: String): CachedManifest? {
+    fun readFromCachedFile(miniAppId: String): CachedManifest? = try {
         val jsonToRead = File(getManifestPath(miniAppId), DEFAULT_FILE_NAME).bufferedReader()
             .use {
                 it.readText()
                     .dropLast(2) // for fixing the json format
             }
-        return toCachedManifest(jsonToRead)
+        toCachedManifest(jsonToRead)
+    } catch (e: Exception) {
+        null
     }
 
     private companion object {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCache.kt
@@ -127,15 +127,20 @@ internal class DownloadedManifestCache(context: Context) {
     }
 
     @VisibleForTesting
-    fun readFromCachedFile(miniAppId: String): CachedManifest? = try {
-        val jsonToRead = File(getManifestPath(miniAppId), DEFAULT_FILE_NAME).bufferedReader()
-            .use {
-                it.readText()
-                    .dropLast(2) // for fixing the json format
-            }
-        toCachedManifest(jsonToRead)
-    } catch (e: Exception) {
-        null
+    fun readFromCachedFile(miniAppId: String): CachedManifest? {
+        try {
+            val file = File(getManifestPath(miniAppId), DEFAULT_FILE_NAME)
+            if (!file.exists()) return null
+
+            val jsonToRead = file.bufferedReader()
+                .use {
+                    it.readText()
+                        .dropLast(2) // for fixing the json format
+                }
+            return toCachedManifest(jsonToRead)
+        } catch (e: Exception) {
+            return null
+        }
     }
 
     private companion object {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/verifier/StoreHashVerifier.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/verifier/StoreHashVerifier.kt
@@ -36,7 +36,7 @@ internal class StoreHashVerifier @VisibleForTesting constructor(
         }
 }
 
-@SuppressWarnings("SwallowedException")
+@SuppressWarnings("SwallowedException", "TooGenericExceptionCaught")
 private fun initEncryptedSharedPreference(context: Context, fileName: String) = try {
     EncryptedSharedPreferences.create(
         context,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCacheSpec.kt
@@ -18,7 +18,6 @@ import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito
 import java.io.File
-import java.io.FileNotFoundException
 import kotlin.test.assertEquals
 
 @Suppress("LongMethod")
@@ -143,7 +142,7 @@ class DownloadedManifestCacheSpec {
         manifestCache.getAccessTokenPermissions(TEST_MA_ID) shouldEqual TEST_ATP_LIST
     }
 
-    @Test(expected = FileNotFoundException::class)
+    @Test
     fun `should get empty list of AccessTokenPermission when no cache`() {
         DownloadedManifestCache(mockContext).getAccessTokenPermissions(TEST_MA_ID) shouldEqual emptyList()
     }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCacheSpec.kt
@@ -46,12 +46,10 @@ class DownloadedManifestCacheSpec {
         doReturn(cachedManifest).whenever(manifestCache).readDownloadedManifest(TEST_MA_ID)
     }
 
-    @Test(expected = FileNotFoundException::class)
+    @Test
     fun `readDownloadedManifest should return null when it hasn't stored any data yet`() {
-        doReturn(null).whenever(manifestCache).readFromCachedFile(TEST_MA_ID)
         val actual = DownloadedManifestCache(mockContext).readDownloadedManifest(TEST_MA_ID)
-        val expected = null
-        actual shouldEqual expected
+        actual shouldEqual null
     }
 
     @Test


### PR DESCRIPTION
# Description
`DownloadedManifestCache.readFromCachedFile` should return `null` while manifest cached file is not found, this PR aims to fix this issue to prevent a crash.

## Links
- MINI-3371

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
