### PR TITLE
[MINI-4415] Get default locale from host app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## CHANGELOG
 
 ### 3.9.0 (2021-XX-XX)
+**SDK**
+- **Feature:** Added `hostLocale` in `HostEnvironmentInfo` to provide default language value from Host App.
+
 **Sample App**
 - **Feature:** Added production and staging toggle to change environments.
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -20,6 +20,7 @@ import com.rakuten.tech.mobile.miniapp.js.chat.ChatBridge
 import com.rakuten.tech.mobile.miniapp.js.chat.ChatBridgeDispatcher
 import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostEnvironmentInfo
 import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostEnvironmentInfoError
+import com.rakuten.tech.mobile.miniapp.js.hostenvironment.isValidLocale
 import com.rakuten.tech.mobile.miniapp.js.userinfo.UserInfoBridge
 import com.rakuten.tech.mobile.miniapp.js.userinfo.UserInfoBridgeDispatcher
 import com.rakuten.tech.mobile.miniapp.permission.CustomPermissionBridgeDispatcher
@@ -30,6 +31,7 @@ import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionResult
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppDevicePermissionResult
 import com.rakuten.tech.mobile.miniapp.permission.ui.MiniAppCustomPermissionWindow
 import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
+import java.util.Locale
 
 @Suppress(
     "TooGenericExceptionCaught", "TooManyFunctions", "LongMethod", "LargeClass",
@@ -143,12 +145,17 @@ open class MiniAppMessageBridge {
         onSuccess: (info: HostEnvironmentInfo) -> Unit,
         onError: (infoError: HostEnvironmentInfoError) -> Unit
     ) {
+        var locale = Locale.getDefault().toLanguageTag()
+        if (!locale.isValidLocale())
+            locale = ""
+
         val hostEnvironmentInfo = HostEnvironmentInfo(
                 platformVersion = Build.VERSION.RELEASE,
                 hostVersion = activity.packageManager.getPackageInfo(
                         activity.packageName, 0
                 ).versionName,
-                sdkVersion = BuildConfig.VERSION_NAME
+                sdkVersion = BuildConfig.VERSION_NAME,
+                hostLocale = locale
         )
 
         onSuccess.invoke(hostEnvironmentInfo)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostAppInfoHelper.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostAppInfoHelper.kt
@@ -1,0 +1,6 @@
+package com.rakuten.tech.mobile.miniapp.js.hostenvironment
+
+import java.util.regex.Pattern
+
+internal fun String.isValidLocale(): Boolean =
+    Pattern.compile("^[a-z]{2}(-[A-Z]{2})?\$").matcher(this).matches()

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostEnvironmentInfo.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostEnvironmentInfo.kt
@@ -7,5 +7,6 @@ import androidx.annotation.Keep
 data class HostEnvironmentInfo(
     val platformVersion: String,
     val hostVersion: String,
-    val sdkVersion: String
+    val sdkVersion: String,
+    val hostLocale: String
 )

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostAppInfoHelperSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostAppInfoHelperSpec.kt
@@ -1,0 +1,22 @@
+package com.rakuten.tech.mobile.miniapp.js.hostenvironment
+
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HostAppInfoHelperSpec {
+
+    @Test
+    fun `host app locale value should match with appropriate pattern`() {
+        assertTrue("en-US".isValidLocale())
+    }
+
+    @Test
+    fun `host app locale value should not match with inappropriate pattern`() {
+        assertFalse("en_US".isValidLocale())
+        assertFalse("00-00".isValidLocale())
+        assertFalse("enn-US".isValidLocale())
+        assertFalse("en-USS".isValidLocale())
+        assertFalse("enn-USS".isValidLocale())
+    }
+}

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostEnvironmentInfoBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostEnvironmentInfoBridgeSpec.kt
@@ -17,6 +17,7 @@ import org.mockito.Mockito
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import java.util.*
 
 @RunWith(AndroidJUnit4::class)
 class HostEnvironmentInfoBridgeSpec : BridgeCommon() {
@@ -48,7 +49,8 @@ class HostEnvironmentInfoBridgeSpec : BridgeCommon() {
             val hostEnvironmentInfo = HostEnvironmentInfo(
                     platformVersion = Build.VERSION.RELEASE,
                     hostVersion = activity.packageManager.getPackageInfo(activity.packageName, 0).versionName,
-                    sdkVersion = BuildConfig.VERSION_NAME
+                    sdkVersion = BuildConfig.VERSION_NAME,
+                    hostLocale = Locale.getDefault().toLanguageTag()
             )
             val miniAppBridge = Mockito.spy(createDefaultMiniAppMessageBridge())
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostEnvironmentInfoBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostEnvironmentInfoBridgeSpec.kt
@@ -17,7 +17,7 @@ import org.mockito.Mockito
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
-import java.util.*
+import java.util.Locale
 
 @RunWith(AndroidJUnit4::class)
 class HostEnvironmentInfoBridgeSpec : BridgeCommon() {


### PR DESCRIPTION
# Description
We need to support in SDK, so that, HostApp can provide locale value to MiniApp. A locale value is considered as a BCP 47 Language tag composed of 2 letters for the country and 2 letters for the language, separated by a dash e.g. `en-US`. In this purpose, this PR aims to add `hostLocale` field to `HostEnvironmentInfo`. 

## Links
- MINI-4415

## Screenshot
![Screen Shot 2021-12-01 at 16 56 03](https://user-images.githubusercontent.com/66930373/144194233-9b8fa972-962c-4b53-9e67-8d0fd3eca270.png)
# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
