### PR TITLE
[MINI-3240] feat: user points implementation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## CHANGELOG
 
+### 3.X.X (2021-XX-XX)
+**SDK**
+- **Feature:** Added `getPoints` interface in `UserInfoBridgeDispatcher` to request for user's point with checking `rakuten.miniapp.user.POINTS` custom permission.
+
+**Sample App**
+- **Feature:** Added a screen to input user's points which can be invoked using `getPoints` interface.
+
 ### 3.4.0 (2021-06-XX)
 **SDK**
 - **Fix:** Prevent exception during calling `onError` asynchronously in `getUniqueId`.

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -220,6 +220,7 @@ The `UserInfoBridgeDispatcher`:
 | getProfilePhoto              | 🚫       |
 | getAccessToken               | 🚫       |
 | getContacts                  | 🚫       |
+| getPoints                    | 🚫       |
 
 The `ChatBridgeDispatcher`:
 
@@ -332,6 +333,18 @@ val userInfoBridgeDispatcher = object : UserInfoBridgeDispatcher {
         else
             onError(message) // reject miniapp to get contacts with message explanation.
     }
+
+    override fun getPoints(
+            onSuccess: (points: Points) -> Unit,
+            onError: (message: String) -> Unit
+        ) {
+            // Check if there is any points in HostApp
+            // .. .. ..
+            if (hasPoints)
+                onSuccess(points) // allow miniapp to get points.
+            else
+                onError(message) // reject miniapp to get points with message explanation.
+        }
 }
 
 // set UserInfoBridgeDispatcher object to miniAppMessageBridge

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -2,6 +2,7 @@ package com.rakuten.tech.mobile.miniapp.js
 
 import android.app.Activity
 import android.content.Intent
+import android.util.Log
 import android.webkit.JavascriptInterface
 import androidx.annotation.VisibleForTesting
 import com.google.gson.Gson
