### PR TITLE
fix: Create custom download cache file provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGELOG
 
+### 3.6.1 (2021-09-17)
+- **Fix:** Prevent manifest merger failure when Host App already has implemented a FileProvider.
+
 ### 3.6.0 (2021-09-16)
 - **Feature:** Added support for downloading files in a Mini App, and added `MiniAppDownloadNavigator` interface for overriding the default file download behavior.
 

--- a/miniapp/src/main/AndroidManifest.xml
+++ b/miniapp/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
             tools:replace="android:initOrder" />
 
         <provider
-            android:name="androidx.core.content.FileProvider"
+            android:name="com.rakuten.tech.mobile.miniapp.display.MiniAppDownloadedFileProvider"
             android:authorities="${applicationId}.miniapp.downloadedfileprovider"
             android:exported="false"
             android:grantUriPermissions="true">

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/WebViewFileDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/WebViewFileDownloader.kt
@@ -68,6 +68,8 @@ internal class WebViewFileDownloader(
     }
 }
 
+class MiniAppDownloadedFileProvider : FileProvider()
+
 internal class DownloadedFileProvider(
     private val context: Context
 ) {

--- a/miniapp/src/main/res/xml/miniapp_downloaded_file_provider_paths.xml
+++ b/miniapp/src/main/res/xml/miniapp_downloaded_file_provider_paths.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
-    <cache-path name="cache_files" path="./mini_app_download"/>
+    <cache-path name="miniapp_downloaded_files_cache" path="./mini_app_download"/>
 </paths>


### PR DESCRIPTION
# Description
Created mini apps own implementation of FileProvider using the default implementation of FileProvider. This prevents manifest merger conflicts when the Host App is already using a FileProvider in their App.

## Links
MINI-4064

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
