### PR TITLE
Fix crash issue QR code preview

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppInfo.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppInfo.kt
@@ -21,8 +21,8 @@ data class MiniAppInfo(
     @SerializedName("displayName") val displayName: String,
     @SerializedName("icon") val icon: String,
     @SerializedName("version") val version: Version,
-    @SerializedName("promotionalImageUrl") val promotionalImageUrl: String,
-    @SerializedName("promotionalText") val promotionalText: String
+    @SerializedName("promotionalImageUrl") val promotionalImageUrl: String?,
+    @SerializedName("promotionalText") val promotionalText: String?
 ) : Parcelable {
     companion object {
         internal fun forUrl() =

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppShareWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppShareWindow.kt
@@ -45,8 +45,8 @@ class MiniAppShareWindow {
 
     private fun renderScreen(miniAppInfo: MiniAppInfo) {
         if (dialog.isShowing) dismissDialog()
-        binding.imgPromotional.load(context, miniAppInfo.promotionalImageUrl)
-        binding.tvPromotionalText.text = miniAppInfo.promotionalText
+        binding.imgPromotional.load(context, miniAppInfo.promotionalImageUrl ?: "", android.R.color.darker_gray)
+        binding.tvPromotionalText.text = miniAppInfo.promotionalText ?: context.getText(R.string.error_desc_promotional_text_missing)
         binding.btnClose.setOnClickListener(listener)
         dialog.setCancelable(false)
         if (!(context as Activity).isFinishing) {

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -90,6 +90,7 @@
     <string name="error_desc_miniapp_no_preview">Please check with the project \nadministrator. See our Help Center for \nmore details.</string>
     <string name="error_title_miniapp_version_mismatch">" Version %1$s is not valid "</string>
     <string name="error_desc_miniapp_version_mismatch">Please check with the project \nadministrator. See our Help Center for \nmore details.</string>
+    <string name="error_desc_promotional_text_missing">Promotional text is not available</string>
 
     <string name="help_center_text">Help Center</string>
     <string name="lb_close">Close</string>


### PR DESCRIPTION
# Description
Make promotional image and text optional.If promotional image and text is missing it will show below UI
<img src="https://user-images.githubusercontent.com/84305007/146296066-21378731-5830-47ae-b9e5-bf5edb213fc3.png" width="200" height="400"/>

## Links
MINI-4523

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
