### PR TITLE
Fix: kotlin.collections.ArraysKt__ArraysJVMKt.copyOfRangeToIndexCheck

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -208,7 +208,7 @@ internal class MiniAppDownloader(
         when {
             doesManifestFileExist(manifest.first) -> {
                 for (file in manifest.first.files) {
-                    if (isSignatureValid(apiClient.downloadFile(file)?.byteStream(), versionId, manifest)) {
+                    if (isSignatureValid(apiClient.downloadFile(file).byteStream(), versionId, manifest)) {
                         miniAppAnalytics.sendAnalytics(
                             eType = Etype.CLICK,
                             actype = Actype.SIGNATURE_VALIDATION_SUCCESS,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/SignatureVerifier.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/SignatureVerifier.kt
@@ -2,6 +2,7 @@ package com.rakuten.tech.mobile.miniapp.signatureverifier
 
 import android.content.Context
 import android.util.Base64
+import android.util.Log
 import com.rakuten.tech.mobile.miniapp.signatureverifier.api.PublicKeyFetcher
 import com.rakuten.tech.mobile.miniapp.signatureverifier.api.SignatureApiClient
 import com.rakuten.tech.mobile.miniapp.signatureverifier.verification.PublicKeyCache
@@ -22,7 +23,6 @@ import java.security.spec.ECGenParameterSpec
 import java.security.spec.ECParameterSpec
 import java.security.spec.ECPoint
 import java.security.spec.ECPublicKeySpec
-import java.util.*
 
 /**
  * Main entry point for the Signature Verifier.
@@ -97,7 +97,7 @@ internal class SignatureVerifier(
             val keyFactory = KeyFactory.getInstance("EC")
             return keyFactory.generatePublic(keySpec) as ECPublicKey
         } catch (e: java.lang.Exception) {
-            e.printStackTrace()
+            Log.e(TAG, e.message.toString())
             return null
         }
     }
@@ -109,7 +109,7 @@ internal class SignatureVerifier(
         return (kpg.generateKeyPair().public as ECPublicKey).params
     }
 
-    @SuppressWarnings("MagicNumber", "PrintStackTrace")
+    @SuppressWarnings("MagicNumber")
     private fun calculateSha256Hash(byteArray: ByteArray): String {
         var generated: String? = null
         try {
@@ -121,12 +121,13 @@ internal class SignatureVerifier(
             }
             generated = sb.toString()
         } catch (e: NoSuchAlgorithmException) {
-            e.printStackTrace()
+            Log.e(TAG, e.message.toString())
         }
         return generated.toString()
     }
 
     companion object {
+        private const val TAG = "SignatureVerifier"
         private const val SIXTEEN_KILOBYTES = 16 * 1024
 
         private const val UNCOMPRESSED_OFFSET = 1

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/api/PublicKeyFetcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/signatureverifier/api/PublicKeyFetcher.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.miniapp.signatureverifier.api
 
+import androidx.annotation.Keep
 import com.google.gson.Gson
 import com.google.gson.JsonSyntaxException
 import java.io.IOException
@@ -20,6 +21,7 @@ internal class PublicKeyFetcher(private val client: SignatureApiClient) {
     }
 }
 
+@Keep
 internal data class PublicKeyResponse(
     val id: String = "",
     val ecKey: String = "",


### PR DESCRIPTION
# Description
There is an issue has been reported e.g. https://appcenter.ms/orgs/Rakuten-Early-Adoption-Organization/apps/Mini-App-Sample/crashes/errors/2398348339u/overview - when SignatureVerifier wants to fetch the public key from api using `PublicKeyFetcher`, its not working in non-debug builds because the `data class` has been minified. This PR aims to fix this issue. Additionally, there is an exception handling is preserved to return `false` value when verifying the signature in case there are other issues while preparing the `ECPublicKey`.

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
