### PR TITLE
bug fix (demo app) : You must call removeView() on the child's parent first.

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -10,6 +10,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup
 import android.webkit.WebView
 import android.widget.Toast
 import androidx.core.app.ActivityCompat
@@ -40,7 +41,6 @@ import com.rakuten.tech.mobile.testapp.helper.showAlertDialog
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import com.rakuten.tech.mobile.testapp.ui.chat.ChatWindow
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
-import java.net.URI
 import java.util.*
 
 class MiniAppDisplayActivity : BaseActivity() {
@@ -142,8 +142,10 @@ class MiniAppDisplayActivity : BaseActivity() {
             miniAppView.observe(this@MiniAppDisplayActivity, Observer {
                 if (ApplicationInfo.FLAG_DEBUGGABLE == 2)
                     WebView.setWebContentsDebuggingEnabled(true)
+
                 //action: display webview
                 addLifeCycleObserver(lifecycle)
+                (binding.root.parent as ViewGroup).removeAllViews()
                 setContentView(it)
             })
 


### PR DESCRIPTION
# Description
This PR aims to fix the following issue: 

```
androidx.appcompat.app.AppCompatDelegateImpl.setContentView
AppCompatDelegateImpl.java, line 687
java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
```

## Links
- MINI-4519

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
