### PR TITLE
[MINI-3240] add user point error 

### DIFF
--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -335,16 +335,16 @@ val userInfoBridgeDispatcher = object : UserInfoBridgeDispatcher {
     }
 
     override fun getPoints(
-            onSuccess: (points: Points) -> Unit,
-            onError: (message: String) -> Unit
-        ) {
-            // Check if there is any points in HostApp
-            // .. .. ..
-            if (hasPoints)
-                onSuccess(points) // allow miniapp to get points.
-            else
-                onError(message) // reject miniapp to get points with message explanation.
-        }
+        onSuccess: (points: Points) -> Unit,
+        onError: (pointsError: MiniAppPointsError) -> Unit
+    ) {
+        // Check if there is any point in HostApp
+        // .. .. ..
+        if (hasPoints)
+            onSuccess(points) // allow miniapp to get points.
+        else
+            onError(pointsError) // reject miniapp to get points with message explanation.
+    }
 }
 
 // set UserInfoBridgeDispatcher object to miniAppMessageBridge

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppPointsError.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppPointsError.kt
@@ -1,0 +1,16 @@
+package com.rakuten.tech.mobile.miniapp.errors
+
+/**
+ * A class to provide the custom errors specific for user's points.
+ */
+class MiniAppPointsError(val type: String? = null, val message: String? = null) :
+    MiniAppBridgeError(type, message) {
+
+    companion object {
+        /**
+         *  send custom error message from host app.
+         *  @property message error message send to mini app.
+         */
+        fun custom(message: String) = MiniAppPointsError(message = message)
+    }
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridge.kt
@@ -5,6 +5,7 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppAccessTokenError
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppBridgeErrorModel
+import com.rakuten.tech.mobile.miniapp.errors.MiniAppPointsError
 import com.rakuten.tech.mobile.miniapp.js.CallbackObj
 import com.rakuten.tech.mobile.miniapp.js.ErrorBridgeMessage.NO_IMPL
 import com.rakuten.tech.mobile.miniapp.js.MiniAppBridgeExecutor
@@ -198,8 +199,8 @@ internal class UserInfoBridge {
                 val successCallback = { points: Points ->
                     bridgeExecutor.postValue(callbackId, Gson().toJson(points))
                 }
-                val errorCallback = { message: String ->
-                    val errorBridgeModel = MiniAppBridgeErrorModel("$ERR_GET_POINTS $message")
+                val errorCallback = { callback: MiniAppPointsError ->
+                    val errorBridgeModel = MiniAppBridgeErrorModel(callback.type, callback.message)
                     bridgeExecutor.postError(callbackId, Gson().toJson(errorBridgeModel))
                 }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeDispatcher.kt
@@ -2,6 +2,7 @@ package com.rakuten.tech.mobile.miniapp.js.userinfo
 
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppAccessTokenError
+import com.rakuten.tech.mobile.miniapp.errors.MiniAppPointsError
 import com.rakuten.tech.mobile.miniapp.js.ErrorBridgeMessage.NO_IMPL
 import com.rakuten.tech.mobile.miniapp.permission.AccessTokenScope
 import java.util.ArrayList
@@ -93,7 +94,7 @@ interface UserInfoBridgeDispatcher {
      */
     fun getPoints(
         onSuccess: (points: Points) -> Unit,
-        onError: (message: String) -> Unit
+        onError: (pointsError: MiniAppPointsError) -> Unit
     ) {
         throw MiniAppSdkException(NO_IMPL)
     }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
@@ -539,11 +539,15 @@ class UserInfoBridgeSpec {
     private val points = Points(0, 0, 0)
     private val testPointsError = MiniAppPointsError(null, "$ERR_GET_POINTS $TEST_ERROR_MSG")
     private fun createPointsImpl(
-        hasGetPoints: Boolean, canGetPoints: Boolean
+        hasGetPoints: Boolean,
+        canGetPoints: Boolean
     ): UserInfoBridgeDispatcher {
         return if (hasGetPoints) {
             object : UserInfoBridgeDispatcher {
-                override fun getPoints(onSuccess: (points: Points) -> Unit, onError: (pointsError: MiniAppPointsError) -> Unit) {
+                override fun getPoints(
+                    onSuccess: (points: Points) -> Unit,
+                    onError: (pointsError: MiniAppPointsError) -> Unit
+                ) {
                     if (canGetPoints)
                         onSuccess.invoke(points)
                     else

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.ads.AdMobDisplayer
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppAccessTokenError
+import com.rakuten.tech.mobile.miniapp.errors.MiniAppPointsError
 import com.rakuten.tech.mobile.miniapp.file.MiniAppFileChooserDefault
 import com.rakuten.tech.mobile.miniapp.js.MessageToContact
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
@@ -222,11 +223,11 @@ class MiniAppDisplayActivity : BaseActivity() {
 
             override fun getPoints(
                 onSuccess: (points: Points) -> Unit,
-                onError: (message: String) -> Unit
+                onError: (pointsError: MiniAppPointsError) -> Unit
             ) {
                 val points = AppSettings.instance.points
                 if (points != null) onSuccess(points)
-                else onError("There is no points found in HostApp.")
+                else onError(MiniAppPointsError(null, "There is no points found in HostApp."))
             }
         }
         miniAppMessageBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -227,7 +227,7 @@ class MiniAppDisplayActivity : BaseActivity() {
             ) {
                 val points = AppSettings.instance.points
                 if (points != null) onSuccess(points)
-                else onError(MiniAppPointsError(null, "There is no points found in HostApp."))
+                else onError(MiniAppPointsError.custom("There is no points found in HostApp."))
             }
         }
         miniAppMessageBridge.setUserInfoBridgeDispatcher(userInfoBridgeDispatcher)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/PointsActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/PointsActivity.kt
@@ -43,7 +43,9 @@ class PointsActivity : BaseActivity() {
                 return true
             }
             R.id.settings_menu_save -> {
-                update()
+                updatePreferences()
+                hideSoftKeyboard(binding.root)
+                finish()
                 return true
             }
             else -> super.onOptionsItemSelected(item)
@@ -55,15 +57,20 @@ class PointsActivity : BaseActivity() {
         settings.points?.standard?.let { binding.edtPointStandard.setText(it.toString()) }
         settings.points?.term?.let { binding.edtPointTimeLimited.setText(it.toString()) }
         settings.points?.cash?.let { binding.edtPointRakutenCash.setText(it.toString()) }
+        updatePreferences()
     }
 
-    private fun update() {
+    private fun updatePreferences() {
+        var pointStandard = edtPointStandard.text.toString()
+        if (pointStandard == "") pointStandard = "0"
+        var pointTimeLimited = edtPointTimeLimited.text.toString()
+        if (pointTimeLimited == "") pointTimeLimited = "0"
+        var pointRakutenCash = edtPointRakutenCash.text.toString()
+        if (pointRakutenCash == "") pointRakutenCash = "0"
         settings.points = Points(
-                edtPointStandard.text.toString().toInt(),
-                edtPointTimeLimited.text.toString().toInt(),
-                edtPointRakutenCash.text.toString().toInt()
+                pointStandard.toInt(),
+                pointTimeLimited.toInt(),
+                pointRakutenCash.toInt()
         )
-        hideSoftKeyboard(binding.root)
-        finish()
     }
 }

--- a/testapp/src/main/res/layout/points_activity.xml
+++ b/testapp/src/main/res/layout/points_activity.xml
@@ -21,7 +21,8 @@
                 android:layout_height="wrap_content"
                 android:hint="@string/hint_points_standard"
                 android:imeOptions="actionDone"
-                android:inputType="number" />
+                android:inputType="number"
+                android:text="@string/hint_points_default_value" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
@@ -38,7 +39,8 @@
                 android:layout_height="wrap_content"
                 android:hint="@string/hint_points_time_limited"
                 android:imeOptions="actionDone"
-                android:inputType="number" />
+                android:inputType="number"
+                android:text="@string/hint_points_default_value" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
@@ -54,7 +56,8 @@
                 android:layout_height="wrap_content"
                 android:hint="@string/hint_points_rakuten_cash"
                 android:imeOptions="actionDone"
-                android:inputType="number" />
+                android:inputType="number"
+                android:text="@string/hint_points_default_value" />
         </com.google.android.material.textfield.TextInputLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="hint_points_standard">Points (Standard)</string>
     <string name="hint_points_time_limited">Points (Time-Limited)</string>
     <string name="hint_points_rakuten_cash">Points (Rakuten Cash)</string>
+    <string name="hint_points_default_value">0</string>
 
     <string name="menu_title_search">Search</string>
     <string name="menu_title_settings">Settings</string>


### PR DESCRIPTION
# Description
Primary work of user's point interface has been added by https://github.com/rakutentech/android-miniapp/pull/331.
This PR aims to add `MiniAppPointsError` for sending it to the mini-apps.

## Links
- MINI-3240

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors