### PR TITLE
feat: [MINI-3999] Add support for downloading files from a mini app

### DIFF
--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -718,6 +718,24 @@ mini app scheme and should close external webview.
 
 Using `#ExternalResultHandler.emitResult(String)` to transmit the url string to mini app view.
 
+#### Downloading files in a Mini App
+
+You can also optionally use your `MiniAppNavigator` to intercept file download requests from the Mini App. Note that this will only receive files that the Mini App downloaded with XHR, so the URL you receive will be a Base64 data URI. If you do not override the file download functionality, then the SDK will use default functionality to create an Intent for sharing the file to another App.
+
+To use this, you must implement the `MiniAppDownloadNavigator` interface in your `MiniAppNavigator` implementation.
+
+```kotlin
+miniAppNavigator = object : MiniAppNavigator, MiniAppDownloadNavigator {
+    // Override MiniAppNavigator functions here
+    // ...
+
+    // Override MiniAppDownloadNavigator functions
+    fun onFileDownloadStart(url: String, userAgent: String, contentDisposition: String, mimetype: String, contentLength: Long) {
+        // Decode URL as Base 64 and then use it somehow - i.e. save to device, share to another App, etc.
+    }
+}
+```
+
 ### File choosing
 **API Docs:** [MiniAppFileChooser](api/com.rakuten.tech.mobile.miniapp.file/-mini-app-file-chooser/)
 

