### PR TITLE
Add SSL pinning Only for QRCode Feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 **SDK**
 - **Feature:** Added `admob-latest` module to support latest admob sdk.
 - **Feature:** Added `getMiniAppInfoByPreviewCode` interface to get MiniAppInfo by preview code.
-- **Feature:** Added optional public key pinning through meta data.
+- **Feature:** Added optional public key pinning through `MiniAppSdkConfig`.
 - **Feature:** Added additional rat events to track sdk feature usage.
 - **Feature:** Added signature verification process before downloading a MiniApp. HostApp also can enable the settings of SDK to verify signature. Please see user-guide.
 

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -48,7 +48,6 @@ The SDK is configured via `meta-data` tags in your `AndroidManifest.xml`. The fo
 | RAS Project ID               | String  | `com.rakuten.tech.mobile.ras.ProjectId`                | ❌         | 🚫        |
 | RAS Project Subscription Key | String  | `com.rakuten.tech.mobile.ras.ProjectSubscriptionKey`   | ❌         | 🚫        |
 | Host App User Agent Info     | String  | `com.rakuten.tech.mobile.miniapp.HostAppUserAgentInfo` | ✅         | 🚫        |
-| Public Key For SSL Pinning   | String  | `com.rakuten.tech.mobile.ras.SSLPinningPublicKey`      | ✅         | 🚫        |
 
 **Note:**  
 * We don't currently host a public API, so you will need to provide your own Base URL for API requests.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -211,7 +211,7 @@ abstract class MiniApp internal constructor() {
                 rasProjectId = miniAppSdkConfig.rasProjectId,
                 subscriptionKey = miniAppSdkConfig.subscriptionKey,
                 isPreviewMode = miniAppSdkConfig.isPreviewMode,
