### PR TITLE
MINI-3934: Pop-up should not disappear when we are passing Contact inputs as empty.

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactListActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactListActivity.kt
@@ -119,9 +119,9 @@ class ContactListActivity : BaseActivity(), ContactListener {
                     val contact = Contact(id = id, name = name, email = email)
                     if (isUpdate) position?.let { adapter.updateContact(it, contact) }
                     else adapter.addContact(adapter.itemCount, contact)
-                }
 
-                this.dialog?.cancel()
+                    this.dialog?.cancel()
+                }
             })
         }.show()
     }


### PR DESCRIPTION
# Description
Close the contact input dialog only after all conditions are verified while adding / updating contact.

## Links
- MINI-3934

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data before every commit, including API endpoints and keys
- [X] I ran `./gradlew check` without errors
