### PR TITLE
[MINI-4458] bugfix: empty host locale value

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -5,10 +5,11 @@ import android.content.Intent
 import android.os.Build
 import android.webkit.JavascriptInterface
 import androidx.annotation.VisibleForTesting
-import androidx.core.content.ContextCompat
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
-import com.rakuten.tech.mobile.miniapp.*
+import com.rakuten.tech.mobile.miniapp.BuildConfig
+import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
+import com.rakuten.tech.mobile.miniapp.R
 import com.rakuten.tech.mobile.miniapp.CustomPermissionsNotImplementedException
 import com.rakuten.tech.mobile.miniapp.DevicePermissionsNotImplementedException
 import com.rakuten.tech.mobile.miniapp.ads.AdMobDisplayer19
@@ -31,7 +32,6 @@ import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionResult
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppDevicePermissionResult
 import com.rakuten.tech.mobile.miniapp.permission.ui.MiniAppCustomPermissionWindow
 import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
-import java.util.Locale
 
 @Suppress(
     "TooGenericExceptionCaught", "TooManyFunctions", "LongMethod", "LargeClass",

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -5,12 +5,12 @@ import android.content.Intent
 import android.os.Build
 import android.webkit.JavascriptInterface
 import androidx.annotation.VisibleForTesting
+import androidx.core.content.ContextCompat
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
-import com.rakuten.tech.mobile.miniapp.BuildConfig
+import com.rakuten.tech.mobile.miniapp.*
 import com.rakuten.tech.mobile.miniapp.CustomPermissionsNotImplementedException
 import com.rakuten.tech.mobile.miniapp.DevicePermissionsNotImplementedException
-import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.ads.AdMobDisplayer19
 import com.rakuten.tech.mobile.miniapp.ads.MiniAppAdDisplayer
 import com.rakuten.tech.mobile.miniapp.display.WebViewListener
@@ -145,7 +145,7 @@ open class MiniAppMessageBridge {
         onSuccess: (info: HostEnvironmentInfo) -> Unit,
         onError: (infoError: HostEnvironmentInfoError) -> Unit
     ) {
-        var locale = Locale.getDefault().toLanguageTag()
+        var locale = activity.getString(R.string.miniapp_sdk_android_locale)
         if (!locale.isValidLocale())
             locale = ""
 

--- a/miniapp/src/main/res/values-ja/strings.xml
+++ b/miniapp/src/main/res/values-ja/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="miniapp.sdk.android.locale">ja-JP</string>
+</resources>

--- a/miniapp/src/main/res/values-ja/strings.xml
+++ b/miniapp/src/main/res/values-ja/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="miniapp.sdk.android.locale">ja-JP</string>
+    <string name="miniapp_sdk_android_locale">ja-JP</string>
 </resources>

--- a/miniapp/src/main/res/values/strings.xml
+++ b/miniapp/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
-    <string name="miniapp_sdk_android_save">Save</string>
-    <string name="miniapp_sdk_android_close">Close</string>
+    <string name="miniapp_sdk_android_save" translatable="false">Save</string>
+    <string name="miniapp_sdk_android_close" translatable="false">Close</string>
     <!-- Permission resources -->
-    <string name="miniapp_sdk_android_permission_tutorial">MiniApp wants to access the following permissions. Please choose your preference accordingly.</string>
+    <string name="miniapp_sdk_android_permission_tutorial" translatable="false">MiniApp wants to access the following permissions. Please choose your preference accordingly.</string>
+    <string name="miniapp.sdk.android.locale">en-US</string>
 </resources>

--- a/miniapp/src/main/res/values/strings.xml
+++ b/miniapp/src/main/res/values/strings.xml
@@ -3,5 +3,5 @@
     <string name="miniapp_sdk_android_close" translatable="false">Close</string>
     <!-- Permission resources -->
     <string name="miniapp_sdk_android_permission_tutorial" translatable="false">MiniApp wants to access the following permissions. Please choose your preference accordingly.</string>
-    <string name="miniapp.sdk.android.locale">en-US</string>
+    <string name="miniapp_sdk_android_locale">en-US</string>
 </resources>


### PR DESCRIPTION
# Description
Host locale is coming empty when the device language is Chinese. This PR aims to fix it with matching with spec. By default, if HostApp doesn't support any language, then it should return `en-US` to MiniApp.

## Links
- MINI-4458

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