-                sslPublicKey = miniAppSdkConfig.sslPinningPublicKey
+                sslPublicKeyList = miniAppSdkConfig.sslPinningPublicKeyList
             )
             val apiClientRepository = ApiClientRepository().apply {
                 registerApiClient(defaultConfig, apiClient)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -214,7 +214,7 @@ abstract class MiniApp internal constructor() {
                 sslPublicKey = miniAppSdkConfig.sslPinningPublicKey
             )
             val apiClientRepository = ApiClientRepository().apply {
-                registerApiClient(defaultConfig.key, apiClient)
+                registerApiClient(defaultConfig, apiClient)
             }
             val signatureVerifier: SignatureVerifier? = SignatureVerifier.init(
                 context = context,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -25,7 +25,7 @@ data class MiniAppSdkConfig(
     val isPreviewMode: Boolean,
     val requireSignatureVerification: Boolean,
     val miniAppAnalyticsConfigList: List<MiniAppAnalyticsConfig> = emptyList(),
-    val sslPinningPublicKey: String = ""
+    val sslPinningPublicKeyList: List<String> = emptyList()
 ) : Parcelable {
     internal val key = "$baseUrl-$isPreviewMode-$rasProjectId-$subscriptionKey"
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -61,12 +61,6 @@ class MiniappSdkInitializer : ContentProvider() {
          **/
         @MetaData(key = "com.rakuten.tech.mobile.ras.ProjectSubscriptionKey")
         fun subscriptionKey(): String
-
-        /**
-         * Public Key for the ssl pinning.
-         **/
-        @MetaData(key = "com.rakuten.tech.mobile.ras.SSLPinningPublicKey")
-        fun sslPinningPublicKey(): String
     }
 
     override fun onCreate(): Boolean {
@@ -90,8 +84,7 @@ class MiniappSdkInitializer : ContentProvider() {
         subscriptionKey = manifestConfig.subscriptionKey(),
         hostAppUserAgentInfo = manifestConfig.hostAppUserAgentInfo(),
         isPreviewMode = manifestConfig.isPreviewMode(),
-        requireSignatureVerification = manifestConfig.requireSignatureVerification(),
-        sslPinningPublicKey = manifestConfig.sslPinningPublicKey()
+        requireSignatureVerification = manifestConfig.requireSignatureVerification()
     )
 
     private fun executeMiniAppAnalytics(rasProjId: String) {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -140,11 +140,11 @@ internal class RealMiniApp(
         downloadedManifestCache.readDownloadedManifest(appId)?.miniAppManifest
 
     override fun updateConfiguration(newConfig: MiniAppSdkConfig, setConfigAsDefault: Boolean) {
-        var nextApiClient = apiClientRepository.getApiClientFor(newConfig.key)
+        var nextApiClient = apiClientRepository.getApiClientFor(newConfig)
         if (nextApiClient == null) {
             nextApiClient = createApiClient(newConfig)
             if (setConfigAsDefault)
-                apiClientRepository.registerApiClient(newConfig.key, nextApiClient)
+                apiClientRepository.registerApiClient(newConfig, nextApiClient)
         }
 
         nextApiClient.also {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -212,6 +212,6 @@ internal class RealMiniApp(
         rasProjectId = newConfig.rasProjectId,
         subscriptionKey = newConfig.subscriptionKey,
         isPreviewMode = newConfig.isPreviewMode,
-        sslPublicKey = newConfig.sslPinningPublicKey
+        sslPublicKeyList = newConfig.sslPinningPublicKeyList
     )
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -40,11 +40,11 @@ internal class ApiClient @VisibleForTesting constructor(
         rasProjectId: String,
         subscriptionKey: String,
         isPreviewMode: Boolean = false,
-        sslPublicKey: String = ""
+        sslPublicKeyList: List<String> = emptyList()
     ) : this(
         retrofit = createRetrofitClient(
             baseUrl = baseUrl,
-            pubKey = sslPublicKey,
+            pubKeyList = sslPublicKeyList,
             rasProjectId = rasProjectId,
             subscriptionKey = subscriptionKey
         ),

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClientRepository.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClientRepository.kt
@@ -1,11 +1,12 @@
 package com.rakuten.tech.mobile.miniapp.api
 
 import androidx.collection.ArrayMap
+import com.rakuten.tech.mobile.miniapp.MiniAppSdkConfig
 
 internal class ApiClientRepository {
-    private val apiClients: MutableMap<String, ApiClient> = ArrayMap()
+    private val apiClients: MutableMap<MiniAppSdkConfig, ApiClient> = ArrayMap()
 
-    fun registerApiClient(key: String, apiClient: ApiClient) = apiClients.put(key, apiClient)
+    fun registerApiClient(config: MiniAppSdkConfig, apiClient: ApiClient) = apiClients.put(config, apiClient)
 
-    fun getApiClientFor(key: String): ApiClient? = apiClients[key]
+    fun getApiClientFor(config: MiniAppSdkConfig): ApiClient? = apiClients[config]
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtils.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtils.kt
@@ -66,7 +66,7 @@ private fun provideHeaderInterceptor(): Interceptor = Interceptor { chain ->
 
 private fun createCertificatePinner(baseUrl: String, pubKeyList: List<String>): CertificatePinner {
     val certificatePinnerBuilder = CertificatePinner.Builder()
-    for (pubKey in pubKeyList){
+    for (pubKey in pubKeyList) {
         certificatePinnerBuilder.add(extractBaseUrl(baseUrl), pubKey)
     }
     return certificatePinnerBuilder.build()

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtils.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtils.kt
@@ -15,12 +15,12 @@ import java.net.URI
 
 internal fun createRetrofitClient(
     baseUrl: String,
-    pubKey: String,
+    pubKeyList: List<String>,
     rasProjectId: String,
     subscriptionKey: String
 ) = createRetrofitClient(
     baseUrl = baseUrl,
-    pubKey = pubKey,
+    pubKeyList = pubKeyList,
     headers = RasSdkHeaders(
         appId = rasProjectId,
         subscriptionKey = subscriptionKey,
@@ -32,18 +32,18 @@ internal fun createRetrofitClient(
 @VisibleForTesting
 internal fun createRetrofitClient(
     baseUrl: String,
-    pubKey: String,
+    pubKeyList: List<String>,
     headers: RasSdkHeaders
 ): Retrofit {
     @Suppress("SpreadOperator")
     val httpClientBuilder = OkHttpClient.Builder()
         .addHeaderInterceptor(*headers.asArray())
         .addInterceptor(provideHeaderInterceptor())
-    if (pubKey != "") {
+    if (pubKeyList.isNotEmpty()) {
         httpClientBuilder.certificatePinner(
             createCertificatePinner(
                 baseUrl = baseUrl,
-                pubKey = pubKey
+                pubKeyList = pubKeyList
             )
         )
     }
@@ -64,10 +64,12 @@ private fun provideHeaderInterceptor(): Interceptor = Interceptor { chain ->
     chain.proceed(request)
 }
 
-private fun createCertificatePinner(baseUrl: String, pubKey: String): CertificatePinner {
-    return CertificatePinner.Builder()
-        .add(extractBaseUrl(baseUrl), pubKey)
-        .build()
+private fun createCertificatePinner(baseUrl: String, pubKeyList: List<String>): CertificatePinner {
+    val certificatePinnerBuilder = CertificatePinner.Builder()
+    for (pubKey in pubKeyList){
+        certificatePinnerBuilder.add(extractBaseUrl(baseUrl), pubKey)
+    }
+    return certificatePinnerBuilder.build()
 }
 
 private fun extractBaseUrl(baseUrl: String): String {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -60,7 +60,7 @@ open class BaseRealMiniAppSpec {
                 ratDispatcher = ratDispatcher
             ))
 
-        When calling apiClientRepository.getApiClientFor(miniAppSdkConfig.key) itReturns apiClient
+        When calling apiClientRepository.getApiClientFor(miniAppSdkConfig) itReturns apiClient
         When calling miniAppSdkConfig.rasProjectId itReturns TEST_HA_ID_PROJECT
         When calling miniAppSdkConfig.miniAppAnalyticsConfigList itReturns TEST_HA_ANALYTICS_CONFIGS
     }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
@@ -36,7 +36,7 @@ internal const val TEST_CALLBACK_ID = "test_callback_id"
 internal const val TEST_CALLBACK_VALUE = "test_callback_value"
 
 internal const val TEST_AD_UNIT_ID = "ca-app-pub-xxxxxxxxxxxxxxxx/xxxxxxxxxx"
-internal const val TEST_PUBLIC_KEY_SSL = ""
+internal val TEST_LIST_PUBLIC_KEY_SSL = emptyList<String>()
 
 private val FILE_SEPARATOR = File.separator
 internal val VALID_FILE_URL_PATH =

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientRepositorySpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientRepositorySpec.kt
@@ -1,22 +1,24 @@
 package com.rakuten.tech.mobile.miniapp.api
 
+import com.rakuten.tech.mobile.miniapp.MiniAppSdkConfig
 import org.mockito.kotlin.mock
 import org.amshove.kluent.shouldBe
 import org.junit.Test
 
 class ApiClientRepositorySpec {
     private val apiClientRepository = ApiClientRepository()
+    private val miniAppSdkConfig: MiniAppSdkConfig = mock()
 
     @Test
     fun `should get null when there is no ApiClient stored`() {
-        apiClientRepository.getApiClientFor("key") shouldBe null
+        apiClientRepository.getApiClientFor(miniAppSdkConfig) shouldBe null
     }
 
     @Test
     fun `should get the exact ApiClient which had been stored`() {
         val apiClient: ApiClient = mock()
 
-        apiClientRepository.registerApiClient("key", apiClient)
-        apiClientRepository.getApiClientFor("key") shouldBe apiClient
+        apiClientRepository.registerApiClient(miniAppSdkConfig, apiClient)
+        apiClientRepository.getApiClientFor(miniAppSdkConfig) shouldBe apiClient
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtilsSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtilsSpec.kt
@@ -1,6 +1,6 @@
 package com.rakuten.tech.mobile.miniapp.api
 
-import com.rakuten.tech.mobile.miniapp.TEST_PUBLIC_KEY_SSL
+import com.rakuten.tech.mobile.miniapp.TEST_LIST_PUBLIC_KEY_SSL
 import org.mockito.kotlin.mock
 import com.rakuten.tech.mobile.miniapp.TEST_VALUE
 import com.rakuten.tech.mobile.sdkutils.RasSdkHeaders
@@ -62,7 +62,7 @@ class RetrofitCreatorUtilsSpec private constructor(
 
     private fun createClient() = createRetrofitClient(
         baseUrl = baseUrl,
-        pubKey = TEST_PUBLIC_KEY_SSL,
+        pubKeyList = TEST_LIST_PUBLIC_KEY_SSL,
         headers = mockRasSdkHeaders
     )
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
@@ -56,7 +56,7 @@ open class RetrofitRequestExecutorSpec private constructor(
         AppInfo.instance = mock()
         val retrofit = createRetrofitClient(
             baseUrl = TEST_URL_HTTPS_2,
-            pubKey = TEST_PUBLIC_KEY_SSL,
+            pubKeyList = TEST_LIST_PUBLIC_KEY_SSL,
             rasProjectId = TEST_HA_ID_PROJECT,
             subscriptionKey = TEST_HA_SUBSCRIPTION_KEY
         )

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -55,8 +55,8 @@ android {
             adMobAppId              : property("ADMOB_APP_ID") ?: "",
             appName                 : defaultAppName + " DEBUG",
             ratEndpoint             : property("ANALYTICS_ENDPOINT") ?: "https://www.example.com/",
-            sslPublicKey            : property("STG_CERTIFICATE_PUBLIC_KEY") ?: "",
-            sslPublicKeyBackup      : property("STG_CERTIFICATE_PUBLIC_KEY_BACKUP") ?: "",
+            sslPublicKey            : property("CERTIFICATE_PUBLIC_KEY") ?: "",
+            sslPublicKeyBackup      : property("CERTIFICATE_PUBLIC_KEY_BACKUP") ?: "",
     ] + commonPlaceholders
     def stagingManifestPlaceholders = debugManifestPlaceholders.clone()
     stagingManifestPlaceholders.appName = defaultAppName + " STG"

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -55,6 +55,8 @@ android {
             adMobAppId              : property("ADMOB_APP_ID") ?: "",
             appName                 : defaultAppName + " DEBUG",
             ratEndpoint             : property("ANALYTICS_ENDPOINT") ?: "https://www.example.com/",
+            sslPublicKey            : property("STG_CERTIFICATE_PUBLIC_KEY") ?: "",
+            sslPublicKeyBackup      : property("STG_CERTIFICATE_PUBLIC_KEY_BACKUP") ?: "",
     ] + commonPlaceholders
     def stagingManifestPlaceholders = debugManifestPlaceholders.clone()
     stagingManifestPlaceholders.appName = defaultAppName + " STG"
@@ -68,6 +70,8 @@ android {
             adMobAppId              : property("PROD_ADMOB_APP_ID") ?: "",
             appName                 : defaultAppName,
             ratEndpoint             : property("PROD_ANALYTICS_ENDPOINT") ?: "https://www.example.com/",
+            sslPublicKey            : property("PROD_CERTIFICATE_PUBLIC_KEY") ?: "",
+            sslPublicKeyBackup      : property("PROD_CERTIFICATE_PUBLIC_KEY_BACKUP") ?: "",
     ] + commonPlaceholders
 
     def buildVersion = System.getenv("CIRCLE_BUILD_NUM") ?: new Date().format('yyMMddHHmm')
@@ -79,10 +83,11 @@ android {
             resValue "string", "build_version", buildVersion
             resValue "string", "miniapp_sdk_version", project.version
             resValue "string", "appcenter_secret", debugManifestPlaceholders.appCenterSecret
+            resValue "string", "sslPublicKey", debugManifestPlaceholders.sslPublicKey
+            resValue "string", "sslPublicKeyBackup", debugManifestPlaceholders.sslPublicKeyBackup
             debuggable true
             minifyEnabled false
             buildConfigField 'boolean', 'ENABLE_APPCENTER_CRASHLYTICS', 'false'
-            buildConfigField "String", "STG_CERTIFICATE_PUBLIC_KEY", property("STG_CERTIFICATE_PUBLIC_KEY") ?: ""
 
             manifestPlaceholders = debugManifestPlaceholders
         }
@@ -90,11 +95,12 @@ android {
             resValue "string", "build_version", buildVersion
             resValue "string", "miniapp_sdk_version", project.version
             resValue "string", "appcenter_secret", prodManifestPlaceholders.appCenterSecret
+            resValue "string", "sslPublicKey", prodManifestPlaceholders.sslPublicKey
+            resValue "string", "sslPublicKeyBackup", prodManifestPlaceholders.sslPublicKeyBackup
             debuggable true
             minifyEnabled true
             shrinkResources true
             buildConfigField 'boolean', 'ENABLE_APPCENTER_CRASHLYTICS', 'true'
-            buildConfigField "String", "PROD_CERTIFICATE_PUBLIC_KEY", property("PROD_CERTIFICATE_PUBLIC_KEY") ?: ""
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 
             manifestPlaceholders = prodManifestPlaceholders
@@ -105,7 +111,6 @@ android {
             versionNameSuffix "-STG-build-$buildVersion"
             buildConfigField 'boolean', 'ENABLE_APPCENTER_CRASHLYTICS', 'true'
             matchingFallbacks = ['release', 'debug']
-            buildConfigField "String", "STG_CERTIFICATE_PUBLIC_KEY", property("STG_CERTIFICATE_PUBLIC_KEY") ?: ""
 
             manifestPlaceholders = stagingManifestPlaceholders
         }
@@ -115,7 +120,6 @@ android {
             versionNameSuffix "-RC-build-$buildVersion"
             buildConfigField 'boolean', 'ENABLE_APPCENTER_CRASHLYTICS', 'true'
             matchingFallbacks = ['release', 'debug']
-            buildConfigField "String", "PROD_CERTIFICATE_PUBLIC_KEY", property("STG_CERTIFICATE_PUBLIC_KEY") ?: ""
 
             manifestPlaceholders = stagingManifestPlaceholders
         }

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -55,7 +55,6 @@ android {
             adMobAppId              : property("ADMOB_APP_ID") ?: "",
             appName                 : defaultAppName + " DEBUG",
             ratEndpoint             : property("ANALYTICS_ENDPOINT") ?: "https://www.example.com/",
-            sslPinningPublicKey     : property("STG_CERTIFICATE_PUBLIC_KEY") ?: ""
     ] + commonPlaceholders
     def stagingManifestPlaceholders = debugManifestPlaceholders.clone()
     stagingManifestPlaceholders.appName = defaultAppName + " STG"
@@ -69,7 +68,6 @@ android {
             adMobAppId              : property("PROD_ADMOB_APP_ID") ?: "",
             appName                 : defaultAppName,
             ratEndpoint             : property("PROD_ANALYTICS_ENDPOINT") ?: "https://www.example.com/",
-            sslPinningPublicKey     : property("PROD_CERTIFICATE_PUBLIC_KEY") ?: ""
     ] + commonPlaceholders
 
     def buildVersion = System.getenv("CIRCLE_BUILD_NUM") ?: new Date().format('yyMMddHHmm')
@@ -84,6 +82,7 @@ android {
             debuggable true
             minifyEnabled false
             buildConfigField 'boolean', 'ENABLE_APPCENTER_CRASHLYTICS', 'false'
+            buildConfigField "String", "STG_CERTIFICATE_PUBLIC_KEY", property("STG_CERTIFICATE_PUBLIC_KEY") ?: ""
 
             manifestPlaceholders = debugManifestPlaceholders
         }
@@ -95,6 +94,7 @@ android {
             minifyEnabled true
             shrinkResources true
             buildConfigField 'boolean', 'ENABLE_APPCENTER_CRASHLYTICS', 'true'
+            buildConfigField "String", "PROD_CERTIFICATE_PUBLIC_KEY", property("PROD_CERTIFICATE_PUBLIC_KEY") ?: ""
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 
             manifestPlaceholders = prodManifestPlaceholders
@@ -105,6 +105,7 @@ android {
             versionNameSuffix "-STG-build-$buildVersion"
             buildConfigField 'boolean', 'ENABLE_APPCENTER_CRASHLYTICS', 'true'
             matchingFallbacks = ['release', 'debug']
+            buildConfigField "String", "STG_CERTIFICATE_PUBLIC_KEY", property("STG_CERTIFICATE_PUBLIC_KEY") ?: ""
 
             manifestPlaceholders = stagingManifestPlaceholders
         }
@@ -114,6 +115,7 @@ android {
             versionNameSuffix "-RC-build-$buildVersion"
             buildConfigField 'boolean', 'ENABLE_APPCENTER_CRASHLYTICS', 'true'
             matchingFallbacks = ['release', 'debug']
+            buildConfigField "String", "PROD_CERTIFICATE_PUBLIC_KEY", property("STG_CERTIFICATE_PUBLIC_KEY") ?: ""
 
             manifestPlaceholders = stagingManifestPlaceholders
         }

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -116,9 +116,6 @@
         <meta-data
             android:name="com.rakuten.tech.mobile.analytics.RATEndpoint"
             android:value="${ratEndpoint}" />
-        <meta-data
-            android:name="com.rakuten.tech.mobile.ras.SSLPinningPublicKey"
-            android:value="${sslPinningPublicKey}" />
     </application>
 
 </manifest>

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/deeplink/SchemeActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/deeplink/SchemeActivity.kt
@@ -71,7 +71,7 @@ class SchemeActivity : BaseActivity(), PreloadMiniAppWindow.PreloadMiniAppLaunch
                     } catch (e: MiniAppHostException) {
                         showErrorDialog(QRCodeErrorType.MiniAppNoPermission)
                     } catch (e: SSLCertificatePinnigException) {
-                        Log.e("SSLCertificatePinnigException", e.message ?: "")
+                        Log.e("SSLCertificatePinningException", e.message ?: "")
                         finish()
                     } catch (e: MiniAppSdkException) {
                         showErrorDialog(QRCodeErrorType.MiniAppNoLongerExist)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/deeplink/SchemeActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/deeplink/SchemeActivity.kt
@@ -11,6 +11,7 @@ import com.rakuten.tech.mobile.testapp.ui.display.error.QRCodeErrorType
 import com.rakuten.tech.mobile.testapp.ui.display.error.QRErrorWindow
 import com.rakuten.tech.mobile.testapp.ui.display.preload.PreloadMiniAppWindow
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
+import com.rakuten.tech.mobile.miniapp.testapp.R
 
 /**
  * This activity will be the gateway of all deeplink scheme.
@@ -114,7 +115,10 @@ class SchemeActivity : BaseActivity(), PreloadMiniAppWindow.PreloadMiniAppLaunch
                     BuildConfig.ADDITIONAL_ANALYTICS_AID
                 )
             ),
-            sslPinningPublicKey = BuildConfig.STG_CERTIFICATE_PUBLIC_KEY
+            sslPinningPublicKeyList = listOf(
+                getString(R.string.sslPublicKey),
+                getString(R.string.sslPublicKeyBackup)
+            )
         )
     }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/error/QRErrorWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/error/QRErrorWindow.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.testapp.ui.display.error
 
+import android.app.Activity
 import android.app.AlertDialog
 import android.content.Context
 import android.text.SpannableString
@@ -58,7 +59,7 @@ class QRErrorWindow {
      * [errorType] type of error.
      * [onClosed] callback when the window closes.
      */
-    fun showMiniAppQRCodeError(errorType: QRCodeErrorType, onClosed: (()->Unit)? = null) {
+    fun showMiniAppQRCodeError(errorType: QRCodeErrorType, onClosed: (() -> Unit)? = null) {
         if (instance != null) {
             renderScreen(errorType)
             this.onClosed = onClosed
@@ -80,7 +81,9 @@ class QRErrorWindow {
         binding.tvErrorDescription.movementMethod = LinkMovementMethod.getInstance()
         binding.btnClose.setOnClickListener(listener)
         dialog.setCancelable(false)
-        dialog.show()
+        if (!(context as Activity).isFinishing) {
+            dialog.show()
+        }
     }
 
     /** return the thumb image res id. */
@@ -92,7 +95,7 @@ class QRErrorWindow {
     }
 
     /** return the error title and error description for specific error type. */
-    private fun getTitleDescription(type: QRCodeErrorType, versionCode: String? = null): Pair<String,SpannableString>{
+    private fun getTitleDescription(type: QRCodeErrorType, versionCode: String? = null): Pair<String, SpannableString>{
         when (type) {
             QRCodeErrorType.MiniAppNoLongerExist -> {
                 return Pair(
@@ -114,13 +117,19 @@ class QRErrorWindow {
             }
             QRCodeErrorType.MiniAppNoPreview -> {
                 return Pair(
-                    context.resources.getString(R.string.error_title_miniapp_no_preview,versionCode ?: ""),
+                    context.resources.getString(
+                        R.string.error_title_miniapp_no_preview,
+                        versionCode ?: ""
+                    ),
                     spanDescription(context.resources.getString(R.string.error_desc_miniapp_no_preview))
                 )
             }
             QRCodeErrorType.MiniAppVersionMisMatch -> {
                 return Pair(
-                    context.resources.getString(R.string.error_title_miniapp_version_mismatch,versionCode ?: ""),
+                    context.resources.getString(
+                        R.string.error_title_miniapp_version_mismatch,
+                        versionCode ?: ""
+                    ),
                     spanDescription(context.resources.getString(R.string.error_desc_miniapp_version_mismatch))
                 )
             }
@@ -130,7 +139,12 @@ class QRErrorWindow {
     /** return the description with added listener which can open support link */
     private fun spanDescription(des: String): SpannableString{
         val ss = SpannableString(des)
-        ss.setSpan(spanListener, getSpanIndex(des).first, getSpanIndex(des).second, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        ss.setSpan(
+            spanListener,
+            getSpanIndex(des).first,
+            getSpanIndex(des).second,
+            Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
         return ss
     }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -137,8 +137,7 @@ class AppSettings private constructor(context: Context) {
                     BuildConfig.ADDITIONAL_ANALYTICS_ACC,
                     BuildConfig.ADDITIONAL_ANALYTICS_AID
                 )
-            ),
-            sslPinningPublicKey = manifestConfig.sslPinningPublicKey()
+            )
         )
 
     companion object {


### PR DESCRIPTION
# Description
- Remove SSLPinningPublicKey from metadata.
- Add SSL pinning through `MiniAppSdkConfig`, if `sslPinningPublicKey` in `MiniAppSdkConfig` is not empty ssl pinning will be enabled.
- Update CHANGELOG and USERGUIDE
- Update the `ApiClientRepository` to store `apiClient` against `sdkConfig` instead of `sdkConfig.key`.
- Added  `sslPinningPublicKeyList` in `MiniAppSdkConfig` to be able to add backup public key.

## Links


# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
