### PR TITLE
fix: host app crashes when sending "onError" response for "getUniqueId"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### 3.4.0 (2021-06-XX)
+**SDK**
+- **Fix:** Prevent exception during calling `onError` asynchronously in `getUniqueId`.
+
 ### 3.3.0 (2021-05-19)
 **SDK**
 - **Deprecated:** Old `getUniqueId`interface.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -173,7 +173,11 @@ open class MiniAppMessageBridge {
         val successCallback = { uniqueId: String ->
             bridgeExecutor.postValue(callbackObj.id, uniqueId)
         }
-        val errorCallback = { message: String -> throw MiniAppSdkException(message) }
+        val errorCallback = { message: String ->
+            bridgeExecutor.postError(
+                    callbackObj.id, "${ErrorBridgeMessage.ERR_UNIQUE_ID} $message"
+            )
+        }
 
         getUniqueId(successCallback, errorCallback)
     } catch (e: Exception) {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/AppHelper.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/AppHelper.kt
@@ -5,7 +5,9 @@ import android.app.AlertDialog
 import android.content.Context
 import android.text.InputType
 import android.util.Patterns
+import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.ImageView
@@ -80,3 +82,8 @@ fun defaultContact(id: String) = Contact(
 )
 
 fun String.isEmailValid(): Boolean = Patterns.EMAIL_ADDRESS.matcher(this).matches()
+
+fun hideSoftKeyboard(view: View) {
+    val imm: InputMethodManager? = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
+    imm?.hideSoftInputFromWindow(view.windowToken, 0)
+}

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -155,10 +155,9 @@ class MiniAppDisplayActivity : BaseActivity() {
                     onSuccess: (uniqueId: String) -> Unit,
                     onError: (message: String) -> Unit
             ) {
-                onSuccess(AppSettings.instance.uniqueId)
-
                 val errorMsg = AppSettings.instance.uniqueIdError
                 if (errorMsg.isNotEmpty()) onError(errorMsg)
+                else onSuccess(AppSettings.instance.uniqueId)
             }
 
             override fun requestDevicePermission(

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -17,7 +17,6 @@ import androidx.lifecycle.ViewModelProvider
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.ads.AdMobDisplayer
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppAccessTokenError
-import com.rakuten.tech.mobile.miniapp.errors.MiniAppBridgeError
 import com.rakuten.tech.mobile.miniapp.file.MiniAppFileChooserDefault
 import com.rakuten.tech.mobile.miniapp.js.MessageToContact
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
@@ -151,10 +150,16 @@ class MiniAppDisplayActivity : BaseActivity() {
     private fun setupMiniAppMessageBridge() {
         // setup MiniAppMessageBridge
         miniAppMessageBridge = object : MiniAppMessageBridge() {
+
             override fun getUniqueId(
                     onSuccess: (uniqueId: String) -> Unit,
                     onError: (message: String) -> Unit
-            ) = onSuccess(AppSettings.instance.uniqueId)
+            ) {
+                onSuccess(AppSettings.instance.uniqueId)
+
+                val errorMsg = AppSettings.instance.uniqueIdError
+                if (errorMsg.isNotEmpty()) onError(errorMsg)
+            }
 
             override fun requestDevicePermission(
                 miniAppPermissionType: MiniAppDevicePermissionType,

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -39,13 +39,15 @@ class AppSettings private constructor(context: Context) {
         }
 
     var uniqueId: String
-        get() {
-            val uniqueId = cache.uniqueId ?: UUID.randomUUID().toString()
+        get() = cache.uniqueId ?: UUID.randomUUID().toString()
+        set(uniqueId) {
             cache.uniqueId = uniqueId
-            return uniqueId
         }
-        set(subscriptionKey) {
-            cache.subscriptionKey = subscriptionKey
+
+    var uniqueIdError: String
+        get() = cache.uniqueIdError ?: ""
+        set(uniqueIdError) {
+            cache.uniqueIdError = uniqueIdError
         }
 
     var isSettingSaved: Boolean
@@ -103,11 +105,9 @@ class AppSettings private constructor(context: Context) {
             cache.accessTokenError = accessTokenError
         }
 
-    val baseUrl = manifestConfig.baseUrl()
-
     val miniAppSettings: MiniAppSdkConfig
         get() = MiniAppSdkConfig(
-            baseUrl = baseUrl,
+            baseUrl = manifestConfig.baseUrl(),
             rasProjectId = projectId,
             subscriptionKey = subscriptionKey,
             // no update for hostAppUserAgentInfo because SDK does not allow changing it at runtime
@@ -158,6 +158,10 @@ private class Settings(context: Context) {
     var uniqueId: String?
         get() = prefs.getString(UNIQUE_ID, null)
         set(uuid) = prefs.edit().putString(UNIQUE_ID, uuid).apply()
+
+    var uniqueIdError: String?
+        get() = prefs.getString(UNIQUE_ID_ERROR, null)
+        set(uniqueIdError) = prefs.edit().putString(UNIQUE_ID_ERROR, uniqueIdError).apply()
 
     var isSettingSaved: Boolean
         get() = prefs.getBoolean(IS_SETTING_SAVED, false)
@@ -213,6 +217,7 @@ private class Settings(context: Context) {
         private const val APP_ID = "app_id"
         private const val SUBSCRIPTION_KEY = "subscription_key"
         private const val UNIQUE_ID = "unique_id"
+        private const val UNIQUE_ID_ERROR = "unique_id_error"
         private const val IS_SETTING_SAVED = "is_setting_saved"
         private const val PROFILE_NAME = "profile_name"
         private const val PROFILE_PICTURE_URL = "profile_picture_url"

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -39,9 +39,13 @@ class AppSettings private constructor(context: Context) {
         }
 
     var uniqueId: String
-        get() = cache.uniqueId ?: UUID.randomUUID().toString()
-        set(uniqueId) {
+        get() {
+            val uniqueId = cache.uniqueId ?: UUID.randomUUID().toString()
             cache.uniqueId = uniqueId
+            return uniqueId
+        }
+        set(subscriptionKey) {
+            cache.subscriptionKey = subscriptionKey
         }
 
     var uniqueIdError: String

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.CompoundButton
+import android.widget.Toast
 import androidx.databinding.DataBindingUtil
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppAccessTokenError
 import com.rakuten.tech.mobile.miniapp.testapp.R
@@ -57,6 +58,7 @@ class QASettingsActivity : BaseActivity() {
     }
 
     private fun renderScreen() {
+        // access token
         if (accessTokenErrorCacheData != null) {
             // set up initial state.
             when {
@@ -78,12 +80,18 @@ class QASettingsActivity : BaseActivity() {
             binding.edtCustomErrorMessage.text?.clear()
         }
 
+        // unique id
+        binding.edtUniqueIdError.isEnabled = settings.uniqueIdError.isNotEmpty()
         binding.edtUniqueIdError.setText(settings.uniqueIdError)
+        binding.switchUniqueIdError.isChecked = settings.uniqueIdError.isNotEmpty()
     }
 
     private fun startListeners(){
         binding.switchAuthFailure.setOnCheckedChangeListener(accessTokenListener)
         binding.switchOtherError.setOnCheckedChangeListener(accessTokenListener)
+        binding.switchUniqueIdError.setOnCheckedChangeListener { _, isChecked ->
+            binding.edtUniqueIdError.isEnabled = isChecked
+        }
     }
 
     private val accessTokenListener =
@@ -124,7 +132,14 @@ class QASettingsActivity : BaseActivity() {
         }
 
         // Save unique ID error response
-        settings.uniqueIdError = binding.edtUniqueIdError.text.toString()
+        if (binding.switchUniqueIdError.isChecked) {
+            if (binding.edtUniqueIdError.text.isNullOrEmpty()) {
+                Toast.makeText(this, "Please input error message for Unique ID", Toast.LENGTH_LONG).show()
+                return
+            } else settings.uniqueIdError = binding.edtUniqueIdError.text.toString()
+        } else settings.uniqueIdError = ""
+
+        // post tasks
         hideSoftKeyboard(binding.root)
         finish()
     }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
@@ -10,6 +10,7 @@ import androidx.databinding.DataBindingUtil
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppAccessTokenError
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.QaSettingsActivityBinding
+import com.rakuten.tech.mobile.testapp.helper.hideSoftKeyboard
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
 
@@ -74,27 +75,29 @@ class QASettingsActivity : BaseActivity() {
             // default state
             binding.switchAuthFailure.isChecked = false
             binding.switchOtherError.isChecked = false
-            binding.edtCustomErrorMessage.text.clear()
+            binding.edtCustomErrorMessage.text?.clear()
         }
+
+        binding.edtUniqueIdError.setText(settings.uniqueIdError)
     }
 
     private fun startListeners(){
-        binding.switchAuthFailure.setOnCheckedChangeListener(listener)
-        binding.switchOtherError.setOnCheckedChangeListener(listener)
+        binding.switchAuthFailure.setOnCheckedChangeListener(accessTokenListener)
+        binding.switchOtherError.setOnCheckedChangeListener(accessTokenListener)
     }
 
-    private val listener =
+    private val accessTokenListener =
         CompoundButton.OnCheckedChangeListener { view, isChecked ->
-            setSwitchStates(view,isChecked)
+            setAccessTokenSwitchStates(view,isChecked)
         }
 
-    private fun setSwitchStates(view: CompoundButton, isChecked: Boolean) {
-        when(view.id){
-            R.id.switchAuthFailure-> {
-                if(isChecked) binding.switchOtherError.isChecked = false
+    private fun setAccessTokenSwitchStates(view: CompoundButton, isChecked: Boolean) {
+        when (view.id) {
+            R.id.switchAuthFailure -> {
+                if (isChecked) binding.switchOtherError.isChecked = false
             }
-            R.id.switchOtherError->{
-                if(isChecked) binding.switchAuthFailure.isChecked = false
+            R.id.switchOtherError -> {
+                if (isChecked) binding.switchAuthFailure.isChecked = false
             }
         }
     }
@@ -119,6 +122,10 @@ class QASettingsActivity : BaseActivity() {
                 settings.accessTokenError = null
             }
         }
+
+        // Save unique ID error response
+        settings.uniqueIdError = binding.edtUniqueIdError.text.toString()
+        hideSoftKeyboard(binding.root)
         finish()
     }
 }

--- a/testapp/src/main/res/layout/qa_settings_activity.xml
+++ b/testapp/src/main/res/layout/qa_settings_activity.xml
@@ -1,5 +1,4 @@
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
 
     <data>
 
@@ -23,54 +22,28 @@
             android:paddingBottom="@dimen/small_4"
             android:text="@string/lb_access_token" />
 
-        <RelativeLayout
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/switchAuthFailure"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:foreground="?attr/selectableItemBackground"
-            android:padding="@dimen/medium_16">
-
-            <Switch
-                android:id="@+id/switchAuthFailure"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:checked="false" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_centerVertical="true"
-                android:text="@string/lb_auth_failure_error"
-                android:textColor="@android:color/black"
-                android:textSize="@dimen/text_large_16" />
-        </RelativeLayout>
+            android:padding="@dimen/medium_16"
+            android:text="@string/lb_auth_failure_error"
+            android:textColor="@android:color/black"
+            android:textSize="@dimen/text_large_16" />
 
         <View
             android:layout_width="match_parent"
             android:layout_height="@dimen/horizontal_divider_height"
             android:background="@color/bg_section" />
 
-        <RelativeLayout
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/switchOtherError"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:foreground="?attr/selectableItemBackground"
-            android:padding="@dimen/medium_16">
-
-            <Switch
-                android:id="@+id/switchOtherError"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:checked="false" />
-
-            <androidx.appcompat.widget.AppCompatTextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_centerVertical="true"
-                android:text="@string/lb_other_error"
-                android:textColor="@android:color/black"
-                android:textSize="@dimen/text_large_16" />
-        </RelativeLayout>
+            android:padding="@dimen/medium_16"
+            android:text="@string/lb_other_error"
+            android:textColor="@android:color/black"
+            android:textSize="@dimen/text_large_16" />
 
         <View
             android:layout_width="match_parent"
@@ -80,16 +53,38 @@
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="@dimen/small_8"
+            android:padding="@dimen/small_8">
 
-            android:visibility="visible">
-
-            <EditText
+            <androidx.appcompat.widget.AppCompatEditText
                 android:id="@+id/edtCustomErrorMessage"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/small_4"
                 android:hint="@string/hint_custom_error_message"
+                android:imeOptions="actionDone"
+                android:inputType="text" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/bg_section"
+            android:paddingStart="@dimen/medium_16"
+            android:paddingTop="@dimen/small_4"
+            android:paddingEnd="@dimen/medium_16"
+            android:paddingBottom="@dimen/small_4"
+            android:text="@string/lb_unique_id" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/small_8">
+
+            <androidx.appcompat.widget.AppCompatEditText
+                android:id="@+id/edtUniqueIdError"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/small_4"
+                android:hint="@string/hint_unique_id_error"
                 android:imeOptions="actionDone"
                 android:inputType="text" />
         </com.google.android.material.textfield.TextInputLayout>

--- a/testapp/src/main/res/layout/qa_settings_activity.xml
+++ b/testapp/src/main/res/layout/qa_settings_activity.xml
@@ -74,6 +74,20 @@
             android:paddingBottom="@dimen/small_4"
             android:text="@string/lb_unique_id" />
 
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/switchUniqueIdError"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/medium_16"
+            android:text="@string/lb_unique_id_error"
+            android:textColor="@android:color/black"
+            android:textSize="@dimen/text_large_16" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/horizontal_divider_height"
+            android:background="@color/bg_section" />
+
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/testapp/src/main/res/layout/settings_menu_activity.xml
+++ b/testapp/src/main/res/layout/settings_menu_activity.xml
@@ -30,6 +30,7 @@
                     android:layout_margin="@dimen/small_8"
                     android:padding="@dimen/small_8"
                     android:textColor="@android:color/black"
+                    android:textSize="@dimen/text_large_16"
                     tools:text="Build Info" />
 
                 <View
@@ -37,13 +38,15 @@
                     android:layout_height="@dimen/horizontal_divider_height"
                     android:background="@color/bg_section" />
 
-                <com.google.android.material.switchmaterial.SwitchMaterial
+                <androidx.appcompat.widget.SwitchCompat
                     android:id="@+id/switchPreviewMode"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_margin="@dimen/small_8"
                     android:padding="@dimen/small_8"
-                    android:text="@string/lb_preview_mode" />
+                    android:text="@string/lb_preview_mode"
+                    android:textColor="@android:color/black"
+                    android:textSize="@dimen/text_large_16" />
 
                 <androidx.appcompat.widget.AppCompatTextView
                     android:layout_width="match_parent"

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="lb_other_error">Always Generate Custom Error</string>
     <string name="hint_custom_error_message">Custom Error Message</string>
 
+    <string name="lb_unique_id_error">Always Generate Unique ID Error</string>
     <string name="hint_unique_id_error">Unique ID Error Message</string>
 
     <string name="menu_title_search">Search</string>

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -11,10 +11,13 @@
     <string name="lb_access_token">Access Token</string>
     <string name="lb_valid_until">Expired Date</string>
     <string name="lb_display_input">Display by Input</string>
+    <string name="lb_unique_id">Unique ID</string>
 
     <string name="lb_auth_failure_error">Always Generate Authorization Error</string>
     <string name="lb_other_error">Always Generate Custom Error</string>
     <string name="hint_custom_error_message">Custom Error Message</string>
+
+    <string name="hint_unique_id_error">Unique ID Error Message</string>
 
     <string name="menu_title_search">Search</string>
     <string name="menu_title_settings">Settings</string>


### PR DESCRIPTION
# Description
- Prevent exception during calling `onError` asynchronously in `getUniqueId`.
- Add an error response for "getUniqueId" to the QA settings section in the demo app.

## Links
- MINI-3385

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
