### PR TITLE
MINI-3418: Adopt Signature Verifier SDK in MiniApp SDK

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/RealSignatureVerifier.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/RealSignatureVerifier.kt
@@ -17,8 +17,8 @@ import java.security.spec.ECPoint
 import java.security.spec.ECPublicKeySpec
 
 internal class RealSignatureVerifier(
-        private val cache: PublicKeyCache,
-        private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val cache: PublicKeyCache,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : SignatureVerifier() {
 
     @SuppressWarnings("LabeledExpression")

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/RealSignatureVerifier.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/RealSignatureVerifier.kt
@@ -1,0 +1,82 @@
+package com.rakuten.tech.mobile.miniapp.signatureverifier
+
+import android.util.Base64
+import com.rakuten.tech.mobile.miniapp.signatureverifier.verification.PublicKeyCache
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.InputStream
+import java.math.BigInteger
+import java.security.KeyFactory
+import java.security.KeyPairGenerator
+import java.security.Signature
+import java.security.interfaces.ECPublicKey
+import java.security.spec.ECGenParameterSpec
+import java.security.spec.ECParameterSpec
+import java.security.spec.ECPoint
+import java.security.spec.ECPublicKeySpec
+
+internal class RealSignatureVerifier(
+        private val cache: PublicKeyCache,
+        private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+) : SignatureVerifier() {
+
+    @SuppressWarnings("LabeledExpression")
+    override suspend fun verify(publicKeyId: String, data: InputStream, signature: String) =
+            withContext(dispatcher) {
+                // always return false when EncryptedSharedPreferences was not initialized
+                // due to keystore validation.
+                val key = cache[publicKeyId] ?: return@withContext false
+
+                val isVerified = Signature.getInstance("SHA256withECDSA").apply {
+                    initVerify(rawToEncodedECPublicKey(key))
+
+                    val buffer = ByteArray(SIXTEEN_KILOBYTES)
+                    var read = data.read(buffer)
+                    while (read != -1) {
+                        update(buffer, 0, read)
+
+                        read = data.read(buffer)
+                    }
+                }.verify(Base64.decode(signature, Base64.DEFAULT))
+
+                if (!isVerified) {
+                    cache.remove(publicKeyId)
+                }
+
+                isVerified
+            }
+
+    private fun rawToEncodedECPublicKey(key: String): ECPublicKey {
+        val parameters = ecParameterSpecForCurve("secp256r1")
+        val keySizeBytes = parameters.order.bitLength() / java.lang.Byte.SIZE
+        val pubKey = Base64.decode(key, Base64.DEFAULT)
+
+        // First Byte represents compressed/uncompressed status
+        // We're expecting it to always be uncompressed (04)
+        var offset = UNCOMPRESSED_OFFSET
+        val x = BigInteger(POSITIVE_BIG_INTEGER, pubKey.copyOfRange(offset, offset + keySizeBytes))
+
+        offset += keySizeBytes
+        val y = BigInteger(POSITIVE_BIG_INTEGER, pubKey.copyOfRange(offset, offset + keySizeBytes))
+
+        val keySpec = ECPublicKeySpec(ECPoint(x, y), parameters)
+        val keyFactory = KeyFactory.getInstance("EC")
+        return keyFactory
+                .generatePublic(keySpec) as ECPublicKey
+    }
+
+    private fun ecParameterSpecForCurve(curveName: String): ECParameterSpec {
+        val kpg = KeyPairGenerator.getInstance("EC")
+        kpg.initialize(ECGenParameterSpec(curveName))
+
+        return (kpg.generateKeyPair().public as ECPublicKey).params
+    }
+
+    companion object {
+        private const val SIXTEEN_KILOBYTES = 16 * 1024
+
+        private const val UNCOMPRESSED_OFFSET = 1
+        private const val POSITIVE_BIG_INTEGER = 1
+    }
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/SignatureVerifier.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/SignatureVerifier.kt
@@ -1,0 +1,73 @@
+package com.rakuten.tech.mobile.miniapp.signatureverifier
+
+import android.content.Context
+import com.rakuten.tech.mobile.miniapp.signatureverifier.api.ApiClient
+import com.rakuten.tech.mobile.miniapp.signatureverifier.api.PublicKeyFetcher
+import com.rakuten.tech.mobile.miniapp.signatureverifier.verification.PublicKeyCache
+import java.io.InputStream
+
+/**
+ * Main entry point for the Signature Verifier SDK.
+ * Should be accessed via [SignatureVerifier.instance].
+ */
+@Suppress("UnnecessaryAbstractClass")
+abstract class SignatureVerifier {
+
+    /**
+     * Verifies the [signature] of the [data] using the [publicKeyId].
+     *
+     * @return true if [signature] associated with [data] is valid.
+     */
+    abstract suspend fun verify(publicKeyId: String, data: InputStream, signature: String): Boolean
+
+    companion object {
+        internal var callback: ((ex: Exception) -> Unit)? = null
+
+        /**
+         * Initializes an instance of the Signature Verifier SDK based on the provided parameters.
+         *
+         * @param [context] application context
+         * @param [baseUrl] endpoint used for public key fetching
+         * @param [subscriptionKey] authorization key for the public key fetching endpoint
+         * @param [errorCallback] optional callback function for app to receive any exception occurred in the SDK.
+         *
+         * @return `instance` if initialization is successful, and `null` otherwise.
+         */
+        @SuppressWarnings("LongMethod", "TooGenericExceptionCaught")
+        fun init(
+                context: Context,
+                baseUrl: String,
+                subscriptionKey: String,
+                errorCallback: ((ex: Exception) -> Unit)? = null
+        ): SignatureVerifier? {
+            callback = errorCallback
+            return try {
+
+                val client = ApiClient(
+                        baseUrl = baseUrl,
+                        subscriptionKey = subscriptionKey,
+                        context = context
+                )
+
+                RealSignatureVerifier(
+                        PublicKeyCache(
+                                keyFetcher = PublicKeyFetcher(client),
+                                context = context,
+                                baseUrl = baseUrl
+                        )
+                )
+            } catch (ex: Exception) {
+                callback?.let {
+                    it(SignatureVerifierException("Signature Verifier initialization failed", ex))
+                }
+                null
+            }
+        }
+    }
+}
+
+/**
+ * Custom exception for Signature Verifier SDK.
+ */
+class SignatureVerifierException(name: String, cause: Throwable? = null) :
+        RuntimeException(name, cause)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/SignatureVerifier.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/SignatureVerifier.kt
@@ -11,7 +11,7 @@ import java.io.InputStream
  * Should be accessed via [SignatureVerifier.instance].
  */
 @Suppress("UnnecessaryAbstractClass", "ParameterListWrapping")
-abstract class SignatureVerifier {
+internal abstract class SignatureVerifier {
 
     /**
      * Verifies the [signature] of the [data] using the [publicKeyId].
@@ -21,7 +21,7 @@ abstract class SignatureVerifier {
     abstract suspend fun verify(publicKeyId: String, data: InputStream, signature: String): Boolean
 
     companion object {
-        internal var callback: ((ex: Exception) -> Unit)? = null
+        var callback: ((ex: Exception) -> Unit)? = null
 
         /**
          * Initializes an instance of the Signature Verifier SDK based on the provided parameters.
@@ -69,5 +69,5 @@ abstract class SignatureVerifier {
 /**
  * Custom exception for Signature Verifier SDK.
  */
-class SignatureVerifierException(name: String, cause: Throwable? = null) :
+internal class SignatureVerifierException(name: String, cause: Throwable? = null) :
         RuntimeException(name, cause)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/SignatureVerifier.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/SignatureVerifier.kt
@@ -10,7 +10,7 @@ import java.io.InputStream
  * Main entry point for the Signature Verifier SDK.
  * Should be accessed via [SignatureVerifier.instance].
  */
-@Suppress("UnnecessaryAbstractClass")
+@Suppress("UnnecessaryAbstractClass", "ParameterListWrapping")
 abstract class SignatureVerifier {
 
     /**
@@ -35,10 +35,10 @@ abstract class SignatureVerifier {
          */
         @SuppressWarnings("LongMethod", "TooGenericExceptionCaught")
         fun init(
-                context: Context,
-                baseUrl: String,
-                subscriptionKey: String,
-                errorCallback: ((ex: Exception) -> Unit)? = null
+            context: Context,
+            baseUrl: String,
+            subscriptionKey: String,
+            errorCallback: ((ex: Exception) -> Unit)? = null
         ): SignatureVerifier? {
             callback = errorCallback
             return try {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/api/ApiClient.kt
@@ -1,0 +1,68 @@
+package com.rakuten.tech.mobile.miniapp.signatureverifier.api
+
+import android.content.Context
+import okhttp3.Cache
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import java.lang.IllegalArgumentException
+
+internal class ApiClient(baseUrl: String, subscriptionKey: String, context: Context) {
+
+    init {
+        if (subscriptionKey.isEmpty()) {
+            throw InvalidSignatureVerifierSubscriptionException()
+        }
+    }
+
+    @Suppress("SpreadOperator")
+    private val client = OkHttpClient.Builder()
+            .cache(Cache(context.cacheDir,
+                    CACHE_SIZE
+            ))
+            .addNetworkInterceptor {
+                val requestBuilder = it.request().newBuilder()
+                requestBuilder.addHeader("apiKey", "ras-$subscriptionKey")
+                it.proceed(requestBuilder.build())
+            }
+            .build()
+
+    private val requestUrl = try {
+        baseUrl.toHttpUrl()
+    } catch (exception: IllegalArgumentException) {
+        throw InvalidSignatureVerifierBaseUrlException(exception)
+    }
+
+    fun fetchPath(path: String, paramMap: Map<String, String>?): Response {
+        val builder = requestUrl.newBuilder().addPathSegments(path)
+
+        if (paramMap != null) {
+            for ((k, v) in paramMap) {
+                if (v.isNotEmpty() && k.isNotEmpty()) builder.addQueryParameter(k, v)
+            }
+        }
+
+        return client.newCall(Request.Builder()
+                .url(builder.build())
+                .build()
+        ).execute()
+    }
+
+    companion object {
+        private const val CACHE_SIZE = 1024 * 1024 * 2L
+    }
+}
+
+/**
+ * Exception thrown when endpoint is not a valid URL.
+ */
+class InvalidSignatureVerifierBaseUrlException(
+        exception: IllegalArgumentException
+) : IllegalArgumentException("An invalid URL was provided for the Signature Verifier base url.", exception)
+
+/**
+ * Exception thrown when subscription key is not a valid.
+ */
+class InvalidSignatureVerifierSubscriptionException :
+        IllegalArgumentException("An invalid value was provided for the Signature Verifier subscription key.")

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/api/ApiClient.kt
@@ -58,7 +58,7 @@ internal class ApiClient(baseUrl: String, subscriptionKey: String, context: Cont
  * Exception thrown when endpoint is not a valid URL.
  */
 class InvalidSignatureVerifierBaseUrlException(
-        exception: IllegalArgumentException
+    exception: IllegalArgumentException
 ) : IllegalArgumentException("An invalid URL was provided for the Signature Verifier base url.", exception)
 
 /**

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/api/PublicKeyFetcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/api/PublicKeyFetcher.kt
@@ -1,0 +1,43 @@
+package com.rakuten.tech.mobile.miniapp.signatureverifier.api
+
+import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
+import java.io.IOException
+
+internal class PublicKeyFetcher(private val client: ApiClient) {
+
+    @Throws(IOException::class)
+    fun fetch(keyId: String): String {
+        val response = client.fetchPath(keyId, null)
+
+        if (!response.isSuccessful) {
+            throw IOException("Unexpected response when fetching public key: $response")
+        }
+
+        val body = response.body!!.string() // Body is never null if request is successful
+
+        return PublicKeyResponse.fromJsonString(body).ecKey
+    }
+}
+
+internal data class PublicKeyResponse(
+        val id: String = "",
+        val ecKey: String = "",
+        val pemKey: String = ""
+) {
+    companion object {
+        @SuppressWarnings("SwallowedException")
+        fun fromJsonString(body: String): PublicKeyResponse {
+            return try {
+                val response = Gson().fromJson(body, PublicKeyResponse::class.java)
+                if (response.id.isEmpty()) {
+                    PublicKeyResponse()
+                } else {
+                    response
+                }
+            } catch (jex: JsonSyntaxException) {
+                PublicKeyResponse()
+            }
+        }
+    }
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/api/PublicKeyFetcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/api/PublicKeyFetcher.kt
@@ -21,9 +21,9 @@ internal class PublicKeyFetcher(private val client: ApiClient) {
 }
 
 internal data class PublicKeyResponse(
-        val id: String = "",
-        val ecKey: String = "",
-        val pemKey: String = ""
+    val id: String = "",
+    val ecKey: String = "",
+    val pemKey: String = ""
 ) {
     companion object {
         @SuppressWarnings("SwallowedException")

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/verification/AesEncryptor.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/verification/AesEncryptor.kt
@@ -19,8 +19,8 @@ import javax.crypto.spec.GCMParameterSpec
 
 @SuppressWarnings("TooGenericExceptionCaught")
 internal class AesEncryptor @VisibleForTesting constructor(
-        private val keyStore: KeyStore?,
-        private val keyGenerator: AesKeyGenerator
+    private val keyStore: KeyStore?,
+    private val keyGenerator: AesKeyGenerator
 ) {
 
     constructor() : this(
@@ -105,8 +105,8 @@ internal class AesEncryptor @VisibleForTesting constructor(
 
 @RequiresApi(Build.VERSION_CODES.M)
 internal class AesKeyGenerator(
-        private val alias: String,
-        private val provider: String
+    private val alias: String,
+    private val provider: String
 ) {
 
     @SuppressWarnings("TooGenericExceptionCaught")
@@ -137,8 +137,8 @@ internal class AesKeyGenerator(
 }
 
 internal data class AesEncryptedData(
-        val iv: String,
-        val encryptedData: String
+    val iv: String,
+    val encryptedData: String
 ) {
 
     fun toJsonString(): String = Gson().toJson(this)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/verification/AesEncryptor.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/verification/AesEncryptor.kt
@@ -1,0 +1,156 @@
+package com.rakuten.tech.mobile.miniapp.signatureverifier.verification
+
+import android.os.Build
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.annotation.VisibleForTesting
+import com.google.gson.Gson
+import com.google.gson.JsonParseException
+import com.rakuten.tech.mobile.miniapp.signatureverifier.SignatureVerifier
+import java.security.KeyStore
+import java.security.KeyStoreException
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+@SuppressWarnings("TooGenericExceptionCaught")
+internal class AesEncryptor @VisibleForTesting constructor(
+        private val keyStore: KeyStore?,
+        private val keyGenerator: AesKeyGenerator
+) {
+
+    constructor() : this(
+            keyStore = try {
+                KeyStore.getInstance("AndroidKeyStore")
+            } catch (ke: KeyStoreException) {
+                Log.d(TAG, "Error generating keystore", ke)
+                null
+            },
+            keyGenerator = AesKeyGenerator(alias = KEYSTORE_ALIAS, provider = "AndroidKeyStore")
+    )
+
+    private val encryptionKey
+        get() = (
+                try {
+                    keyStore?.getEntry(KEYSTORE_ALIAS, null) as KeyStore.SecretKeyEntry?
+                } catch (e: ClassCastException) {
+                    // Key wasn't an AES key, so we need to generate a new one
+                    Log.d(TAG, "Error retrieving key from KeyStore, will be generate new key.", e)
+                    SignatureVerifier.callback?.let { it(e) }
+                    null
+                }
+                )?.secretKey ?: keyGenerator.generateKey()
+
+    init {
+        try {
+            keyStore?.load(null)
+        } catch (ex: Exception) {
+            Log.d(TAG, "Error loading the keystore", ex)
+            SignatureVerifier.callback?.let { it(ex) }
+        }
+    }
+
+    fun encrypt(data: String, cipher: Cipher = Cipher.getInstance(CIPHER_TRANSFORMATION)): String? {
+        val key = encryptionKey // so key will only be generated once call
+        if (key != null) {
+            try {
+                cipher.init(Cipher.ENCRYPT_MODE, key)
+                val encryptedData = cipher.doFinal(data.toByteArray(Charsets.UTF_8))
+
+                return AesEncryptedData(
+                        Base64.encodeToString(cipher.iv, Base64.DEFAULT),
+                        Base64.encodeToString(encryptedData, Base64.DEFAULT)
+                ).toJsonString()
+            } catch (e: Exception) {
+                Log.d(TAG, "Error encrypting the data", e)
+                SignatureVerifier.callback?.let { it(e) }
+            }
+        }
+
+        return null
+    }
+
+    fun decrypt(data: String, cipher: Cipher = Cipher.getInstance(CIPHER_TRANSFORMATION)): String? {
+        val key = encryptionKey // so key will only be generated once per call
+        if (key != null) {
+            try {
+                val (iv, encryptedData) = AesEncryptedData.fromJsonString(data)
+
+                val spec = GCMParameterSpec(GCM_TAG_LENGTH, Base64.decode(iv, Base64.DEFAULT))
+                cipher.init(Cipher.DECRYPT_MODE, key, spec)
+
+                val decryptedData = cipher.doFinal(Base64.decode(encryptedData, Base64.DEFAULT))
+
+                return String(decryptedData)
+            } catch (e: Exception) {
+                Log.d(TAG, "Error decrypting the data", e)
+                SignatureVerifier.callback?.let { it(e) }
+            }
+        }
+
+        return null
+    }
+
+    companion object {
+        private const val TAG = "RSV_AES"
+        private const val KEYSTORE_ALIAS = "signature-verifier-public-key-encryption-decryption"
+        private const val CIPHER_TRANSFORMATION = "AES/GCM/NoPadding"
+        private const val GCM_TAG_LENGTH = 128
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.M)
+internal class AesKeyGenerator(
+        private val alias: String,
+        private val provider: String
+) {
+
+    @SuppressWarnings("TooGenericExceptionCaught")
+    fun generateKey(): SecretKey? {
+        return try {
+            val algorithmSpec = KeyGenParameterSpec.Builder(alias, PURPOSE)
+                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                    .setRandomizedEncryptionRequired(true)
+                    .build()
+
+            val keyGenerator =
+                    KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, provider)
+
+            keyGenerator.init(algorithmSpec)
+            keyGenerator.generateKey()
+        } catch (e: Exception) {
+            Log.d(TAG, "Error generating the secret key", e)
+            SignatureVerifier.callback?.let { it(e) }
+            null
+        }
+    }
+
+    companion object {
+        private const val TAG = "RSV_AesKeyGenerator"
+        private const val PURPOSE = KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+    }
+}
+
+internal data class AesEncryptedData(
+        val iv: String,
+        val encryptedData: String
+) {
+
+    fun toJsonString(): String = Gson().toJson(this)
+
+    companion object {
+        private const val TAG = "RSV_AesEncryptedData"
+        fun fromJsonString(body: String): AesEncryptedData = try {
+            Gson().fromJson(body, AesEncryptedData::class.java)
+        } catch (ex: JsonParseException) {
+            Log.d(TAG, ex.localizedMessage, ex)
+            SignatureVerifier.callback?.let { it(ex) }
+            AesEncryptedData("", "")
+        }
+    }
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/verification/PublicKeyCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/verification/PublicKeyCache.kt
@@ -1,0 +1,86 @@
+package com.rakuten.tech.mobile.miniapp.signatureverifier.verification
+
+import android.content.Context
+import androidx.annotation.VisibleForTesting
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.rakuten.tech.mobile.miniapp.signatureverifier.SignatureVerifier
+import com.rakuten.tech.mobile.miniapp.signatureverifier.api.PublicKeyFetcher
+import java.io.File
+
+internal class PublicKeyCache(
+        private val keyFetcher: PublicKeyFetcher,
+        context: Context,
+        baseUrl: String,
+        encryptor: AesEncryptor? = null,
+        testKeys: MutableMap<String, String>? = null
+) {
+
+    private val encryptor: AesEncryptor by lazy { encryptor ?: AesEncryptor() }
+
+    private val file: File by lazy {
+        // replace all non-alphanumeric characters to '.':
+        // - multiple/group of non-alphanumeric will be replace by one '.'
+        // - trailing period is removed
+        val filepath = baseUrl.replace(Regex("[^a-zA-Z0-9]+"), ".").replace(Regex(".$"), "")
+        File(
+                context.noBackupFilesDir,
+                ("signature.keys.$filepath").take(MAX_PATH)
+        )
+    }
+
+    @VisibleForTesting
+    internal val keys: MutableMap<String, String> by lazy {
+        testKeys
+                ?: if (file.exists()) {
+                    val text = file.readText()
+
+                    if (text.isNotBlank()) {
+                        val type = object : TypeToken<MutableMap<String, String>>() {}.type
+                        Gson().fromJson(text, type)
+                    } else {
+                        mutableMapOf()
+                    }
+                } else {
+                    mutableMapOf()
+                }
+    }
+
+    operator fun get(keyId: String): String? {
+        val encryptedKey = keys[keyId]
+
+        return if (encryptedKey != null) {
+            encryptor.decrypt(encryptedKey) ?: fetch(keyId)
+        } else {
+            fetch(keyId)
+        }
+    }
+
+    fun remove(keyId: String) {
+        keys.remove(keyId)
+
+        file.writeText(Gson().toJson(keys))
+    }
+
+    @SuppressWarnings("TooGenericExceptionCaught")
+    private fun fetch(keyId: String): String? {
+        val key = try {
+            keyFetcher.fetch(keyId)
+        } catch (ex: Exception) {
+            SignatureVerifier.callback?.let { it(ex) }
+            null
+        }
+        if (!key.isNullOrEmpty()) {
+            encryptor.encrypt(key)?.let {
+                keys[keyId] = it
+                file.writeText(Gson().toJson(keys))
+            }
+        }
+
+        return key
+    }
+
+    companion object {
+        private const val MAX_PATH = 100
+    }
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/verification/PublicKeyCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/verification/PublicKeyCache.kt
@@ -9,11 +9,11 @@ import com.rakuten.tech.mobile.miniapp.signatureverifier.api.PublicKeyFetcher
 import java.io.File
 
 internal class PublicKeyCache(
-        private val keyFetcher: PublicKeyFetcher,
-        context: Context,
-        baseUrl: String,
-        encryptor: AesEncryptor? = null,
-        testKeys: MutableMap<String, String>? = null
+    private val keyFetcher: PublicKeyFetcher,
+    context: Context,
+    baseUrl: String,
+    encryptor: AesEncryptor? = null,
+    testKeys: MutableMap<String, String>? = null
 ) {
 
     private val encryptor: AesEncryptor by lazy { encryptor ?: AesEncryptor() }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RobolectricBaseSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RobolectricBaseSpec.kt
@@ -1,0 +1,11 @@
+package com.rakuten.tech.mobile.miniapp
+
+import org.junit.Ignore
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+@Ignore("base class")
+open class RobolectricBaseSpec

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/signatureverifier/RealSignatureVerifierSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/signatureverifier/RealSignatureVerifierSpec.kt
@@ -1,0 +1,73 @@
+package com.rakuten.tech.mobile.miniapp.signatureverifier
+
+import com.rakuten.tech.mobile.miniapp.RobolectricBaseSpec
+import com.rakuten.tech.mobile.miniapp.signatureverifier.api.PublicKeyFetcher
+import com.rakuten.tech.mobile.miniapp.signatureverifier.verification.PublicKeyCache
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.amshove.kluent.When
+import org.amshove.kluent.calling
+import org.amshove.kluent.itReturns
+import org.amshove.kluent.shouldEqualTo
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+
+@ExperimentalCoroutinesApi
+open class RealSignatureVerifierSpec : RobolectricBaseSpec() {
+
+    companion object {
+
+        private const val KEY_ID = "test_id"
+        private const val PUBLIC_KEY =
+            "BI2zZr56ghnMLXBMeC4bkIVg6zpFD2ICIS7V6cWo8p8LkibuershO+Hd5ru6oBFLlUk" +
+                    "6IFFOIVfHKiOenHLBNIY="
+        private const val BODY = """{"testKey": "test_value"}"""
+        private const val SIGNATURE =
+            "MEUCIHRXIgQhyASpyCP1Lg0ZSn2/bUbTq6U7jpKBa9Ow/1OTAiEA4jAq48uDgNl7UM7" +
+                    "LmxhiRhPPNnTolokScTq5ijbp5fU="
+    }
+
+    private val mockPublicKeyCache = Mockito.mock(PublicKeyCache::class.java)
+    private val mockFetcher = Mockito.mock(PublicKeyFetcher::class.java)
+
+    @Before
+    fun setup() {
+        When calling mockPublicKeyCache[KEY_ID] itReturns PUBLIC_KEY
+    }
+
+    @Test
+    fun `should verify the signature`() = runBlockingTest {
+        val verifier = RealSignatureVerifier(mockPublicKeyCache, TestCoroutineDispatcher())
+
+        verifier.verify(
+            KEY_ID,
+            BODY.byteInputStream(),
+            SIGNATURE
+        ) shouldEqualTo true
+    }
+
+    @Test
+    fun `should not verify the signature when message has been modified`() = runBlockingTest {
+        val verifier = RealSignatureVerifier(mockPublicKeyCache, TestCoroutineDispatcher())
+
+        verifier.verify(
+            KEY_ID,
+            "wrong message".byteInputStream(),
+            SIGNATURE
+        ) shouldEqualTo false
+    }
+
+    @Test
+    fun `should not verify the signature cache returns null`() = runBlockingTest {
+        When calling mockPublicKeyCache[KEY_ID] itReturns null
+        val verifier = RealSignatureVerifier(mockPublicKeyCache, TestCoroutineDispatcher())
+
+        verifier.verify(
+            KEY_ID,
+            "wrong message".byteInputStream(),
+            SIGNATURE
+        ) shouldEqualTo false
+    }
+}

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/signatureverifier/SignatureVerifierSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/signatureverifier/SignatureVerifierSpec.kt
@@ -1,0 +1,80 @@
+package com.rakuten.tech.mobile.miniapp.signatureverifier
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.rakuten.tech.mobile.miniapp.RobolectricBaseSpec
+import org.amshove.kluent.any
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mockito
+
+class SignatureVerifierSpec : RobolectricBaseSpec() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val function: (ex: Exception) -> Unit = {}
+    private val mockCb = Mockito.mock(function.javaClass)
+
+    @Test
+    fun `should initialize instance with correct parameters`() {
+        val instance = SignatureVerifier.init(context, BASE_URL, SUB_KEY)
+
+        instance.shouldNotBeNull()
+        instance shouldBeInstanceOf RealSignatureVerifier::class
+    }
+
+    @Test
+    fun `should initialize instance with correct parameters with callback`() {
+        val instance = SignatureVerifier.init(context, BASE_URL, SUB_KEY) {
+            Assert.fail()
+        }
+
+        instance.shouldNotBeNull()
+        instance shouldBeInstanceOf RealSignatureVerifier::class
+    }
+
+    @Test
+    fun `should return null initialization failed due to context`() {
+        val mockContext = Mockito.mock(Context::class.java)
+        SignatureVerifier.init(mockContext, BASE_URL, SUB_KEY).shouldBeNull()
+    }
+
+    @Test
+    fun `should return null initialization failed due to context with callback`() {
+        val mockContext = Mockito.mock(Context::class.java)
+        SignatureVerifier.init(mockContext, BASE_URL, SUB_KEY, mockCb).shouldBeNull()
+
+        Mockito.verify(mockCb).invoke(any())
+    }
+
+    @Test
+    fun `should return null initialization failed due to invalid endpoint`() {
+        SignatureVerifier.init(context, "", SUB_KEY).shouldBeNull()
+    }
+
+    @Test
+    fun `should return null initialization failed due to invalid endpoint with callback`() {
+        SignatureVerifier.init(context, "", SUB_KEY, mockCb).shouldBeNull()
+
+        Mockito.verify(mockCb).invoke(any(SignatureVerifierException::class))
+    }
+
+    @Test
+    fun `should return null initialization failed due to invalid key`() {
+        SignatureVerifier.init(context, BASE_URL, "").shouldBeNull()
+    }
+
+    @Test
+    fun `should return null initialization failed due to invalid key with callback`() {
+        SignatureVerifier.init(context, BASE_URL, "", mockCb).shouldBeNull()
+
+        Mockito.verify(mockCb).invoke(any(SignatureVerifierException::class))
+    }
+
+    companion object {
+        private const val BASE_URL = "http://sample.com"
+        private const val SUB_KEY = "test_key"
+    }
+}

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/signatureverifier/api/ApiClientSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/signatureverifier/api/ApiClientSpec.kt
@@ -1,0 +1,188 @@
+package com.rakuten.tech.mobile.miniapp.signatureverifier.api
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.rakuten.tech.mobile.miniapp.RobolectricBaseSpec
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.amshove.kluent.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.logging.Level
+import java.util.logging.LogManager
+
+class ApiClientSpec : RobolectricBaseSpec() {
+
+    private val server = MockWebServer()
+    private val mockContext = ApplicationProvider.getApplicationContext<Context>()
+    private lateinit var baseUrl: String
+
+    init {
+        LogManager.getLogManager()
+            .getLogger(MockWebServer::class.java.name).level = Level.OFF
+    }
+
+    @Before
+    fun setup() {
+        server.start()
+        baseUrl = server.url("client").toString()
+    }
+
+    @After
+    fun teardown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `should fetch the response`() {
+        val client = createClient()
+        enqueueResponse("test_body")
+
+        client.fetchPath("test-path", null).body!!.string() shouldBeEqualTo "test_body"
+    }
+
+    @Test
+    fun `should fetch from the base url`() {
+        val client = createClient()
+        enqueueResponse()
+
+        client.fetchPath("test-path", null)
+
+        server.takeRequest().requestUrl.toString() shouldStartWith baseUrl
+    }
+
+    @Test
+    fun `should fetch using the provided path`() {
+        val client = createClient()
+        enqueueResponse()
+
+        client.fetchPath("test/path/to/fetch", null)
+
+        server.takeRequest().requestUrl.toString() shouldContain "/test/path/to/fetch"
+    }
+
+    @Test
+    fun `should attach ETag value to subsequent requests as If-None-Match`() {
+        val client = createClient()
+        enqueueResponse(etag = "etag_value")
+        enqueueResponse()
+
+        client.fetchPath("test-path", null).body!!.string()
+        server.takeRequest()
+        client.fetchPath("test-path", null).body!!.string()
+
+        server.takeRequest().headers["If-None-Match"] shouldEqual "etag_value"
+    }
+
+    @Test
+    fun `should return cached body for 304 response code`() {
+        val client = createClient()
+        enqueueResponse("test-body")
+        server.enqueue(MockResponse().setResponseCode(304))
+
+        client.fetchPath("test-path", null).body!!.string()
+
+        client.fetchPath("test-path", null).body!!.string() shouldBeEqualTo "test-body"
+    }
+
+    @Test
+    fun `should cache the body between App launches`() {
+        enqueueResponse("test-body")
+        server.enqueue(MockResponse().setResponseCode(304))
+
+        createClient().fetchPath("test-path", null).body!!.string()
+
+        createClient().fetchPath("test-path", null).body!!.string() shouldBeEqualTo "test-body"
+    }
+
+    @Test
+    fun `should include all query parameter`() {
+        val paramMap = HashMap<String, String>()
+        paramMap["key1"] = "value1"
+        paramMap["key2"] = "value2"
+        val client = ApiClient(baseUrl, "key", mockContext)
+
+        enqueueResponse("test-body")
+        server.enqueue(MockResponse().setResponseCode(304))
+        val response = client.fetchPath("test-path", paramMap)
+
+        for ((k, v) in paramMap) response.request.url.queryParameter(k) shouldBe v
+    }
+
+    @Test
+    fun `should include have empty value query param`() {
+        val paramMap = HashMap<String, String>()
+        paramMap["key1"] = "value1"
+        paramMap["key2"] = ""
+        val client = ApiClient(baseUrl, "key", mockContext)
+
+        enqueueResponse("test-body")
+        server.enqueue(MockResponse().setResponseCode(304))
+        val response = client.fetchPath("test-path", paramMap)
+
+        response.request.url.queryParameterNames.size shouldBe 1
+        response.request.url.queryParameter("key1") shouldBe "value1"
+        response.request.url.queryParameter("key2").shouldBeNull()
+    }
+
+    @Test
+    fun `should include have empty key query param`() {
+        val paramMap = HashMap<String, String>()
+        paramMap["key1"] = "value1"
+        paramMap[""] = "value2"
+        val client = ApiClient(baseUrl, "key", mockContext)
+
+        enqueueResponse("test-body")
+        server.enqueue(MockResponse().setResponseCode(304))
+        val response = client.fetchPath("test-path", paramMap)
+
+        response.request.url.queryParameterNames.size shouldBe 1
+        response.request.url.queryParameter("key1") shouldBe "value1"
+        response.request.url.queryParameter("").shouldBeNull()
+    }
+
+    @Test
+    fun `should include have empty key value query param`() {
+        val paramMap = HashMap<String, String>()
+        paramMap["key1"] = "value1"
+        paramMap[""] = ""
+        val client = ApiClient(baseUrl, "key", mockContext)
+
+        enqueueResponse("test-body")
+        server.enqueue(MockResponse().setResponseCode(304))
+        val response = client.fetchPath("test-path", paramMap)
+
+        response.request.url.queryParameterNames.size shouldBe 1
+        response.request.url.queryParameter("key1") shouldBe "value1"
+        response.request.url.queryParameter("").shouldBeNull()
+    }
+
+    @Test
+    fun `should not include empty value`() {
+        val paramMap = HashMap<String, String>()
+        val client = ApiClient(baseUrl, "key", mockContext)
+
+        enqueueResponse("test-body")
+        server.enqueue(MockResponse().setResponseCode(304))
+        val response = client.fetchPath("test-path", paramMap)
+
+        response.request.url.queryParameterNames.shouldBeEmpty()
+    }
+
+    @Test(expected = Exception::class)
+    fun `should throw when an invalid base url is provided`() {
+        createClient(url = "invalid url")
+    }
+
+    private fun enqueueResponse(body: String = "test_body", etag: String = "etag_value") {
+        server.enqueue(
+            MockResponse()
+                .setBody(body)
+                .setHeader("ETag", etag)
+        )
+    }
+
+    private fun createClient(url: String = baseUrl) =
+        ApiClient(url, "key", ApplicationProvider.getApplicationContext())
+}

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/signatureverifier/api/PublicKeyFetcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/signatureverifier/api/PublicKeyFetcherSpec.kt
@@ -1,0 +1,209 @@
+package com.rakuten.tech.mobile.miniapp.signatureverifier.api
+
+import androidx.test.core.app.ApplicationProvider
+import junit.framework.TestCase
+import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.amshove.kluent.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.kotlin.argForWhich
+import org.mockito.kotlin.eq
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.IOException
+
+open class PublicKeyFetcherSpec {
+    internal val mockApiClient = Mockito.mock(ApiClient::class.java)
+
+    internal fun createFetcher() =
+        PublicKeyFetcher(mockApiClient)
+
+    internal fun enqueueResponse(
+        body: String,
+        code: Int
+    ) {
+        When calling mockApiClient.fetchPath(any(), eq(null)) itReturns Response.Builder()
+            .request(Request.Builder().url("https://www.example.com").build())
+            .protocol(Protocol.HTTP_2)
+            .message("")
+            .code(code)
+            .body(body.toResponseBody("text/plain; charset=utf-8".toMediaType()))
+            .build()
+    }
+}
+
+class PublicKeyFetcherNormalSpec : PublicKeyFetcherSpec() {
+
+    private fun enqueueSuccessResponse(
+        id: String = "test_id",
+        ecKey: String = "test_key",
+        pemKey: String = "test_pemkey"
+    ) {
+        enqueueResponse(
+            body = """
+                {
+                    "id": "$id",
+                    "ecKey": "$ecKey",
+                    "pemKey": "$pemKey"
+                }
+            """.trimIndent(),
+            code = 200
+        )
+    }
+
+    @Test
+    fun `should fetch the public key`() {
+        val fetcher = createFetcher()
+        enqueueSuccessResponse(ecKey = "test_key")
+
+        fetcher.fetch("test_key_id") shouldBeEqualTo "test_key"
+    }
+
+    @Test
+    fun `should fetch the public key for the provided key id`() {
+        val fetcher = createFetcher()
+        enqueueSuccessResponse(id = "test_key_id")
+
+        fetcher.fetch("test_key_id")
+
+        Verify on mockApiClient that mockApiClient.fetchPath(argForWhich {
+            contains("test_key_id")
+        }, eq(null))
+    }
+
+    @Test
+    fun `should parse response correctly`() {
+        val response = PublicKeyResponse.fromJsonString(SAMPLE_RESPONSE)
+        response.id shouldBeEqualTo "test_id"
+        response.ecKey shouldBeEqualTo "test_key"
+        response.pemKey shouldBeEqualTo "test_pemKey"
+    }
+
+    companion object {
+        private val SAMPLE_RESPONSE =
+            """{
+                "id": "test_id",
+                "ecKey": "test_key",
+                "pemKey": "test_pemKey"
+            }""".trimIndent()
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class PublicKeyFetcherErrorSpec : PublicKeyFetcherSpec() {
+
+    private fun enqueueErrorResponse(
+        body: String = "",
+        code: Int = 200
+    ) {
+        enqueueResponse(
+            body = body,
+            code = code
+        )
+    }
+
+    @Test(expected = IOException::class)
+    fun `should throw when the request is unsuccessful`() {
+        enqueueErrorResponse(code = 400)
+
+        val fetcher = createFetcher()
+
+        fetcher.fetch("test_key_id")
+    }
+
+    @Test
+    fun `should return empty even if 'id' key is missing in response`() {
+        enqueueErrorResponse(
+            body = """{
+                "ecKey": "test_key",
+                "pemKey": "test_pemKey"
+            }""".trimIndent()
+        )
+        val fetcher = createFetcher()
+
+        fetcher.fetch("test_key_id").shouldBeEmpty()
+    }
+
+    @Test
+    fun `should return empty when the 'ecKey' key is missing in response`() {
+        enqueueErrorResponse(
+            body = """{
+                "id": "test_key_id",
+                "pemKey": "test_pemKey"
+            }""".trimIndent()
+        )
+        val fetcher = createFetcher()
+
+        fetcher.fetch("test_key_id").shouldBeEmpty()
+    }
+
+    @Test
+    fun `should return valid key even if 'pemKey' key is missing in response`() {
+        enqueueErrorResponse(
+            body = """{
+                "id": "test_key_id",
+                "ecKey": "test_key"
+            }""".trimIndent()
+        )
+        val fetcher = createFetcher()
+
+        fetcher.fetch("test_key_id") shouldBeEqualTo "test_key"
+    }
+
+    @Test(expected = IOException::class)
+    fun `should throw when valid client but invalid url`() {
+        enqueueErrorResponse(code = 404)
+
+        val fetcher = PublicKeyFetcher(
+            ApiClient(
+                "https://www.example.com",
+                "key",
+                ApplicationProvider.getApplicationContext()
+            )
+        )
+
+        fetcher.fetch("test_key_id")
+    }
+
+    @Test
+    @Suppress("TooGenericExceptionCaught")
+    fun `should not throw when there are extra keys in the response`() {
+        enqueueErrorResponse(
+            body = """{
+                "id": "test_id",
+                "ecKey": "test_key",
+                "pemKey": "test_pemKey",
+                "randomKey": "random_value"
+            }""".trimIndent()
+        )
+        val fetcher = createFetcher()
+
+        try {
+            fetcher.fetch("test_key_id")
+        } catch (e: Exception) {
+            TestCase.fail("Should not throw an exception.")
+            throw e
+        }
+    }
+
+    @Test
+    fun `should be empty if invalid json format`() {
+        val response = PublicKeyResponse.fromJsonString(INVALID_RESPONSE)
+        response.id.shouldBeEmpty()
+        response.ecKey.shouldBeEmpty()
+        response.ecKey.shouldBeEmpty()
+    }
+
+    companion object {
+        private val INVALID_RESPONSE =
+            """{
+                "some": "test_id",
+                "other": "test_key",
+                "values": "test
+            }""".trimIndent()
+    }
+}

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/signatureverifier/verification/AesEncryptorSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/signatureverifier/verification/AesEncryptorSpec.kt
@@ -1,0 +1,240 @@
+package com.rakuten.tech.mobile.miniapp.signatureverifier.verification
+
+import com.google.gson.JsonParseException
+import com.rakuten.tech.mobile.miniapp.RobolectricBaseSpec
+import com.rakuten.tech.mobile.miniapp.signatureverifier.SignatureVerifier
+import org.amshove.kluent.*
+import org.amshove.kluent.any
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.kotlin.*
+import java.lang.ClassCastException
+import java.lang.IllegalArgumentException
+import java.security.InvalidKeyException
+import java.security.KeyStore
+import java.security.NoSuchAlgorithmException
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+open class AesEncryptorSpec : RobolectricBaseSpec() {
+
+    internal val mockKeyStore = Mockito.mock(KeyStore::class.java)
+    private val mockKeyGenerator = Mockito.mock(AesKeyGenerator::class.java)
+    private val mockKeyEntry = Mockito.mock(KeyStore.SecretKeyEntry::class.java)
+
+    @Before
+    open fun setup() {
+        val key = generateAesKey()
+        SignatureVerifier.callback = null
+        When calling mockKeyGenerator.generateKey() itReturns key
+        When calling mockKeyEntry.secretKey itReturns key
+        When calling mockKeyStore.getEntry(any(), anyOrNull()) itReturns mockKeyEntry
+    }
+
+    @Test
+    fun `it should encrypt the data`() {
+        val encryptor = createAesEncryptor()
+
+        val data = encryptor.encrypt("test data")
+        data.shouldNotBeNull()
+        data.shouldNotContain("test data")
+    }
+
+    @Test
+    fun `it should attach IV`() {
+        val encryptor = createAesEncryptor()
+
+        val data = encryptor.encrypt("test data")
+        data.shouldNotBeNull()
+        data.shouldContain("\"iv\":")
+    }
+
+    @Test
+    fun `it should decrypt the data`() {
+        val encryptor = createAesEncryptor()
+
+        val encryptedData = encryptor.encrypt("test data")
+
+        encryptedData.shouldNotBeNull()
+        encryptor.decrypt(encryptedData)!! shouldBeEqualTo "test data"
+    }
+
+    @Test
+    fun `it should generate a new key when one is not in the key store`() {
+        When calling mockKeyStore.getEntry(any(), anyOrNull()) itReturns null
+        val encryptor = createAesEncryptor()
+
+        encryptor.encrypt("test data")
+
+        Mockito.verify(mockKeyGenerator).generateKey()
+    }
+
+    @Test
+    fun `it should not generate a key when one is already in the key store`() {
+        When calling mockKeyGenerator.generateKey() itReturns mock()
+        val encryptor = createAesEncryptor()
+
+        encryptor.encrypt("test data")
+
+        Mockito.verify(mockKeyGenerator, never()).generateKey()
+    }
+
+    @Test
+    fun `it should generate a new key when the one in the store is not an AES key`() {
+        val mockRsaKeyEntry: KeyStore.PrivateKeyEntry = mock()
+        When calling mockKeyStore.getEntry(any(), anyOrNull()) itReturns mockRsaKeyEntry
+        val encryptor = createAesEncryptor()
+        encryptor.encrypt("test data")
+
+        Mockito.verify(mockKeyGenerator).generateKey()
+    }
+
+    internal fun createAesEncryptor(
+        keyStore: KeyStore? = mockKeyStore,
+        keyGenerator: AesKeyGenerator = mockKeyGenerator
+    ) = AesEncryptor(keyStore, keyGenerator)
+
+    private fun generateAesKey(): SecretKey {
+        val kgen = KeyGenerator.getInstance("AES")
+        kgen.init(256)
+        return kgen.generateKey()
+    }
+}
+
+open class AesEncryptorExceptionSpec : AesEncryptorSpec() {
+
+    private val function: (ex: Exception) -> Unit = {}
+    private val mockCallback = Mockito.mock(function.javaClass)
+
+    @Before
+    override fun setup() {
+        super.setup()
+        SignatureVerifier.callback = mockCallback
+    }
+
+    @Test
+    fun `should not crash and return valid when keystore is null`() {
+        val encryptor = createAesEncryptor(keyStore = null)
+
+        verifyFunction(encryptor, true)
+    }
+
+    @Test
+    fun `should not crash and return valid when keystore throws ClassCastException`() {
+        When calling mockKeyStore.getEntry(any(), anyOrNull()) itThrows ClassCastException()
+
+        val encryptor = createAesEncryptor()
+
+        verifyFunction(encryptor, true)
+        Mockito.verify(mockCallback, times(2)).invoke(any(ClassCastException::class))
+    }
+
+    @Test
+    fun `should not crash and return null when key generator throws IllegalArgumentException`() {
+        When calling mockKeyStore.getEntry(any(), anyOrNull()) itReturns null
+
+        val generator = AesKeyGenerator("", "AndroidKeyStore")
+
+        val encryptor = createAesEncryptor(keyGenerator = generator)
+
+        verifyFunction(encryptor, false)
+        // twice called: encrypt and decrypt
+        Mockito.verify(mockCallback, times(2)).invoke(any(IllegalArgumentException::class))
+    }
+
+    @Test
+    fun `should not crash and return valid when keystore load throw NoSuchAlgorithmException`() {
+        When calling mockKeyStore.load(isNull()) itThrows NoSuchAlgorithmException()
+        val encryptor = createAesEncryptor()
+
+        verifyFunction(encryptor, true)
+        Mockito.verify(mockCallback).invoke(any(NoSuchAlgorithmException::class))
+    }
+
+    @Test
+    fun `should not crash and return null when cipher throws InvalidKeyException`() {
+        val mockCipher = Mockito.mock(Cipher::class.java)
+        When calling mockCipher.init(eq(Cipher.DECRYPT_MODE), any(SecretKey::class), any(
+            GCMParameterSpec::class)) itThrows InvalidKeyException()
+        When calling mockCipher.init(eq(Cipher.ENCRYPT_MODE),
+            any(SecretKey::class)) itThrows InvalidKeyException()
+        val encryptor = createAesEncryptor()
+
+        encryptor.encrypt("test data", mockCipher).shouldBeNull()
+        encryptor.decrypt("test data", mockCipher).shouldBeNull()
+        Mockito.verify(mockCallback, times(2)).invoke(any(InvalidKeyException::class))
+    }
+
+    private fun verifyFunction(encryptor: AesEncryptor, isValid: Boolean) {
+        if (isValid) {
+            val data = encryptor.encrypt("test data")
+            data.shouldNotBeNull()
+            data.shouldNotContain("test data")
+            encryptor.decrypt(data).shouldNotBeNull()
+        } else {
+            encryptor.encrypt("test data").shouldBeNull()
+            encryptor.decrypt("test data").shouldBeNull()
+        }
+    }
+}
+
+class AesEncryptedDataSpec : RobolectricBaseSpec() {
+
+    @Before
+    fun setup() {
+        SignatureVerifier.callback = null
+    }
+
+    @Test
+    fun `should serialize empty string data is correctly`() {
+        val json = AesEncryptedData("", "").toJsonString()
+        json.shouldNotBeEmpty()
+
+        val data = AesEncryptedData.fromJsonString(json)
+        data.iv.shouldBeEmpty()
+        data.encryptedData.shouldBeEmpty()
+    }
+
+    @Test
+    fun `should return correct data`() {
+        val data = AesEncryptedData.fromJsonString(DATA)
+        data.iv shouldBeEqualTo "test_iv"
+        data.encryptedData shouldBeEqualTo "test_data"
+    }
+
+    @Test
+    fun `should return empty data when parsing failed`() {
+        val data = AesEncryptedData.fromJsonString(DATA_FAILED)
+        data.iv.shouldBeEmpty()
+        data.encryptedData.shouldBeEmpty()
+    }
+
+    @Test
+    fun `should return empty data when parsing failed with callback`() {
+        val function: (ex: Exception) -> Unit = {}
+        val mockCallback = Mockito.mock(function.javaClass)
+        SignatureVerifier.callback = mockCallback
+        val data = AesEncryptedData.fromJsonString(DATA_FAILED)
+        data.iv.shouldBeEmpty()
+        data.encryptedData.shouldBeEmpty()
+
+        Mockito.verify(mockCallback).invoke(any(JsonParseException::class))
+    }
+
+    companion object {
+        private val DATA =
+            """{
+                "iv": "test_iv",
+                "encryptedData": "test_data"
+            }""".trimIndent()
+
+        private val DATA_FAILED =
+            """{
+                "iv": "test_iv",
+                "encryptedData"
+            """.trimIndent()
+    }
+}

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/signatureverifier/verification/PublicKeyCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/signatureverifier/verification/PublicKeyCacheSpec.kt
@@ -1,0 +1,114 @@
+package com.rakuten.tech.mobile.miniapp.signatureverifier.verification
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.rakuten.tech.mobile.miniapp.RobolectricBaseSpec
+import com.rakuten.tech.mobile.miniapp.signatureverifier.SignatureVerifier
+import com.rakuten.tech.mobile.miniapp.signatureverifier.api.PublicKeyFetcher
+import org.amshove.kluent.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import java.io.IOException
+
+class PublicKeyCacheSpec : RobolectricBaseSpec() {
+
+    private val mockFetcher = Mockito.mock(PublicKeyFetcher::class.java)
+    private val mockEncryptor = Mockito.mock(AesEncryptor::class.java)
+    private val mockMap = HashMap<String, String>()
+
+    @Before
+    fun setup() {
+        SignatureVerifier.callback = null
+        mockMap["test_key_id"] = "encrypted"
+        When calling mockFetcher.fetch("test_key_id") itReturns "test_public_key"
+        When calling mockEncryptor.encrypt(any(String::class), any()) itReturns "encrypted"
+        When calling mockEncryptor.decrypt(eq("encrypted"), any()) itReturns "test_public_key"
+    }
+
+    @Test
+    fun `should return cached key`() {
+        val cache = createCache(map = mockMap)
+        cache["test_key_id"] shouldBe ("test_public_key")
+        Mockito.verify(mockFetcher, never()).fetch(eq("test_key_id"))
+    }
+
+    @Test
+    fun `should call fetched when key is removed cached key`() {
+        val cache = createCache(map = mockMap)
+        cache["test_key_id"] shouldBe ("test_public_key")
+        Mockito.verify(mockFetcher, never()).fetch(eq("test_key_id"))
+
+        cache.remove("test_key_id")
+        cache["test_key_id"] shouldBe ("test_public_key")
+        Mockito.verify(mockFetcher).fetch(eq("test_key_id"))
+    }
+
+    @Test
+    fun `should call fetcher for key id that is not cached`() {
+        val cache = createCache()
+
+        cache["test_key_id"]?.shouldBeEqualTo("test_public_key")
+        Mockito.verify(mockFetcher).fetch(eq("test_key_id"))
+    }
+
+    @Test
+    fun `should return null when key fetcher failed`() {
+        val function: (ex: Exception) -> Unit = {}
+        val mockCallback = Mockito.mock(function.javaClass)
+        SignatureVerifier.callback = mockCallback
+        val cache = createCache()
+        When calling mockEncryptor.encrypt(any(), any()) itReturns null
+        When calling mockFetcher.fetch(eq("test_key_id")) itThrows IOException("test")
+
+        cache["test_key_id"].shouldBeNull()
+        Mockito.verify(mockFetcher).fetch(eq("test_key_id"))
+        Mockito.verify(mockCallback).invoke(any(IOException::class))
+    }
+
+    @Test
+    fun `should cache the public key between App launches`() {
+        val cache = createCache()
+
+        // fetched and cached
+        cache["test_key_id"] shouldBe ("test_public_key")
+        Mockito.verify(mockFetcher).fetch(eq("test_key_id"))
+
+        val secondCache = createCache()
+
+        secondCache["test_key_id"] shouldBe ("test_public_key")
+        Mockito.verify(mockFetcher).fetch(eq("test_key_id"))
+    }
+
+    @Test
+    fun `should return cached key when using real encryptor`() {
+        TestKeyStore.setup
+        val cache = createCache(encryptor = null)
+
+        cache["test_key_id"] shouldBe ("test_public_key")
+        Mockito.verify(mockFetcher).fetch(eq("test_key_id"))
+    }
+
+    @Test
+    fun `should return valid when used actual encryptor`() {
+        TestKeyStore.setup
+        val cache = createCache(encryptor = AesEncryptor())
+
+        cache["test_key_id"] shouldBe ("test_public_key")
+        Mockito.verify(mockFetcher).fetch(eq("test_key_id"))
+
+        cache["test_key_id"] shouldBe ("test_public_key")
+        // called again since encryption and decryption (keystore test) will fail and will fetch
+        Mockito.verify(mockFetcher, times(2)).fetch(eq("test_key_id"))
+    }
+
+    private fun createCache(
+        fetcher: PublicKeyFetcher = mockFetcher,
+        context: Context = ApplicationProvider.getApplicationContext(),
+        encryptor: AesEncryptor? = mockEncryptor,
+        map: MutableMap<String, String>? = null
+    ) = PublicKeyCache(fetcher, context, "test", encryptor, map)
+}

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/signatureverifier/verification/TestKeyStore.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/signatureverifier/verification/TestKeyStore.kt
@@ -1,0 +1,85 @@
+package com.rakuten.tech.mobile.miniapp.signatureverifier.verification
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import java.io.InputStream
+import java.io.OutputStream
+import java.security.*
+import java.security.cert.Certificate
+import java.security.spec.AlgorithmParameterSpec
+import java.util.*
+import javax.crypto.KeyGenerator
+import javax.crypto.KeyGeneratorSpi
+import javax.crypto.SecretKey
+
+object TestKeyStore {
+
+    val setup by lazy {
+        Security.removeProvider("AndroidKeyStore")
+        Security.addProvider(BouncyCastleProvider())
+        Security.addProvider(object : Provider("AndroidKeyStore", 1.0, "") {
+            init {
+                put("KeyStore.AndroidKeyStore", MockKeyStore::class.java.name)
+                put("KeyGenerator.AES", MockAesKeyGenerator::class.java.name)
+            }
+        })
+    }
+
+    @Suppress("unused")
+    class MockKeyStore : KeyStoreSpi() {
+        private val wrapped = KeyStore.getInstance(KeyStore.getDefaultType())
+
+        override fun engineIsKeyEntry(alias: String?): Boolean = wrapped.isKeyEntry(alias)
+        override fun engineIsCertificateEntry(alias: String?): Boolean =
+            wrapped.isCertificateEntry(alias)
+
+        override fun engineGetCertificate(alias: String?): Certificate =
+            wrapped.getCertificate(alias)
+
+        override fun engineGetCreationDate(alias: String?): Date = wrapped.getCreationDate(alias)
+        override fun engineDeleteEntry(alias: String?) = wrapped.deleteEntry(alias)
+        override fun engineSetKeyEntry(
+            alias: String?,
+            key: Key?,
+            password: CharArray?,
+            chain: Array<out Certificate>?
+        ) =
+            wrapped.setKeyEntry(alias, key, password, chain)
+
+        override fun engineSetKeyEntry(
+            alias: String?,
+            key: ByteArray?,
+            chain: Array<out Certificate>?
+        ) = wrapped.setKeyEntry(alias, key, chain)
+
+        override fun engineStore(stream: OutputStream?, password: CharArray?) =
+            wrapped.store(stream, password)
+
+        override fun engineSize(): Int = wrapped.size()
+        override fun engineAliases(): Enumeration<String> = wrapped.aliases()
+        override fun engineContainsAlias(alias: String?): Boolean = wrapped.containsAlias(alias)
+        override fun engineLoad(stream: InputStream?, password: CharArray?) =
+            wrapped.load(stream, password)
+
+        override fun engineGetCertificateChain(alias: String?): Array<Certificate> =
+            wrapped.getCertificateChain(alias)
+
+        override fun engineSetCertificateEntry(alias: String?, cert: Certificate?) =
+            wrapped.setCertificateEntry(alias, cert)
+
+        override fun engineGetCertificateAlias(cert: Certificate?): String =
+            wrapped.getCertificateAlias(cert)
+
+        override fun engineGetKey(alias: String?, password: CharArray?): Key? =
+            wrapped.getKey(alias, password)
+    }
+
+    @Suppress("unused")
+    class MockAesKeyGenerator : KeyGeneratorSpi() {
+        private val wrapped = KeyGenerator.getInstance("AES")
+
+        override fun engineInit(random: SecureRandom?) = Unit
+        override fun engineInit(params: AlgorithmParameterSpec?, random: SecureRandom?) = Unit
+        override fun engineInit(keysize: Int, random: SecureRandom?) = Unit
+        override fun engineGenerateKey(): SecretKey = wrapped.generateKey()
+    }
+}


### PR DESCRIPTION
# Description
This PR is adopting [Signature Verifier SDK](https://github.com/rakutentech/android-signatureverifier) in MiniApp SDK.

## Links
- MINI-3418

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
