### PR TITLE
fix: Tel scheme url in Android 11

### DIFF
--- a/miniapp/src/main/AndroidManifest.xml
+++ b/miniapp/src/main/AndroidManifest.xml
@@ -21,4 +21,10 @@
             android:initOrder="100"
             tools:replace="android:initOrder" />
     </application>
+
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.DIAL" />
+        </intent>
+    </queries>
 </manifest>


### PR DESCRIPTION
# Description
Tel scheme link is not working in Android 11. Basically, `MiniAppScheme.openPhoneDialer` intent has no issue, but in `MiniAppScheme.startExportedActivity` while the `android.intent.action.DIAL` is trying to resolve the `packageManager` - it's getting blocked due to restriction in Android 11.  This PR aims to fix this issue by adding `<queries>...</queries>` element in manifest. 

reference: https://developer.android.com/training/package-visibility/declaring

## Links
- MINI-3524

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
