### PR TITLE
bugfix: resolve crash when click on permissions button on settings page

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/MiniAppDownloadedListActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/MiniAppDownloadedListActivity.kt
@@ -18,6 +18,7 @@ import com.rakuten.tech.mobile.miniapp.testapp.databinding.MiniappDownloadedList
 import com.rakuten.tech.mobile.testapp.helper.MiniAppListStore
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import com.rakuten.tech.mobile.testapp.ui.miniapplist.MiniAppListViewModel
+import com.rakuten.tech.mobile.testapp.ui.miniapplist.MiniAppListViewModelFactory
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
 import com.rakuten.tech.mobile.testapp.ui.settings.SettingsProgressDialog
 
@@ -82,8 +83,9 @@ class MiniAppDownloadedListActivity(private val miniApp: MiniApp) : BaseActivity
 
     private fun loadList() {
         settingsProgressDialog.show()
+        val factory = MiniAppListViewModelFactory(MiniApp.instance(AppSettings.instance.miniAppSettings))
         viewModel =
-            ViewModelProvider.NewInstanceFactory().create(MiniAppListViewModel::class.java).apply {
+                ViewModelProvider(this, factory).get(MiniAppListViewModel::class.java).apply {
                 settingsProgressDialog.cancel()
                 miniAppListData.observe(
                     this@MiniAppDownloadedListActivity,


### PR DESCRIPTION
# Description
This PR will resolve the following issue when click on "Permissions" button in Demo app settings:

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{com.rakuten.tech.mobile.miniapp.testapp.debug/com.rakuten.tech.mobile.testapp.ui.permission.MiniAppDownloadedListActivity}: java.lang.RuntimeException: Cannot create an instance of class com.rakuten.tech.mobile.testapp.ui.miniapplist.MiniAppListViewModel
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2913)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3048)
       ....
     Caused by: java.lang.RuntimeException: Cannot create an instance of class com.rakuten.tech.mobile.testapp.ui.miniapplist.MiniAppListViewModel
        at androidx.lifecycle.ViewModelProvider$NewInstanceFactory.create(ViewModelProvider.java:221)
        at com.rakuten.tech.mobile.testapp.ui.permission.MiniAppDownloadedListActivity.loadList(MiniAppDownloadedListActivity.kt:86)
        at com.rakuten.tech.mobile.testapp.ui.permission.MiniAppDownloadedListActivity.renderScreen(MiniAppDownloadedListActivity.kt:71)
        at com.rakuten.tech.mobile.testapp.ui.permission.MiniAppDownloadedListActivity.onCreate(MiniAppDownloadedListActivity.kt:56)
        ....
```

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