@@ -126,6 +127,7 @@ open class MiniAppMessageBridge {
     @SuppressWarnings("UndocumentedPublicFunction")
     @JavascriptInterface
     fun postMessage(jsonStr: String) {
+        Log.d("AAAAA",""+jsonStr)
         val callbackObj = Gson().fromJson(jsonStr, CallbackObj::class.java)
 
         when (callbackObj.action) {
@@ -138,6 +140,7 @@ open class MiniAppMessageBridge {
             ActionType.GET_USER_NAME.action -> userInfoBridge.onGetUserName(callbackObj.id)
             ActionType.GET_PROFILE_PHOTO.action -> userInfoBridge.onGetProfilePhoto(callbackObj.id)
             ActionType.GET_ACCESS_TOKEN.action -> userInfoBridge.onGetAccessToken(callbackObj)
+            ActionType.GET_POINTS.action -> userInfoBridge.onGetPoints(callbackObj.id)
             ActionType.SET_SCREEN_ORIENTATION.action -> screenBridgeDispatcher.onScreenRequest(callbackObj)
             ActionType.GET_CONTACTS.action -> userInfoBridge.onGetContacts(callbackObj.id)
             ActionType.SEND_MESSAGE_TO_CONTACT.action -> chatBridge.onSendMessageToContact(

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -2,7 +2,6 @@ package com.rakuten.tech.mobile.miniapp.js
 
 import android.app.Activity
 import android.content.Intent
-import android.util.Log
 import android.webkit.JavascriptInterface
 import androidx.annotation.VisibleForTesting
 import com.google.gson.Gson
@@ -127,7 +126,6 @@ open class MiniAppMessageBridge {
     @SuppressWarnings("UndocumentedPublicFunction")
     @JavascriptInterface
     fun postMessage(jsonStr: String) {
-        Log.d("AAAAA",""+jsonStr)
         val callbackObj = Gson().fromJson(jsonStr, CallbackObj::class.java)
 
         when (callbackObj.action) {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/Type.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/Type.kt
@@ -15,6 +15,7 @@ internal enum class ActionType(val action: String) {
     SEND_MESSAGE_TO_CONTACT("sendMessageToContact"),
     SEND_MESSAGE_TO_CONTACT_ID("sendMessageToContactId"),
     SEND_MESSAGE_TO_MULTIPLE_CONTACTS("sendMessageToMultipleContacts"),
+    GET_POINTS("getPoints"),
 }
 
 internal enum class DialogType {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/Points.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/Points.kt
@@ -2,7 +2,7 @@ package com.rakuten.tech.mobile.miniapp.js.userinfo
 
 import androidx.annotation.Keep
 
-/** Point object for miniapp. */
+/** Points object for miniapp. */
 @Keep
 data class Points(
     val standard: Int,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/Points.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/Points.kt
@@ -1,0 +1,11 @@
+package com.rakuten.tech.mobile.miniapp.js.userinfo
+
+import androidx.annotation.Keep
+
+/** Point object for miniapp. */
+@Keep
+data class Points(
+    val standard: Int,
+    var term: Int,
+    var cash: Int
+)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridge.kt
@@ -1,6 +1,5 @@
 package com.rakuten.tech.mobile.miniapp.js.userinfo
 
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -193,7 +192,7 @@ internal class UserInfoBridge {
     }
 
     @Suppress("LongMethod")
-    internal fun onGetPoints(callbackId: String) = whenReady(callbackId) {
+    fun onGetPoints(callbackId: String) = whenReady(callbackId) {
         try {
             if (customPermissionCache.hasPermission(miniAppId, MiniAppCustomPermissionType.POINTS)) {
                 val successCallback = { points: Points ->

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridge.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.miniapp.js.userinfo
 
+import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -191,6 +192,26 @@ internal class UserInfoBridge {
         }
     }
 
+    @Suppress("LongMethod")
+    internal fun onGetPoints(callbackId: String) = whenReady(callbackId) {
+        try {
+            if (customPermissionCache.hasPermission(miniAppId, MiniAppCustomPermissionType.POINTS)) {
+                val successCallback = { points: Points ->
+                    Log.d("AAAAA2",""+points)
+                    bridgeExecutor.postValue(callbackId, Gson().toJson(points))
+                }
+                val errorCallback = { message: String ->
+                    bridgeExecutor.postError(callbackId, "$ERR_GET_POINTS $message")
+                }
+
+                userInfoBridgeDispatcher.getPoints(successCallback, errorCallback)
+            } else
+                bridgeExecutor.postError(callbackId, "$ERR_GET_POINTS $ERR_GET_POINTS_NO_PERMISSION")
+        } catch (e: Exception) {
+            bridgeExecutor.postError(callbackId, "$ERR_GET_POINTS ${e.message}")
+        }
+    }
+
     @VisibleForTesting
     internal companion object {
         const val ERR_GET_USER_NAME = "Cannot get user name:"
@@ -206,5 +227,8 @@ internal class UserInfoBridge {
         const val ERR_GET_CONTACTS = "Cannot get contacts:"
         const val ERR_GET_CONTACTS_NO_PERMISSION =
             "Permission has not been accepted yet for getting contacts."
+        const val ERR_GET_POINTS = "Cannot get points:"
+        const val ERR_GET_POINTS_NO_PERMISSION =
+                "Permission has not been accepted yet for getting points."
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridge.kt
@@ -197,18 +197,27 @@ internal class UserInfoBridge {
         try {
             if (customPermissionCache.hasPermission(miniAppId, MiniAppCustomPermissionType.POINTS)) {
                 val successCallback = { points: Points ->
-                    Log.d("AAAAA2",""+points)
                     bridgeExecutor.postValue(callbackId, Gson().toJson(points))
                 }
                 val errorCallback = { message: String ->
-                    bridgeExecutor.postError(callbackId, "$ERR_GET_POINTS $message")
+                    val errorBridgeModel = MiniAppBridgeErrorModel("$ERR_GET_POINTS $message")
+                    bridgeExecutor.postError(callbackId, Gson().toJson(errorBridgeModel))
                 }
 
                 userInfoBridgeDispatcher.getPoints(successCallback, errorCallback)
-            } else
-                bridgeExecutor.postError(callbackId, "$ERR_GET_POINTS $ERR_GET_POINTS_NO_PERMISSION")
+            } else {
+                bridgeExecutor.postError(callbackId,
+                        Gson().toJson(MiniAppBridgeErrorModel(
+                                "$ERR_GET_POINTS $ERR_GET_POINTS_NO_PERMISSION")
+                        )
+                )
+            }
         } catch (e: Exception) {
-            bridgeExecutor.postError(callbackId, "$ERR_GET_POINTS ${e.message}")
+            bridgeExecutor.postError(callbackId,
+                    Gson().toJson(MiniAppBridgeErrorModel(
+                            "$ERR_GET_POINTS ${e.message}")
+                    )
+            )
         }
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
@@ -86,4 +86,15 @@ interface UserInfoBridgeDispatcher {
     ) {
         throw MiniAppSdkException(NO_IMPL)
     }
+
+    /**
+     * Get points from host app.
+     * You can also throw an [Exception] from this method to pass an error message to the mini app.
+     */
+    fun getPoints(
+        onSuccess: (points: Points) -> Unit,
+        onError: (message: String) -> Unit
+    ) {
+        throw MiniAppSdkException(NO_IMPL)
+    }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppPermission.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppPermission.kt
@@ -22,6 +22,7 @@ enum class MiniAppCustomPermissionType(val type: String) {
     ACCESS_TOKEN("rakuten.miniapp.user.ACCESS_TOKEN"),
     SEND_MESSAGE("rakuten.miniapp.user.action.SEND_MESSAGE"),
     LOCATION("rakuten.miniapp.device.LOCATION"),
+    POINTS("rakuten.miniapp.user.POINTS"),
     UNKNOWN("UNKNOWN");
 
     internal companion object {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionAdapter.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionAdapter.kt
@@ -95,6 +95,7 @@ internal class MiniAppCustomPermissionAdapter :
             MiniAppCustomPermissionType.ACCESS_TOKEN -> "Access Token"
             MiniAppCustomPermissionType.SEND_MESSAGE -> "Send Message"
             MiniAppCustomPermissionType.LOCATION -> "Device Location"
+            MiniAppCustomPermissionType.POINTS -> "Rakuten Points"
             else -> "Unknown"
         }
     }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
@@ -537,14 +537,13 @@ class UserInfoBridgeSpec {
     /** start region: get points */
     private val points = Points(0, 0, 0)
     private fun createPointsImpl(
-            hasGetPoints: Boolean,
-            canGetPoints: Boolean
+        hasGetPoints: Boolean, canGetPoints: Boolean
     ): UserInfoBridgeDispatcher {
         return if (hasGetPoints) {
             object : UserInfoBridgeDispatcher {
                 override fun getPoints(
-                        onSuccess: (points: Points) -> Unit,
-                        onError: (message: String) -> Unit) {
+                    onSuccess: (points: Points) -> Unit, onError: (message: String) -> Unit
+                ) {
                     if (canGetPoints)
                         onSuccess.invoke(points)
                     else

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
@@ -16,11 +16,14 @@ import com.rakuten.tech.mobile.miniapp.display.WebViewListener
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppAccessTokenError
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppBridgeErrorModel
 import com.rakuten.tech.mobile.miniapp.js.*
+import com.rakuten.tech.mobile.miniapp.js.ErrorBridgeMessage.NO_IMPL
 import com.rakuten.tech.mobile.miniapp.js.userinfo.UserInfoBridge.Companion.ERR_ACCESS_TOKEN_NOT_MATCH_MANIFEST
 import com.rakuten.tech.mobile.miniapp.js.userinfo.UserInfoBridge.Companion.ERR_ACCESS_TOKEN_NO_PERMISSION
 import com.rakuten.tech.mobile.miniapp.js.userinfo.UserInfoBridge.Companion.ERR_GET_ACCESS_TOKEN
 import com.rakuten.tech.mobile.miniapp.js.userinfo.UserInfoBridge.Companion.ERR_GET_CONTACTS
 import com.rakuten.tech.mobile.miniapp.js.userinfo.UserInfoBridge.Companion.ERR_GET_CONTACTS_NO_PERMISSION
+import com.rakuten.tech.mobile.miniapp.js.userinfo.UserInfoBridge.Companion.ERR_GET_POINTS
+import com.rakuten.tech.mobile.miniapp.js.userinfo.UserInfoBridge.Companion.ERR_GET_POINTS_NO_PERMISSION
 import com.rakuten.tech.mobile.miniapp.js.userinfo.UserInfoBridge.Companion.ERR_GET_PROFILE_PHOTO
 import com.rakuten.tech.mobile.miniapp.js.userinfo.UserInfoBridge.Companion.ERR_GET_USER_NAME
 import com.rakuten.tech.mobile.miniapp.permission.*
@@ -50,6 +53,11 @@ class UserInfoBridgeSpec {
         action = ActionType.GET_CONTACTS.action,
         param = null,
         id = TEST_CALLBACK_ID
+    )
+    private val pointsCallbackObj = CallbackObj(
+            action = ActionType.GET_POINTS.action,
+            param = null,
+            id = TEST_CALLBACK_ID
     )
     private val customPermissionCache: MiniAppCustomPermissionCache = mock()
     private val downloadedManifestCache: DownloadedManifestCache = mock()
@@ -85,6 +93,9 @@ class UserInfoBridgeSpec {
         ).thenReturn(true)
         whenever(customPermissionCache.hasPermission(
             miniAppInfo.id, MiniAppCustomPermissionType.ACCESS_TOKEN)
+        ).thenReturn(true)
+        whenever(customPermissionCache.hasPermission(
+                miniAppInfo.id, MiniAppCustomPermissionType.POINTS)
         ).thenReturn(true)
         When calling downloadedManifestCache.getAccessTokenPermissions(TEST_MA_ID) itReturns TEST_ATP_LIST
     }
@@ -520,6 +531,71 @@ class UserInfoBridgeSpec {
         userInfoBridgeWrapper.onGetContacts(contactsCallbackObj.id)
 
         verify(bridgeExecutor).postValue(contactsCallbackObj.id, Gson().toJson(contacts))
+    }
+    /** end region */
+
+    /** start region: get points */
+    private val points = Points(0, 0, 0)
+    private fun createPointsImpl(
+            hasGetPoints: Boolean,
+            canGetPoints: Boolean
+    ): UserInfoBridgeDispatcher {
+        return if (hasGetPoints) {
+            object : UserInfoBridgeDispatcher {
+                override fun getPoints(
+                        onSuccess: (points: Points) -> Unit,
+                        onError: (message: String) -> Unit) {
+                    if (canGetPoints)
+                        onSuccess.invoke(points)
+                    else
+                        onError.invoke(TEST_ERROR_MSG)
+                }
+            }
+        } else {
+            object : UserInfoBridgeDispatcher {}
+        }
+    }
+
+    @Test
+    fun `postError should be called when there is no get points retrieval implementation`() {
+        val userInfoBridgeDispatcher = Mockito.spy(createPointsImpl(false, false))
+        miniAppBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)
+        val errMsg = "{\"type\":\"$ERR_GET_POINTS $NO_IMPL\"}"
+        miniAppBridge.postMessage(Gson().toJson(pointsCallbackObj))
+
+        verify(bridgeExecutor).postError(pointsCallbackObj.id, errMsg)
+    }
+
+    @Test
+    fun `postError should be called when points permission hasn't been allowed`() {
+        val userInfoBridgeDispatcher = Mockito.spy(createPointsImpl(true, true))
+        val userInfoBridgeWrapper = Mockito.spy(createUserInfoBridgeWrapper(userInfoBridgeDispatcher))
+        val errMsg = "{\"type\":\"$ERR_GET_POINTS $ERR_GET_POINTS_NO_PERMISSION\"}"
+        whenever(customPermissionCache.hasPermission(
+                miniAppInfo.id, MiniAppCustomPermissionType.POINTS)
+        ).thenReturn(false)
+        userInfoBridgeWrapper.onGetPoints(pointsCallbackObj.id)
+
+        verify(bridgeExecutor).postError(pointsCallbackObj.id, errMsg)
+    }
+
+    @Test
+    fun `postError should be called when hostapp doesn't providing points`() {
+        val errMsg = "{\"type\":\"$ERR_GET_POINTS $TEST_ERROR_MSG\"}"
+        val userInfoBridgeDispatcher = Mockito.spy(createPointsImpl(true, false))
+        val userInfoBridgeWrapper = Mockito.spy(createUserInfoBridgeWrapper(userInfoBridgeDispatcher))
+        userInfoBridgeWrapper.onGetPoints(pointsCallbackObj.id)
+
+        verify(bridgeExecutor).postError(pointsCallbackObj.id, errMsg)
+    }
+
+    @Test
+    fun `postValue should be called when retrieve points successfully`() {
+        val userInfoBridgeDispatcher = Mockito.spy(createPointsImpl(true, true))
+        val userInfoBridgeWrapper = Mockito.spy(createUserInfoBridgeWrapper(userInfoBridgeDispatcher))
+        userInfoBridgeWrapper.onGetPoints(pointsCallbackObj.id)
+
+        verify(bridgeExecutor).postValue(pointsCallbackObj.id, Gson().toJson(points))
     }
     /** end region */
 

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -64,6 +64,9 @@
             android:name="com.rakuten.tech.mobile.testapp.ui.userdata.AccessTokenActivity"
             android:label="@string/lb_access_token" />
         <activity
+            android:name="com.rakuten.tech.mobile.testapp.ui.userdata.PointsActivity"
+            android:label="@string/action_points" />
+        <activity
             android:name="com.rakuten.tech.mobile.testapp.ui.deeplink.SchemeActivity"
             android:permission="android.permission.CAMERA"> <!-- Added camera permission so that only apps(i.e QRcode scanner) with camera permission can open demo app. -->
             <intent-filter

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.os.Bundle
+import android.util.Log
 import android.view.MenuItem
 import android.view.View
 import android.webkit.WebView
@@ -218,6 +219,13 @@ class MiniAppDisplayActivity : BaseActivity() {
                     onSuccess(AppSettings.instance.contacts)
                 else
                     onError("There is no contact found in HostApp.")
+            }
+
+            override fun getPoints(onSuccess: (points: Points) -> Unit,
+                                   onError: (message: String) -> Unit) {
+                val points = Points(100, 200, 350)
+                onSuccess(points)
+                Log.d("AAAAA0",""+points)
             }
         }
         miniAppMessageBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.os.Bundle
-import android.util.Log
 import android.view.MenuItem
 import android.view.View
 import android.webkit.WebView

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -221,11 +221,13 @@ class MiniAppDisplayActivity : BaseActivity() {
                     onError("There is no contact found in HostApp.")
             }
 
-            override fun getPoints(onSuccess: (points: Points) -> Unit,
-                                   onError: (message: String) -> Unit) {
-                val points = Points(100, 200, 350)
-                onSuccess(points)
-                Log.d("AAAAA0",""+points)
+            override fun getPoints(
+                onSuccess: (points: Points) -> Unit,
+                onError: (message: String) -> Unit
+            ) {
+                val points = AppSettings.instance.points
+                if (points != null) onSuccess(points)
+                else onError("There is no points found in HostApp.")
             }
         }
         miniAppMessageBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/PermissionsUtils.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/PermissionsUtils.kt
@@ -11,6 +11,7 @@ fun toReadableName(type: MiniAppCustomPermissionType?): String {
         MiniAppCustomPermissionType.ACCESS_TOKEN -> "Access Token"
         MiniAppCustomPermissionType.SEND_MESSAGE -> "Send Message"
         MiniAppCustomPermissionType.LOCATION -> "Device Location"
+        MiniAppCustomPermissionType.POINTS -> "Rakuten Points"
         else -> "Unknown"
     }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -9,6 +9,7 @@ import com.rakuten.tech.mobile.miniapp.MiniAppSdkConfig
 import com.rakuten.tech.mobile.miniapp.analytics.MiniAppAnalyticsConfig
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppAccessTokenError
 import com.rakuten.tech.mobile.miniapp.js.userinfo.Contact
+import com.rakuten.tech.mobile.miniapp.js.userinfo.Points
 import com.rakuten.tech.mobile.miniapp.js.userinfo.TokenData
 import com.rakuten.tech.mobile.miniapp.testapp.BuildConfig
 import java.util.Date
@@ -107,6 +108,12 @@ class AppSettings private constructor(context: Context) {
         get() = cache.accessTokenError
         set(accessTokenError) {
             cache.accessTokenError = accessTokenError
+        }
+
+    var points: Points?
+        get() = cache.points
+        set(points) {
+            cache.points = points
         }
 
     val miniAppSettings: MiniAppSdkConfig
@@ -216,6 +223,11 @@ private class Settings(context: Context) {
         set(accessTokenError) = prefs.edit().putString(ACCESS_TOKEN_ERROR, gson.toJson(accessTokenError))
             .apply()
 
+    var points: Points?
+        get() = gson.fromJson(prefs.getString(POINTS, null), Points::class.java)
+        set(points) = prefs.edit().putString(POINTS, gson.toJson(points))
+                .apply()
+
     companion object {
         private const val IS_PREVIEW_MODE = "is_preview_mode"
         private const val APP_ID = "app_id"
@@ -231,5 +243,6 @@ private class Settings(context: Context) {
         private const val URL_PARAMETERS = "url_parameters"
         private const val ANALYTIC_CONFIGS = "analytic_configs"
         private const val ACCESS_TOKEN_ERROR = "access_token_error"
+        private const val POINTS = "points"
     }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
@@ -24,10 +24,7 @@ import com.rakuten.tech.mobile.testapp.ui.input.MiniAppInputActivity
 import com.rakuten.tech.mobile.testapp.ui.miniapplist.MiniAppListActivity
 import com.rakuten.tech.mobile.testapp.ui.permission.MiniAppDownloadedListActivity
 import com.rakuten.tech.mobile.testapp.ui.settings.MenuBaseActivity.Companion.MENU_SCREEN_NAME
-import com.rakuten.tech.mobile.testapp.ui.userdata.AccessTokenActivity
-import com.rakuten.tech.mobile.testapp.ui.userdata.ContactListActivity
-import com.rakuten.tech.mobile.testapp.ui.userdata.ProfileSettingsActivity
-import com.rakuten.tech.mobile.testapp.ui.userdata.QASettingsActivity
+import com.rakuten.tech.mobile.testapp.ui.userdata.*
 import kotlinx.coroutines.launch
 import java.net.URL
 import kotlin.properties.Delegates
@@ -125,6 +122,10 @@ class SettingsMenuActivity : BaseActivity() {
 
         binding.buttonAccessToken.setOnClickListener {
             AccessTokenActivity.start(this@SettingsMenuActivity)
+        }
+
+        binding.buttonPoints.setOnClickListener {
+            PointsActivity.start(this@SettingsMenuActivity)
         }
 
         binding.buttonQA.setOnClickListener {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/PointsActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/PointsActivity.kt
@@ -1,0 +1,69 @@
+package com.rakuten.tech.mobile.testapp.ui.userdata
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
+import androidx.databinding.DataBindingUtil
+import com.rakuten.tech.mobile.miniapp.js.userinfo.Points
+import com.rakuten.tech.mobile.miniapp.testapp.R
+import com.rakuten.tech.mobile.miniapp.testapp.databinding.PointsActivityBinding
+import com.rakuten.tech.mobile.testapp.helper.hideSoftKeyboard
+import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
+import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
+import kotlinx.android.synthetic.main.points_activity.*
+
+class PointsActivity : BaseActivity() {
+    private lateinit var settings: AppSettings
+    private lateinit var binding: PointsActivityBinding
+
+    companion object {
+        fun start(activity: Activity) {
+            activity.startActivity(Intent(activity, PointsActivity::class.java))
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        settings = AppSettings.instance
+        showBackIcon()
+        renderScreen()
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.settings_menu, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                finish()
+                return true
+            }
+            R.id.settings_menu_save -> {
+                update()
+                return true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    private fun renderScreen() {
+        binding = DataBindingUtil.setContentView(this, R.layout.points_activity)
+        settings.points?.standard?.let { binding.edtPointStandard.setText(it.toString()) }
+        settings.points?.term?.let { binding.edtPointTimeLimited.setText(it.toString()) }
+        settings.points?.cash?.let { binding.edtPointRakutenCash.setText(it.toString()) }
+    }
+
+    private fun update() {
+        settings.points = Points(
+                edtPointStandard.text.toString().toInt(),
+                edtPointTimeLimited.text.toString().toInt(),
+                edtPointRakutenCash.text.toString().toInt()
+        )
+        hideSoftKeyboard(binding.root)
+        finish()
+    }
+}

--- a/testapp/src/main/res/layout/points_activity.xml
+++ b/testapp/src/main/res/layout/points_activity.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/layoutPointStandard"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/small_8"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.appcompat.widget.AppCompatEditText
+                android:id="@+id/edtPointStandard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_points_standard"
+                android:imeOptions="actionDone"
+                android:inputType="number" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/layoutPointTimeLimited"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/small_8"
+            app:layout_constraintStart_toStartOf="@id/layoutPointStandard"
+            app:layout_constraintTop_toBottomOf="@+id/layoutPointStandard">
+
+            <androidx.appcompat.widget.AppCompatEditText
+                android:id="@+id/edtPointTimeLimited"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_points_time_limited"
+                android:imeOptions="actionDone"
+                android:inputType="number" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/small_8"
+            app:layout_constraintStart_toStartOf="@id/layoutPointTimeLimited"
+            app:layout_constraintTop_toBottomOf="@+id/layoutPointTimeLimited">
+
+            <androidx.appcompat.widget.AppCompatEditText
+                android:id="@+id/edtPointRakutenCash"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_points_rakuten_cash"
+                android:imeOptions="actionDone"
+                android:inputType="number" />
+        </com.google.android.material.textfield.TextInputLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/testapp/src/main/res/layout/settings_menu_activity.xml
+++ b/testapp/src/main/res/layout/settings_menu_activity.xml
@@ -205,6 +205,33 @@
                     android:background="@color/bg_section" />
 
                 <RelativeLayout
+                    android:id="@+id/buttonPoints"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:foreground="?attr/selectableItemBackground"
+                    android:padding="@dimen/medium_16">
+
+                    <ImageView
+                        android:layout_width="@dimen/sec_icon_size"
+                        android:layout_height="@dimen/sec_icon_size"
+                        android:layout_alignParentEnd="true"
+                        android:src="@drawable/ic_arrow_forward" />
+
+                    <androidx.appcompat.widget.AppCompatTextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_centerVertical="true"
+                        android:text="@string/action_points"
+                        android:textColor="@android:color/black"
+                        android:textSize="@dimen/text_large_16" />
+                </RelativeLayout>
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/horizontal_divider_height"
+                    android:background="@color/bg_section" />
+
+                <RelativeLayout
                     android:id="@+id/buttonQA"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -21,6 +21,10 @@
     <string name="lb_unique_id_error">Always Generate Unique ID Error</string>
     <string name="hint_unique_id_error">Unique ID Error Message</string>
 
+    <string name="hint_points_standard">Points (Standard)</string>
+    <string name="hint_points_time_limited">Points (Time-Limited)</string>
+    <string name="hint_points_rakuten_cash">Points (Rakuten Cash)</string>
+
     <string name="menu_title_search">Search</string>
     <string name="menu_title_settings">Settings</string>
     <string name="menu_title_change_settings">Change App Settings</string>
@@ -50,6 +54,7 @@
     <string name="action_cancel">Cancel</string>
     <string name="action_profile">Profile</string>
     <string name="action_contacts">Contacts</string>
+    <string name="action_points">Points</string>
     <string name="action_qa">QA</string>
     <string name="action_custom_permissions">Permissions</string>
     <string name="action_first_time_accept">Accept</string>


### PR DESCRIPTION
# Description
- Add an interface to retrieve the user's points information with custom permission e.g. `rakuten.miniapp.user.POINTS`
- In the Demo App settings screen, add an option where the points data can be set.
- Update with JS bridge. 

## Links
- MINI-3240

## Screenshot
![Screen Shot 2021-06-29 at 14 22 07](https://user-images.githubusercontent.com/66930373/123741691-73645e00-d8e5-11eb-97e8-0066e52ee41e.png)

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
