### PR TITLE
[MINI-4418] Support promotional image text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 **SDK**
 - **Feature:** Added `languageCode` parameter in `MiniApp.getMiniAppManifest` to support for internationalized manifest.
 - **Feature:** Added `hostLocale` in `HostEnvironmentInfo` to provide default language value from Host App.
+- **Feature:** Added `promotionalImageUrl` and `promotionalText` in MiniAppInfo model.
 
 **Sample App**
 - **Feature:** Added production and staging toggle to change environments.
+- **Feature:** Adding Sharing option to display the promotional content via `MiniAppDisplay`.
 
 ### 3.8.0 (2021-11-09)
 **SDK**

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppInfo.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppInfo.kt
@@ -18,10 +18,13 @@ data class MiniAppInfo(
     @SerializedName("id") val id: String,
     @SerializedName("displayName") val displayName: String,
     @SerializedName("icon") val icon: String,
-    @SerializedName("version") val version: Version
+    @SerializedName("version") val version: Version,
+    @SerializedName("promotionalImageUrl") val promotionalImageUrl: String,
+    @SerializedName("promotionalText") val promotionalText: String
 ) : Parcelable {
     companion object {
-        internal fun forUrl() = MiniAppInfo(UUID.randomUUID().toString(), "", "", Version("", ""))
+        internal fun forUrl() =
+            MiniAppInfo(UUID.randomUUID().toString(), "", "", Version("", ""), "", "")
     }
 }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppInfo.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppInfo.kt
@@ -11,6 +11,8 @@ import java.util.UUID
  * @property displayName Display name of the mini app.
  * @property icon Icon of the mini app, obtainable from the provided data for this resource.
  * @property version Version information of the mini app.
