### PR TITLE
fix: add default value for requireSignatureVerification

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -23,7 +23,7 @@ data class MiniAppSdkConfig(
     val hostAppVersionId: String = "",
     val hostAppUserAgentInfo: String,
     val isPreviewMode: Boolean,
-    val requireSignatureVerification: Boolean,
+    val requireSignatureVerification: Boolean = false,
     val miniAppAnalyticsConfigList: List<MiniAppAnalyticsConfig> = emptyList(),
     val sslPinningPublicKeyList: List<String> = emptyList()
 ) : Parcelable {


### PR DESCRIPTION
# Description
This PR aims to add a default value `(=false)` in `MiniAppSdkConfig.requireSignatureVerification` in order to avoid breaking change in HostApp.

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