--- a/miniapp/src/main/AndroidManifest.xml
+++ b/miniapp/src/main/AndroidManifest.xml
@@ -20,6 +20,16 @@
             android:exported="false"
             android:initOrder="100"
             tools:replace="android:initOrder" />
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.miniapp.downloadedfileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/miniapp_downloaded_file_provider_paths" />
+        </provider>
     </application>
 
     <queries>

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/WebViewFileDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/WebViewFileDownloader.kt
@@ -1,0 +1,79 @@
+package com.rakuten.tech.mobile.miniapp.display
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Base64
+import android.util.Log
+import android.webkit.MimeTypeMap
+import androidx.core.content.FileProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.io.File
+import java.io.IOException
+
+private const val TAG = "WebViewFileDownloader"
+
+internal class WebViewFileDownloader(
+    private val context: Context,
+    private val cache: File,
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO),
+    private val mimeTypeMap: MimeTypeMap = MimeTypeMap.getSingleton(),
+    private val fileProvider: DownloadedFileProvider = DownloadedFileProvider(context)
+) {
+    fun onDownloadStart(url: String, mimetype: String, onUnsupportedFile: () -> Unit) {
+        if (url.startsWith("data:")) {
+            val decodedBytes = try {
+                Base64.decode(
+                    url.substring(url.indexOf(",") + 1),
+                    Base64.DEFAULT
+                )
+            } catch (e: IllegalArgumentException) {
+                Log.e(TAG, "Could not share the downloaded file: failed to decode the file as Base64.", e)
+                return
+            }
+
+            val dir = File(cache, System.currentTimeMillis().toString())
+            dir.mkdirs()
+            val fileExtension = mimeTypeMap.getExtensionFromMimeType(mimetype)?.let { ".$it" } ?: ""
+            val fileName = "download$fileExtension"
+            val file = File(dir, fileName)
+            try {
+                file.writeBytes(decodedBytes)
+            } catch (e: IOException) {
+                Log.e(TAG, "Could not share the downloaded file: failed to write temporary file to cache.", e)
+                return
+            }
+
+            val intent = Intent(Intent.ACTION_SEND)
+            intent.type = mimetype
+            intent.putExtra(Intent.EXTRA_STREAM, fileProvider.getUriForFile(file))
+
+            context.startActivity(Intent.createChooser(intent, null))
+        } else {
+            onUnsupportedFile()
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    fun cleanup() {
+        scope.launch {
+            try {
+                cache.deleteRecursively()
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to delete downloaded file cache.", e)
+            }
+        }
+    }
+}
+
+internal class DownloadedFileProvider(
+    private val context: Context
+) {
+    fun getUriForFile(file: File): Uri = FileProvider.getUriForFile(
+        context,
+        context.applicationContext.packageName.toString() + ".miniapp.downloadedfileprovider",
+        file
+    )
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/navigator/MiniAppNavigator.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/navigator/MiniAppNavigator.kt
@@ -1,6 +1,12 @@
 package com.rakuten.tech.mobile.miniapp.navigator
 
-/** The navigation controller of sdk mini app view. **/
+import android.webkit.WebView
+import com.rakuten.tech.mobile.miniapp.MiniApp
+
+/**
+ * The navigation controller of sdk mini app view.
+ * You can optionally pass an implementation of this when creating a mini app using [MiniApp.create]
+ */
 interface MiniAppNavigator {
 
     /**
@@ -9,4 +15,37 @@ interface MiniAppNavigator {
      * @param externalResultHandler Use this to send any result such as url to mini app view.
      */
     fun openExternalUrl(url: String, externalResultHandler: ExternalResultHandler)
+}
+
+/**
+ * File download controller for mini app view.
+ * This interface can optionally be used with your MiniAppNavigator if you wish to intercept
+ * file download requests from the mini app. If you do not use this interface,
+ * then default handling will be used for file download requests.
+ */
+interface MiniAppDownloadNavigator : MiniAppNavigator {
+    /**
+     * Notify the host application that a file should be downloaded.
+     *
+     * Note that this will only receive requests When the mini app downloaded a file via JavaScript XHR.
+     * In this case the [url] received here will be a base64 data string which you must decode to bytes.
+     *
+     * In the case that a mini app wants to download a file from an external URL
+     * such as https://www.example.com/test.zip, the request will be sent to [MiniAppNavigator.openExternalUrl],
+     * so you should handle this case in your custom WebView instance using [WebView.setDownloadListener].
+     *
+     * @param url The full url to the content that should be downloaded
+     * @param userAgent the user agent to be used for the download.
+     * @param contentDisposition Content-disposition http header, if
+     *                           present.
+     * @param mimetype The mimetype of the content reported by the server
+     * @param contentLength The file size reported by the server
+     */
+    fun onFileDownloadStart(
+        url: String,
+        userAgent: String,
+        contentDisposition: String,
+        mimetype: String,
+        contentLength: Long
+    )
 }

--- a/miniapp/src/main/res/xml/miniapp_downloaded_file_provider_paths.xml
+++ b/miniapp/src/main/res/xml/miniapp_downloaded_file_provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="cache_files" path="./mini_app_download"/>
+</paths>

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppSpec.kt
@@ -1,13 +1,10 @@
 package com.rakuten.tech.mobile.miniapp
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.junit.Test
-import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
 class MiniAppSpec {
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/WebViewFileDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/WebViewFileDownloaderSpec.kt
@@ -1,0 +1,61 @@
+package com.rakuten.tech.mobile.miniapp.display
+
+import android.content.Context
+import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.amshove.kluent.Verify
+import org.amshove.kluent.called
+import org.amshove.kluent.on
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.that
+import org.amshove.kluent.was
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.mock
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class WebViewFileDownloaderSpec {
+
+    @Rule @JvmField
+    val temporaryFolder = TemporaryFolder()
+    private val context: Context = mock()
+    private val scope = TestCoroutineScope()
+    private val fileProvider: DownloadedFileProvider = mock()
+
+    private val base64Data = "iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAAAAABzQ+pjAAAAC0lEQVQI12NgQAAAAAwAA" +
+            "eQ06mYAAAAASUVORK5CYII="
+    private val dataUrl = "data:image/png;base64,$base64Data"
+    private val mimeType = "image/png"
+
+    private lateinit var fileDownloader: WebViewFileDownloader
+    private lateinit var cache: File
+
+    @Before
+    fun setup() {
+        cache = temporaryFolder.newFolder()
+        fileDownloader = WebViewFileDownloader(context, cache, scope, mock(), fileProvider)
+    }
+
+    @Test
+    fun `onDownloadStart should launch a Chooser Intent`() {
+        fileDownloader.onDownloadStart(dataUrl, mimeType) {}
+
+        Verify on context that context.startActivity(argThat {
+            action == Intent.ACTION_CHOOSER
+        }) was called
+    }
+
+    @Test
+    fun `cleanup should delete the cache folder`() {
+        fileDownloader.onDownloadStart(dataUrl, mimeType) {}
+        fileDownloader.cleanup()
+
+        cache.exists() shouldBe false
+    }
+}


### PR DESCRIPTION
# Description
Note that this is being merged to a `feature` branch because we will release this as it's own 3.6.0 release.

The mini app sdk receives a Base64 URI from the mini app which we save to a temporary file and then create an Intent to share the file to another App.

I added a few unit tests, but they don't really cover the feature fully, so probably I can make another PR to add more tests.

## Links
MINI-3999

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