+ * @property promotionalImageUrl promotional image, obtainable from the provided data for this resource.
+ * @property promotionalText promotional details to share.
  */
 @Parcelize
 data class MiniAppInfo(

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloaderSpec.kt
@@ -76,7 +76,8 @@ open class MiniAppDownloaderBaseSpec {
         When calling apiClient.fetchInfo(appId) itReturns
                 MiniAppInfo(
                     id = appId, displayName = TEST_MA_DISPLAY_NAME, icon = "",
-                    version = Version(versionTag = TEST_MA_VERSION_TAG, versionId = versionId)
+                    version = Version(versionTag = TEST_MA_VERSION_TAG, versionId = versionId),
+                    promotionalImageUrl = TEST_PROMOTIONAL_URL, promotionalText = TEST_PROMOTIONAL_TEXT
                 )
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -247,7 +247,8 @@ class RealMiniAppSpec : BaseRealMiniAppSpec() {
     fun `should return the correct result when listDownloadedWithCustomPermissions calls`() {
         val miniAppInfo = MiniAppInfo(
             "test_id", "display_name", "test_icon_url",
-            Version("test_version_tag", "test_version_id")
+            Version("test_version_tag", "test_version_id"),
+            TEST_PROMOTIONAL_URL, TEST_PROMOTIONAL_TEXT
         )
         val downloadedList = listOf(miniAppInfo)
         val miniAppCustomPermission = MiniAppCustomPermission(

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
@@ -49,12 +49,16 @@ internal const val INVALID_FILE_URL_PATH = "https://78d85043-d04f-486a-8212-bf26
 internal const val TEST_USER_NAME = "test_user_name"
 internal const val TEST_PROFILE_PHOTO = "data:image/png;base64,encodedValue"
 internal val TEST_CONTACT = Contact("test_contact_id", "test_contact_name", "test_contact_email")
+internal const val TEST_PROMOTIONAL_URL = "http://testImageurl.co"
+internal const val TEST_PROMOTIONAL_TEXT = "test_promotional_text"
 
 internal val TEST_MA = MiniAppInfo(
     id = TEST_MA_ID,
     displayName = TEST_MA_DISPLAY_NAME,
     icon = TEST_MA_ICON,
-    version = Version(versionTag = TEST_MA_VERSION_TAG, versionId = TEST_MA_VERSION_ID)
+    version = Version(versionTag = TEST_MA_VERSION_TAG, versionId = TEST_MA_VERSION_ID),
+    promotionalImageUrl = TEST_PROMOTIONAL_URL,
+    promotionalText = TEST_PROMOTIONAL_TEXT
 )
 
 // ACCESS_TOKEN_PERMISSIONS

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/analytics/MiniAppAnalyticsSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/analytics/MiniAppAnalyticsSpec.kt
@@ -11,7 +11,9 @@ class MiniAppAnalyticsSpec {
         id = "test_id",
         displayName = "test_mini_app",
         icon = "test_icon",
-        version = Version("test_version_tag", "test_version_id")
+        version = Version("test_version_tag", "test_version_id"),
+        promotionalImageUrl = TEST_PROMOTIONAL_URL,
+        promotionalText = TEST_PROMOTIONAL_TEXT
     )
 
     private val cp = JSONObject()

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
@@ -30,7 +30,9 @@ open class ApiClientSpec {
         id = TEST_MA_ID,
         displayName = TEST_MA_DISPLAY_NAME,
         icon = TEST_MA_ICON,
-        version = Version(TEST_MA_VERSION_TAG, TEST_MA_VERSION_ID)
+        version = Version(TEST_MA_VERSION_TAG, TEST_MA_VERSION_ID),
+        promotionalImageUrl = TEST_PROMOTIONAL_URL,
+        promotionalText = TEST_PROMOTIONAL_TEXT
     )
 
     private val previewMiniAppInfo = PreviewMiniAppInfo(

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
@@ -66,7 +66,9 @@ class UserInfoBridgeSpec {
         id = TEST_MA_ID,
         displayName = TEST_MA_DISPLAY_NAME,
         icon = TEST_MA_ICON,
-        version = Version(TEST_MA_VERSION_TAG, TEST_MA_VERSION_ID)
+        version = Version(TEST_MA_VERSION_TAG, TEST_MA_VERSION_ID),
+        promotionalImageUrl = TEST_PROMOTIONAL_URL,
+        promotionalText = TEST_PROMOTIONAL_TEXT
     )
     private val webViewListener: WebViewListener = mock()
     private val bridgeExecutor = Mockito.spy(MiniAppBridgeExecutor(webViewListener))

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/adapter/MiniAppListAdapter.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/adapter/MiniAppListAdapter.kt
@@ -71,7 +71,7 @@ class MiniAppListAdapter(
 
     private fun addFooter() {
         if (miniApps.size > 0) {
-            val footerItem = MiniAppInfo("", "", "", Version("", ""))
+            val footerItem = MiniAppInfo("", "", "", Version("", ""), "", "")
             miniApps.add(itemCount, footerItem)
         }
     }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -94,6 +94,11 @@ class MiniAppDisplayActivity : BaseActivity() {
 
     private lateinit var viewModel: MiniAppDisplayViewModel
 
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.miniapp_display_menu, menu)
+        return true
+    }
+
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         super.onOptionsItemSelected(item)
         return when (item.itemId) {
@@ -109,11 +114,6 @@ class MiniAppDisplayActivity : BaseActivity() {
             }
             else -> super.onOptionsItemSelected(item)
         }
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu): Boolean {
-        menuInflater.inflate(R.menu.miniapp_display_menu, menu)
-        return true
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -7,6 +7,7 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
+import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.webkit.WebView
@@ -57,6 +58,8 @@ class MiniAppDisplayActivity : BaseActivity() {
     private val fileChoosingReqCode = 10101
     private val miniAppFileChooser = MiniAppFileChooserDefault(requestCode = fileChoosingReqCode)
 
+    private var appInfo: MiniAppInfo? = null
+
     companion object {
         private val appIdTag = "app_id_tag"
         private val miniAppTag = "mini_app_tag"
@@ -98,8 +101,19 @@ class MiniAppDisplayActivity : BaseActivity() {
                 finish()
                 true
             }
+            R.id.share_mini_app -> {
+                appInfo?.let {
+                    MiniAppShareWindow.getInstance(this).show(miniAppInfo = it)
+                }
+                true
+            }
             else -> super.onOptionsItemSelected(item)
         }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.miniapp_display_menu, menu)
+        return true
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -112,7 +126,7 @@ class MiniAppDisplayActivity : BaseActivity() {
         }
 
         //Three different ways to get miniapp.
-        val appInfo = intent.getParcelableExtra<MiniAppInfo>(miniAppTag)
+        appInfo = intent.getParcelableExtra<MiniAppInfo>(miniAppTag)
         val appId = intent.getStringExtra(appIdTag) ?: appInfo?.id
         val appUrl = intent.getStringExtra(appUrlTag)
         var miniAppSdkConfig = intent.getParcelableExtra<MiniAppSdkConfig>(sdkConfigTag)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppShareWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppShareWindow.kt
@@ -45,7 +45,7 @@ class MiniAppShareWindow {
 
     private fun renderScreen(miniAppInfo: MiniAppInfo) {
         if (dialog.isShowing) dismissDialog()
-        binding.imgPromotional.load(context, miniAppInfo.promotionalImageUrl ?: "")
+        binding.imgPromotional.load(context, miniAppInfo.promotionalImageUrl)
         binding.tvPromotionalText.text = miniAppInfo.promotionalText
         binding.btnClose.setOnClickListener(listener)
         dialog.setCancelable(false)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppShareWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppShareWindow.kt
@@ -1,0 +1,63 @@
+package com.rakuten.tech.mobile.testapp.ui.display
+
+import android.app.Activity
+import android.app.AlertDialog
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import androidx.databinding.DataBindingUtil
+import com.rakuten.tech.mobile.miniapp.MiniAppInfo
+import com.rakuten.tech.mobile.miniapp.testapp.R
+import com.rakuten.tech.mobile.miniapp.testapp.databinding.WindowShareMiniappBinding
+import com.rakuten.tech.mobile.testapp.helper.load
+
+class MiniAppShareWindow {
+    companion object {
+        private var instance: MiniAppShareWindow? = null
+        private lateinit var dialog: AlertDialog
+        private lateinit var binding: WindowShareMiniappBinding
+        private lateinit var context: Context
+
+        @Synchronized
+        fun getInstance(context: Context): MiniAppShareWindow {
+            dialog = initDialog(context)
+            this.context = context
+            return instance ?: MiniAppShareWindow().also { instance = it }
+        }
+
+        private fun initDialog(context: Context): AlertDialog {
+            // set ui components
+            val layoutInflater = LayoutInflater.from(context)
+            binding = DataBindingUtil.inflate(
+                layoutInflater, R.layout.window_share_miniapp, null, false
+            )
+            val alertDialog = AlertDialog.Builder(context, R.style.AppThemeSettings).create()
+            alertDialog?.setView(binding.root)
+            return alertDialog
+        }
+    }
+
+    fun show(miniAppInfo: MiniAppInfo) {
+        if (instance != null) {
+            renderScreen(miniAppInfo)
+        }
+    }
+
+    private fun renderScreen(miniAppInfo: MiniAppInfo) {
+        if (dialog.isShowing) dismissDialog()
+        binding.imgPromotional.load(context, miniAppInfo.promotionalImageUrl ?: "")
+        binding.tvPromotionalText.text = miniAppInfo.promotionalText
+        binding.btnClose.setOnClickListener(listener)
+        dialog.setCancelable(false)
+        if (!(context as Activity).isFinishing) {
+            dialog.show()
+        }
+    }
+
+    private fun dismissDialog() {
+        dialog.cancel()
+    }
+
+    private val listener = View.OnClickListener { dismissDialog() }
+
+}

--- a/testapp/src/main/res/drawable/ic_menu_share.xml
+++ b/testapp/src/main/res/drawable/ic_menu_share.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18,16.08c-0.76,0 -1.44,0.3 -1.96,0.77L8.91,12.7c0.05,-0.23 0.09,-0.46 0.09,-0.7s-0.04,-0.47 -0.09,-0.7l7.05,-4.11c0.54,0.5 1.25,0.81 2.04,0.81 1.66,0 3,-1.34 3,-3s-1.34,-3 -3,-3 -3,1.34 -3,3c0,0.24 0.04,0.47 0.09,0.7L8.04,9.81C7.5,9.31 6.79,9 6,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3c0.79,0 1.5,-0.31 2.04,-0.81l7.12,4.16c-0.05,0.21 -0.08,0.43 -0.08,0.65 0,1.61 1.31,2.92 2.92,2.92 1.61,0 2.92,-1.31 2.92,-2.92s-1.31,-2.92 -2.92,-2.92z"/>
+</vector>

--- a/testapp/src/main/res/layout/window_share_miniapp.xml
+++ b/testapp/src/main/res/layout/window_share_miniapp.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- This Relative layout is only to show the alert Dialog fullscreen-->
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@android:color/white"
+            android:orientation="vertical"
+            android:weightSum="4">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="3"
+                android:gravity="top"
+                android:orientation="vertical">
+
+                <ImageView
+                    android:id="@+id/img_promotional"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="@dimen/margin_10"
+                    android:layout_marginBottom="@dimen/margin_30" />
+
+                <TextView
+                    android:id="@+id/tv_promotional_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/margin_20"
+                    android:layout_marginTop="@dimen/margin_16"
+                    android:layout_marginEnd="@dimen/margin_20"
+                    android:layout_marginBottom="@dimen/margin_10"
+                    android:gravity="center"
+                    android:lineSpacingExtra="@dimen/line_space_1"
+                    android:textColor="@color/qr_error_title"
+                    android:textSize="@dimen/text_large_22"
+                    android:textStyle="bold" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:gravity="center">
+
+                <TextView
+                    android:id="@+id/btn_close"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center|bottom"
+                    android:layout_marginBottom="@dimen/margin_20"
+                    android:text="@string/lb_close"
+                    android:textColor="@color/link_blue"
+                    android:textSize="@dimen/text_large_16"
+                    android:textStyle="bold" />
+            </LinearLayout>
+        </LinearLayout>
+    </RelativeLayout>
+</layout>

--- a/testapp/src/main/res/layout/window_share_miniapp.xml
+++ b/testapp/src/main/res/layout/window_share_miniapp.xml
@@ -22,23 +22,20 @@
                 <ImageView
                     android:id="@+id/img_promotional"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    android:layout_height="200dp"
                     android:layout_margin="@dimen/margin_10"
-                    android:layout_marginBottom="@dimen/margin_30" />
+                    android:layout_marginBottom="@dimen/margin_20"
+                    android:scaleType="centerCrop" />
 
                 <TextView
                     android:id="@+id/tv_promotional_text"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/margin_20"
-                    android:layout_marginTop="@dimen/margin_16"
-                    android:layout_marginEnd="@dimen/margin_20"
-                    android:layout_marginBottom="@dimen/margin_10"
+                    android:layout_margin="@dimen/margin_10"
                     android:gravity="center"
                     android:lineSpacingExtra="@dimen/line_space_1"
                     android:textColor="@color/qr_error_title"
-                    android:textSize="@dimen/text_large_22"
-                    android:textStyle="bold" />
+                    android:textSize="@dimen/text_large_16" />
             </LinearLayout>
 
             <LinearLayout

--- a/testapp/src/main/res/menu/miniapp_display_menu.xml
+++ b/testapp/src/main/res/menu/miniapp_display_menu.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/share_mini_app"
+        android:icon="@drawable/ic_menu_share"
+        android:title="@string/menu_title_change_settings"
+        app:showAsAction="always" />
+
+</menu>


### PR DESCRIPTION
# Description
- Extending MiniAppInfo by `promotionalImageUrl` and `promotionalText`
- Adding Sharing option to display the promotional content via `MiniAppDisplay`

https://user-images.githubusercontent.com/84305007/144957887-3af6be7b-c7a2-4b02-9415-ef0b4d4734e0.mov

## Links
MINI-4418

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
