### PR TITLE
Remove jcenter from build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     ext.glide = '4.11.0'
     ext.jsr250 = '1.0'
     ext.junit = '4.12'
-    ext.kluent_android = '1.48'
+    ext.kluent_android = '1.59'
     ext.kotlin_coroutines = '1.3.3'
     ext.kotlin_version = '1.3.50'
     ext.material = '1.3.0'
@@ -48,7 +48,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 }
 
@@ -67,7 +66,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
         // check whether can get env var
         if (property("GITHUB_USERNAME") != null) {
             maven {

--- a/miniapp/build.gradle
+++ b/miniapp/build.gradle
@@ -83,6 +83,7 @@ dependencies {
     testImplementation "org.json:json:$json_test"
 
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_coroutines"
+    implementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testImplementation "org.robolectric:robolectric:$robolectric"
     testImplementation "com.squareup.okhttp3:mockwebserver:$okhttp"
     testImplementation "com.google.android.gms:play-services-ads:$google_ads"


### PR DESCRIPTION
# Description
Jcenter has been deprecated and all of our depedendencies have been migrated elswhere

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
