### PR TITLE
[MINI-3959] Show the scopes requested for the RAE token in first time screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 3.6.0 (2021-MM-DD)
 **Sample App**
 - **Feature:** User can edit contact name and email in App Settings.
+- **Feature:** User can see access token scopes requested for the RAE audience in first-time screen.
 
 ### 3.5.0 (2021-07-27)
 **SDK**

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadManifestPermission.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadManifestPermission.kt
@@ -5,7 +5,8 @@ import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
 
 @Keep
 data class PreloadManifestPermission(
-    val type: MiniAppCustomPermissionType,
-    val isRequired: Boolean,
-    val reason: String
+        val type: MiniAppCustomPermissionType,
+        val isRequired: Boolean,
+        val reason: String,
+        var optionalInfo: String = ""
 )

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppPermissionAdapter.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppPermissionAdapter.kt
@@ -41,6 +41,10 @@ class PreloadMiniAppPermissionAdapter :
             holder.permissionReason.visibility = View.GONE
         else holder.permissionReason.visibility = View.VISIBLE
 
+        if (manifestPermissions[position].optionalInfo.isNotEmpty())
+            holder.permissionOptionalInfo.text = manifestPermissions[position].optionalInfo
+        else holder.permissionOptionalInfo.visibility = View.GONE
+
         holder.permissionSwitch.setOnCheckedChangeListener { _, _ ->
             manifestPermissionPairs.removeAt(position)
             manifestPermissionPairs.add(
@@ -69,6 +73,7 @@ class PreloadMiniAppPermissionAdapter :
         val permissionStatus: TextView = itemView.manifestPermissionStatus
         val permissionSwitch: SwitchCompat = itemView.manifestPermissionSwitch
         val permissionReason: TextView = itemView.permissionReason
+        val permissionOptionalInfo: TextView = itemView.permissionOptionalInfo
     }
 
     private fun permissionResultToText(isChecked: Boolean): MiniAppCustomPermissionResult {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
@@ -123,20 +123,8 @@ class PreloadMiniAppWindow(
             manifestPermissions.add(permission)
         }
 
-        permissionAdapter.addManifestPermissionList(manifestPermissions)
-        prepareBottomText(binding.preloadMiniAppMetaData, manifest, manifestPermissions)
-
-        launchScreen()
-    }
-
-    private fun prepareBottomText(
-        bottomTextView: TextView,
-        manifest: MiniAppManifest,
-        manifestPermissions: List<PreloadManifestPermission>
-    ) {
-        val bottomText = StringBuilder()
-
         // add scopes requested for the RAE audience
+        var scope = ""
         manifestPermissions.find {
             it.type == MiniAppCustomPermissionType.ACCESS_TOKEN
         }.let {
@@ -145,19 +133,30 @@ class PreloadMiniAppWindow(
                     scope.audience == "rae"
                 }.let {
                     val scopes: List<String> = it?.scopes ?: emptyList()
-                    bottomText.append(LABEL_RAE_SCOPES).append("\n").append(
-                        scopes.joinToString(
+                    scope = scopes.joinToString(
                             separator = ", ",
                             prefix = "",
                             postfix = "",
                             truncated = "",
                             limit = scopes.size
-                        )
-                    ).append("\n\n")
+                    )
                 }
+
+                it?.optionalInfo = "(rae scopes): $scope"
             }
         }
 
+        permissionAdapter.addManifestPermissionList(manifestPermissions)
+        prepareBottomText(binding.preloadMiniAppMetaData, manifest)
+
+        launchScreen()
+    }
+
+    private fun prepareBottomText(
+        bottomTextView: TextView,
+        manifest: MiniAppManifest
+    ) {
+        val bottomText = StringBuilder()
         val metaData = toPrettyMetadata(manifest.customMetaData)
         if (!metaData.contentEquals("{}"))
             bottomText.append(LABEL_CUSTOM_METADATA + toPrettyMetadata(manifest.customMetaData))

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
@@ -136,7 +136,7 @@ class PreloadMiniAppWindow(
     ) {
         val bottomText = StringBuilder()
 
-        // add scopes requested for the RAE token
+        // add scopes requested for the RAE audience
         manifestPermissions.find {
             it.type == MiniAppCustomPermissionType.ACCESS_TOKEN
         }.let {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
@@ -3,6 +3,8 @@ package com.rakuten.tech.mobile.testapp.ui.display.preload
 import android.annotation.SuppressLint
 import android.content.Context
 import android.view.LayoutInflater
+import android.view.View
+import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.databinding.DataBindingUtil
@@ -14,9 +16,11 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.gson.GsonBuilder
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.MiniAppManifest
+import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.WindowPreloadMiniappBinding
 import com.rakuten.tech.mobile.testapp.helper.load
+import java.lang.StringBuilder
 
 class PreloadMiniAppWindow(
     private val context: Context,
@@ -120,10 +124,46 @@ class PreloadMiniAppWindow(
         }
 
         permissionAdapter.addManifestPermissionList(manifestPermissions)
-        binding.preloadMiniAppMetaData.text =
-            LABEL_CUSTOM_METADATA + toPrettyMetadata(manifest.customMetaData)
+        prepareBottomText(binding.preloadMiniAppMetaData, manifest, manifestPermissions)
 
         launchScreen()
+    }
+
+    private fun prepareBottomText(
+        bottomTextView: TextView,
+        manifest: MiniAppManifest,
+        manifestPermissions: List<PreloadManifestPermission>
+    ) {
+        val bottomText = StringBuilder()
+
+        // add scopes requested for the RAE token
+        manifestPermissions.find {
+            it.type == MiniAppCustomPermissionType.ACCESS_TOKEN
+        }.let {
+            if (manifest.accessTokenPermissions.isNotEmpty()) {
+                manifest.accessTokenPermissions.find { scope ->
+                    scope.audience == "rae"
+                }.let {
+                    val scopes: List<String> = it?.scopes ?: emptyList()
+                    bottomText.append(LABEL_RAE_SCOPES).append("\n").append(
+                        scopes.joinToString(
+                            separator = ", ",
+                            prefix = "",
+                            postfix = "",
+                            truncated = "",
+                            limit = scopes.size
+                        )
+                    ).append("\n\n")
+                }
+            }
+        }
+
+        val metaData = toPrettyMetadata(manifest.customMetaData)
+        if (!metaData.contentEquals("{}"))
+            bottomText.append(LABEL_CUSTOM_METADATA + toPrettyMetadata(manifest.customMetaData))
+
+        if (bottomText.toString().isNotEmpty()) bottomTextView.text = bottomText.toString()
+        else bottomTextView.visibility = View.GONE
     }
 
     private fun onAccept() {
@@ -137,7 +177,7 @@ class PreloadMiniAppWindow(
     }
 
     private fun toPrettyMetadata(metadata: Map<String, String>) =
-        GsonBuilder().setPrettyPrinting().create().toJson(metadata)
+        GsonBuilder().setPrettyPrinting().create().toJson(metadata).toString()
 
     interface PreloadMiniAppLaunchListener {
         fun onPreloadMiniAppResponse(isAccepted: Boolean)
@@ -146,6 +186,7 @@ class PreloadMiniAppWindow(
     private companion object {
         const val LABEL_VERSION = "Version: "
         const val LABEL_CUSTOM_METADATA = "Custom MetaData: "
+        const val LABEL_RAE_SCOPES = "RAE Access Token Scopes: "
         const val ERR_NO_INFO = "No info found for this miniapp!"
     }
 }

--- a/testapp/src/main/res/layout/item_list_manifest_permission.xml
+++ b/testapp/src/main/res/layout/item_list_manifest_permission.xml
@@ -51,6 +51,17 @@
         android:textColor="@android:color/black"
         android:textSize="@dimen/text_medium_14"
         tools:text="Manifest Permission Reason" />
+
+      <TextView
+          android:id="@+id/permissionOptionalInfo"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginEnd="@dimen/small_8"
+          android:padding="@dimen/small_4"
+          android:textColor="@color/colorPrimaryDark"
+          android:textSize="@dimen/text_medium_14"
+          tools:text="Optional Info"
+          tools:visibility="visible" />
     </LinearLayout>
 
       <com.rakuten.tech.mobile.testapp.analytics.rat_wrapper.RATSwitch

--- a/testapp/src/main/res/layout/window_preload_miniapp.xml
+++ b/testapp/src/main/res/layout/window_preload_miniapp.xml
@@ -80,7 +80,7 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:nestedScrollingEnabled="false"
-          tools:listitem="@layout/item_list_custom_permission" />
+          tools:listitem="@layout/item_list_manifest_permission" />
 
         <TextView
           android:id="@+id/preloadMiniAppMetaData"


### PR DESCRIPTION
# Description
Added access token scopes requested for the RAE audience in first-time screen.

## Links
- MINI-3959

## Screenshot
![Screen Shot 2021-09-08 at 15 30 56](https://user-images.githubusercontent.com/66930373/132457900-0536dbf5-f123-4594-ace2-a0c5af379281.png)

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
