### PR TITLE
fix: preload screen re-launches after uploading new miniapp codebase by same version id

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -217,6 +217,7 @@ abstract class MiniApp internal constructor() {
                 miniAppInfoFetcher = MiniAppInfoFetcher(apiClient),
                 initCustomPermissionCache = { MiniAppCustomPermissionCache(context) },
                 initDownloadedManifestCache = { DownloadedManifestCache(context) },
+                initManifestApiCache = { ManifestApiCache(context) },
                 initManifestVerifier = { MiniAppManifestVerifier(context) },
                 miniAppAnalytics = MiniAppAnalytics(
                     miniAppSdkConfig.rasProjectId,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -99,7 +99,7 @@ internal class MiniAppDownloader(
         miniAppStatus.saveDownloadedMiniApp(miniAppInfo)
     }
 
-    @SuppressWarnings("MaximumLineLength", "LongMethod")
+    @SuppressWarnings("MaximumLineLength")
     private fun retrieveDownloadedVersionPath(miniAppInfo: MiniAppInfo): String? {
         val versionPath = storage.getMiniAppVersionPath(miniAppInfo.id, miniAppInfo.version.versionId)
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCache.kt
@@ -128,18 +128,17 @@ internal class DownloadedManifestCache(context: Context) {
 
     @VisibleForTesting
     fun readFromCachedFile(miniAppId: String): CachedManifest? {
-        try {
-            val file = File(getManifestPath(miniAppId), DEFAULT_FILE_NAME)
-            if (!file.exists()) return null
-
+        val file = File(getManifestPath(miniAppId), DEFAULT_FILE_NAME)
+        if (!file.exists()) return null
+        return try {
             val jsonToRead = file.bufferedReader()
-                .use {
-                    it.readText()
-                        .dropLast(2) // for fixing the json format
-                }
-            return toCachedManifest(jsonToRead)
+                    .use {
+                        it.readText()
+                                .dropLast(2) // for fixing the json format
+                    }
+            toCachedManifest(jsonToRead)
         } catch (e: Exception) {
-            return null
+            null
         }
     }
 


### PR DESCRIPTION
# Description
Users can upload a new miniapp codebase using the same version id, in this case, previously it causes issues e.g.  MINI-3376 & MINI-3379.
This PR aims to fixes those issues while storing manifest into files.

## Links
- MINI-3376
- MINI-3379

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
