### PR TITLE
[MINI-2947] improvement: migrate to file verification for manifest

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -13,7 +13,6 @@ import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 import com.rakuten.tech.mobile.miniapp.storage.CachedManifest
 import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
 import com.rakuten.tech.mobile.miniapp.storage.verifier.MiniAppManifestVerifier
-import java.io.File
 
 @Suppress("TooManyFunctions", "LongMethod")
 internal class RealMiniApp(
@@ -150,7 +149,7 @@ internal class RealMiniApp(
     suspend fun verifyManifest(appId: String, versionId: String) {
         val cachedManifest = downloadedManifestCache.readDownloadedManifest(appId)
         checkToDownloadManifest(appId, versionId, cachedManifest)
-        val manifestFile = File(downloadedManifestCache.getManifestPath(appId))
+        val manifestFile = downloadedManifestCache.getManifestFile(appId)
         if (cachedManifest != null && manifestVerifier.verify(appId, manifestFile)) {
             val customPermissions = miniAppCustomPermissionCache.readPermissions(appId)
             val manifestPermissions = downloadedManifestCache.getAllPermissions(customPermissions)
@@ -169,7 +168,7 @@ internal class RealMiniApp(
         if (isDifferentVersion || isSameVerDiffApp) {
             val storableManifest = CachedManifest(versionId, apiManifest)
             downloadedManifestCache.storeDownloadedManifest(appId, storableManifest)
-            val manifestFile = File(downloadedManifestCache.getManifestPath(appId))
+            val manifestFile = downloadedManifestCache.getManifestFile(appId)
             manifestVerifier.storeHashAsync(appId, manifestFile)
         }
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -13,6 +13,7 @@ import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 import com.rakuten.tech.mobile.miniapp.storage.CachedManifest
 import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
 import com.rakuten.tech.mobile.miniapp.storage.verifier.MiniAppManifestVerifier
+import java.io.File
 
 @Suppress("TooManyFunctions", "LongMethod")
 internal class RealMiniApp(
@@ -149,7 +150,8 @@ internal class RealMiniApp(
     suspend fun verifyManifest(appId: String, versionId: String) {
         val cachedManifest = downloadedManifestCache.readDownloadedManifest(appId)
         checkToDownloadManifest(appId, versionId, cachedManifest)
-        if (cachedManifest != null && manifestVerifier.verify(appId, cachedManifest)) {
+        val manifestFile = File(downloadedManifestCache.getManifestPath(appId))
+        if (cachedManifest != null && manifestVerifier.verify(appId, manifestFile)) {
             val customPermissions = miniAppCustomPermissionCache.readPermissions(appId)
             val manifestPermissions = downloadedManifestCache.getAllPermissions(customPermissions)
             miniAppCustomPermissionCache.removePermissionsNotMatching(appId, manifestPermissions)
@@ -167,7 +169,8 @@ internal class RealMiniApp(
         if (isDifferentVersion || isSameVerDiffApp) {
             val storableManifest = CachedManifest(versionId, apiManifest)
             downloadedManifestCache.storeDownloadedManifest(appId, storableManifest)
-            manifestVerifier.storeHashAsync(appId, storableManifest)
+            val manifestFile = File(downloadedManifestCache.getManifestPath(appId))
+            manifestVerifier.storeHashAsync(appId, manifestFile)
         }
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCache.kt
@@ -24,6 +24,8 @@ internal class DownloadedManifestCache(context: Context) {
 
     private val sdkBasePath = context.filesDir.path
     private val miniAppBasePath = "$sdkBasePath/$SUB_DIR_MINIAPP/"
+
+    @VisibleForTesting
     fun getManifestPath(appId: String) = "${miniAppBasePath}$appId/"
 
     init {
@@ -141,6 +143,8 @@ internal class DownloadedManifestCache(context: Context) {
             null
         }
     }
+
+    fun getManifestFile(miniAppId: String) = File(getManifestPath(miniAppId))
 
     private companion object {
         const val DEFAULT_FILE_NAME = "manifest.txt"

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCache.kt
@@ -24,7 +24,7 @@ internal class DownloadedManifestCache(context: Context) {
 
     private val sdkBasePath = context.filesDir.path
     private val miniAppBasePath = "$sdkBasePath/$SUB_DIR_MINIAPP/"
-    private fun getManifestPath(appId: String) = "${miniAppBasePath}$appId/"
+    fun getManifestPath(appId: String) = "${miniAppBasePath}$appId/"
 
     init {
         migrateToFileStorage()

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/verifier/CachedMiniAppVerifier.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/verifier/CachedMiniAppVerifier.kt
@@ -1,10 +1,7 @@
 package com.rakuten.tech.mobile.miniapp.storage.verifier
 
 import android.content.Context
-import android.util.Base64
-import android.util.Log
 import java.io.File
-import java.security.MessageDigest
 
 internal class CachedMiniAppVerifier(context: Context) {
     private var storeHashVerifier =
@@ -12,39 +9,9 @@ internal class CachedMiniAppVerifier(context: Context) {
 
     /** Verifies that the cached files for the Mini App have not been modified. */
     fun verify(appId: String, directory: File): Boolean =
-        storeHashVerifier.verify(appId, calculateHash(directory))
+        storeHashVerifier.verify(appId, directory)
 
     /** Stores hash in encrypted shared preferences. */
     suspend fun storeHashAsync(appId: String, directory: File) =
-        storeHashVerifier.storeHashAsync(appId, calculateHash(directory))
-
-    @SuppressWarnings("TooGenericExceptionCaught", "LongMethod", "NestedBlockDepth")
-    private fun calculateHash(
-        directory: File
-    ): String = try {
-        val buffer = ByteArray(BUFFER_SIZE)
-        var count: Int
-        val digest = MessageDigest.getInstance("SHA-256")
-
-        directory.walk()
-            .filter { it.isFile }
-            .sortedBy { it.name }
-            .forEach { file ->
-                file.inputStream().use { stream ->
-                    while (stream.read(buffer).also { count = it } > 0) {
-                        digest.update(buffer, 0, count)
-                    }
-                }
-            }
-
-        Base64.encodeToString(digest.digest(), Base64.NO_WRAP)
-    } catch (e: Exception) {
-        Log.e(TAG, "Failed to calculate hash for the Mini App.", e)
-        ""
-    }
-
-    companion object {
-        private val TAG = this::class.simpleName
-        private const val BUFFER_SIZE = 8192
-    }
+        storeHashVerifier.storeHashAsync(appId, directory)
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/verifier/MiniAppManifestVerifier.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/verifier/MiniAppManifestVerifier.kt
@@ -1,34 +1,17 @@
 package com.rakuten.tech.mobile.miniapp.storage.verifier
 
 import android.content.Context
-import android.util.Base64
-import android.util.Log
-import com.rakuten.tech.mobile.miniapp.storage.CachedManifest
-import java.security.MessageDigest
+import java.io.File
 
 internal class MiniAppManifestVerifier(context: Context) {
     private var storeHashVerifier =
         StoreHashVerifier(context, "com.rakuten.tech.mobile.miniapp.manifest.cache.hash")
 
     /** Verifies that the cached data for the Mini App manifest have not been modified. */
-    fun verify(appId: String, cachedManifest: CachedManifest): Boolean =
-        storeHashVerifier.verify(appId, calculateHash(cachedManifest))
-
-    @SuppressWarnings("TooGenericExceptionCaught")
-    private fun calculateHash(cachedManifest: CachedManifest): String = try {
-        val messageDigest = MessageDigest.getInstance("SHA-256")
-        val hashedBytes = messageDigest.digest(cachedManifest.toString().toByteArray(Charsets.UTF_8))
-        Base64.encodeToString(hashedBytes, Base64.NO_WRAP)
-    } catch (e: Exception) {
-        Log.e(TAG, "Failed to calculate hash for the Mini App manifest.", e)
-        ""
-    }
+    fun verify(appId: String, directory: File): Boolean =
+            storeHashVerifier.verify(appId, directory)
 
     /** Stores hash in encrypted shared preferences. */
-    suspend fun storeHashAsync(appId: String, cachedManifest: CachedManifest) =
-        storeHashVerifier.storeHashAsync(appId, calculateHash(cachedManifest))
-
-    companion object {
-        private val TAG = this::class.simpleName
-    }
+    suspend fun storeHashAsync(appId: String, directory: File) =
+            storeHashVerifier.storeHashAsync(appId, directory)
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/verifier/StoreHashVerifier.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/verifier/StoreHashVerifier.kt
@@ -2,6 +2,8 @@ package com.rakuten.tech.mobile.miniapp.storage.verifier
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Base64
+import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
@@ -10,6 +12,8 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
+import java.io.File
+import java.security.MessageDigest
 
 internal class StoreHashVerifier @VisibleForTesting constructor(
     private val prefs: SharedPreferences,
@@ -22,18 +26,48 @@ internal class StoreHashVerifier @VisibleForTesting constructor(
     )
 
     /** Verifies that the cached data has not been modified. */
-    fun verify(appId: String, hash: String): Boolean {
+    fun verify(appId: String, directory: File): Boolean {
+        val hash = calculateHash(directory)
         val storedHash = prefs.getString(appId, null) ?: ""
         return hash == storedHash
     }
 
     /** Stores hash in encrypted shared preferences. This runs asynchronously so it will return immediately. */
-    suspend fun storeHashAsync(appId: String, hash: String) =
+    suspend fun storeHashAsync(appId: String, directory: File) =
         withContext(coroutineDispatcher) {
             async {
+                val hash = calculateHash(directory)
                 prefs.edit().putString(appId, hash).apply()
             }
         }
+
+    @SuppressWarnings("TooGenericExceptionCaught", "LongMethod", "NestedBlockDepth")
+    private fun calculateHash(directory: File): String = try {
+        val buffer = ByteArray(BUFFER_SIZE)
+        var count: Int
+        val digest = MessageDigest.getInstance("SHA-256")
+
+        directory.walk()
+                .filter { it.isFile }
+                .sortedBy { it.name }
+                .forEach { file ->
+                    file.inputStream().use { stream ->
+                        while (stream.read(buffer).also { count = it } > 0) {
+                            digest.update(buffer, 0, count)
+                        }
+                    }
+                }
+
+        Base64.encodeToString(digest.digest(), Base64.NO_WRAP)
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to calculate hash for the Mini App.", e)
+        ""
+    }
+
+    companion object {
+        private val TAG = this::class.simpleName
+        private const val BUFFER_SIZE = 8192
+    }
 }
 
 @SuppressWarnings("SwallowedException", "TooGenericExceptionCaught")

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -1,6 +1,5 @@
 package com.rakuten.tech.mobile.miniapp
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.rakuten.tech.mobile.miniapp.analytics.MiniAppAnalytics
 import com.rakuten.tech.mobile.miniapp.api.*
 import com.rakuten.tech.mobile.miniapp.display.Displayer
@@ -16,10 +15,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.*
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TemporaryFolder
-import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.kotlin.*
 import org.mockito.kotlin.mock
@@ -109,7 +105,6 @@ class RealMiniAppSpec : BaseRealMiniAppSpec() {
         val cachedManifest = CachedManifest(TEST_MA_VERSION_ID, dummyManifest)
         When calling downloadedManifestCache.readDownloadedManifest(TEST_MA_ID) itReturns cachedManifest
         When calling realMiniApp.getMiniAppManifest(TEST_MA_ID, TEST_MA_VERSION_ID) itReturns dummyManifest
-        //When calling manifestVerifier.verify(TEST_MA_ID, cachedManifest) itReturns true
     }
 
     @Test
@@ -277,7 +272,6 @@ class RealMiniAppSpec : BaseRealMiniAppSpec() {
 }
 
 @Suppress("LongMethod")
-@RunWith(AndroidJUnit4::class)
 @ExperimentalCoroutinesApi
 class RealMiniAppManifestSpec : BaseRealMiniAppSpec() {
     private val cachedManifest = CachedManifest(TEST_MA_VERSION_ID, dummyManifest)
@@ -285,18 +279,13 @@ class RealMiniAppManifestSpec : BaseRealMiniAppSpec() {
         TEST_MA_ID,
         listOf(Pair(MiniAppCustomPermissionType.USER_NAME, MiniAppCustomPermissionResult.DENIED))
     )
-
-    @Rule
-    @JvmField
-    val tempFolder = TemporaryFolder()
+    private val file: File = mock()
 
     @Before
     fun before() {
-        val folder = tempFolder.newFolder("mini-app-folder")
-        File(folder, "file1.html").writeText("test content")
-        File(folder, "file2.html").writeText("test content")
         When calling downloadedManifestCache.readDownloadedManifest(TEST_MA_ID) itReturns cachedManifest
-        When calling manifestVerifier.verify(TEST_MA_ID, folder) itReturns true
+        When calling downloadedManifestCache.getManifestFile(TEST_MA_ID) itReturns file
+        When calling manifestVerifier.verify(TEST_MA_ID, file) itReturns true
     }
 
     /** region: Manifest verification */
@@ -360,10 +349,9 @@ class RealMiniAppManifestSpec : BaseRealMiniAppSpec() {
     @Test
     fun `verifyManifest will download api manifest when hash has not been verified`() =
         runBlockingTest {
-
             When calling realMiniApp.getMiniAppManifest(TEST_MA_ID, TEST_MA_VERSION_ID) itReturns dummyManifest
-            //When calling manifestVerifier.verify(TEST_MA_ID, folder) itReturns false
             When calling miniAppCustomPermissionCache.readPermissions(TEST_MA_ID) itReturns deniedPermission
+            When calling manifestVerifier.verify(TEST_MA_ID, file) itReturns false
 
             realMiniApp.verifyManifest(TEST_MA_ID, TEST_MA_VERSION_ID)
 
@@ -378,16 +366,13 @@ class RealMiniAppManifestSpec : BaseRealMiniAppSpec() {
                             Pair(MiniAppCustomPermissionType.CONTACT_LIST, "reason")), listOf(),
                     TEST_ATP_LIST, mapOf(), TEST_MA_VERSION_ID
             )
-            val folder = tempFolder.newFolder("mini-app-folder3")
-            File(folder, "file1.html").writeText("test content")
-            File(folder, "file2.html").writeText("test content")
             val cachedManifest = CachedManifest(TEST_MA_VERSION_ID, manifest)
             val manifestToStore = CachedManifest(TEST_MA_VERSION_ID, dummyManifest)
             When calling realMiniApp.getMiniAppManifest(TEST_MA_ID, TEST_MA_VERSION_ID) itReturns dummyManifest
             realMiniApp.checkToDownloadManifest(TEST_MA_ID, TEST_MA_VERSION_ID, cachedManifest)
 
             verify(downloadedManifestCache).storeDownloadedManifest(TEST_MA_ID, manifestToStore)
-            verify(manifestVerifier).storeHashAsync(TEST_MA_ID, folder)
+            verify(manifestVerifier).storeHashAsync(TEST_MA_ID, file)
         }
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/DownloadedManifestCacheSpec.kt
@@ -147,6 +147,12 @@ class DownloadedManifestCacheSpec {
         DownloadedManifestCache(mockContext).getAccessTokenPermissions(TEST_MA_ID) shouldEqual emptyList()
     }
 
+    @Test
+    fun `getManifestFile should invoke with manifest file path`() {
+        manifestCache.getManifestFile(TEST_MA_ID)
+        verify(manifestCache).getManifestPath(TEST_MA_ID)
+    }
+
     private fun createCustomPermission(isAllowed: Boolean): MiniAppCustomPermission {
         val list = arrayListOf<Pair<MiniAppCustomPermissionType, MiniAppCustomPermissionResult>>()
         if (isAllowed) list.add(

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/verifier/StoreHashVerifierSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/verifier/StoreHashVerifierSpec.kt
@@ -3,41 +3,75 @@ package com.rakuten.tech.mobile.miniapp.storage.verifier
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.rakuten.tech.mobile.miniapp.MiniAppVerificationException
-import com.rakuten.tech.mobile.miniapp.TEST_MA_ID
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
-import org.amshove.kluent.shouldBe
+import org.amshove.kluent.*
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
+import java.io.File
 
 @RunWith(AndroidJUnit4::class)
 @ExperimentalCoroutinesApi
 class StoreHashVerifierSpec {
+
+    @Rule
+    @JvmField
+    val tempFolder = TemporaryFolder()
+
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val prefs = context.getSharedPreferences("test-cache", Context.MODE_PRIVATE)
     private val dispatcher = TestCoroutineDispatcher()
+
     private val verifier = StoreHashVerifier(prefs, dispatcher)
+    private val id = "test-miniapp-id"
 
     @Test
-    fun `should verify hash for data`() = runBlockingTest {
-        val hash = "hash-data"
-        verifier.storeHashAsync(TEST_MA_ID, hash)
-        verifier.verify(TEST_MA_ID, hash) shouldBe true
+    fun `should verify hash for files`() = runBlockingTest {
+        val folder = tempFolder.newFolder("mini-app-folder")
+        File(folder, "file1.html").writeText("test content")
+        File(folder, "file2.html").writeText("test content")
+
+        verifier.storeHashAsync(id, folder)
+
+        verifier.verify(id, folder) shouldBe true
     }
 
     @Test
-    fun `should fail to verify hash when data has been modified`() = runBlockingTest {
-        var hash = "hash-data"
-        verifier.storeHashAsync(TEST_MA_ID, hash)
-        hash = "another-hash-data"
-        verifier.verify(TEST_MA_ID, hash) shouldBe false
+    fun `should fail to verify hash when files have been modified`() = runBlockingTest {
+        val folder = tempFolder.newFolder("mini-app-folder")
+        val file = File(folder, "file1.html")
+        file.writeText("test content")
+
+        verifier.storeHashAsync(id, folder)
+        file.writeText("modified content")
+
+        verifier.verify(id, folder) shouldBe false
     }
 
-    @Test(expected = MiniAppVerificationException::class)
-    fun `should throw exception when there is problem with device keystore`() {
-        // cannot retrieve key store from test context.
-        StoreHashVerifier(context, "")
+    @Test
+    fun `should fail to verify hash when files in subdirectories have been modified`() = runBlockingTest {
+        val folder = tempFolder.newFolder("mini-app-folder", "sub-folder")
+        val file = File(folder, "file1.html")
+        file.writeText("test content")
+
+        verifier.storeHashAsync(id, folder)
+        file.writeText("modified content")
+
+        verifier.verify(id, folder) shouldBe false
+    }
+
+    @Test
+    fun `should fail to verify hash when mini app files are deleted`() = runBlockingTest {
+        val folder = tempFolder.newFolder("mini-app-folder")
+        val file = File(folder, "file1.html")
+        file.writeText("test content")
+
+        verifier.storeHashAsync(id, folder)
+        folder.deleteRecursively()
+
+        verifier.verify(id, folder) shouldBe false
     }
 }


### PR DESCRIPTION
# Description
Manifest verification has been added previously in https://github.com/rakutentech/android-miniapp/pull/305 where `MiniAppManifestVerifier` was introduced. After finishing of MINI-2945, this PR aims to refactor the verification process with manifest files. Mainly, `MiniAppManifestVerifier` will use the functions of `StoreHashVerifier` same like `CachedMiniAppVerifier`.

## Links
- MINI-2947

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
