### PR TITLE
build: Update target SDK to API 31

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  android-sdk: rakutentech/android-sdk@0.2.1
+  android-sdk: rakutentech/android-sdk@0.3.0
   app-center: rakutentech/app-center@0.1.3
 
 commands:

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 ## CHANGELOG
+### 4.0.0 (In progress)
+**SDK**
+- **Upgraded:** Target SDK is now API 31
+- **Upgraded:** SDK dependencies to new versions
+    - com.google.android.gms:play-services-ads:20.5.0
+    - org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31
+
+**Sample App**
+- **Upgraded:** Target SDK is now API 31
 
 ### 3.9.1 (2021-12-20)
 

--- a/admob-latest/build.gradle
+++ b/admob-latest/build.gradle
@@ -24,7 +24,7 @@ android {
 }
 
 ext {
-    google_ads_latest = '20.2.0'
+    google_ads_latest = '20.5.0'
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.androidBuildTool = '29.0.2'
     ext.androidx_appcompat = '1.2.0'
     ext.androidx_constraintLayout = '2.0.4'
     ext.androidx_coreKtx = '1.3.0'
@@ -14,8 +13,8 @@ buildscript {
     ext.jsr250 = '1.0'
     ext.junit = '4.12'
     ext.kluent_android = '1.59'
-    ext.kotlin_coroutines = '1.3.3'
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_coroutines = '1.5.2'
+    ext.kotlin_version = '1.5.31'
     ext.material = '1.3.0'
     ext.mockito = '3.3.3'
     ext.okhttp = '4.9.0'
@@ -37,6 +36,8 @@ buildscript {
 //  Build Config.
     apply from: 'config/index.gradle'
     CONFIG.versions.android.sdk.min = 24
+    CONFIG.versions.android.sdk.compile = 31
+    CONFIG.versions.android.sdk.target = 31
 
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'

--- a/miniapp/build.gradle
+++ b/miniapp/build.gradle
@@ -28,8 +28,6 @@ android {
         unitTests.returnDefaultValues = true
         unitTests.includeAndroidResources = true
     }
-
-    buildToolsVersion = androidBuildTool
 }
 
 androidExtensions {

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -20,7 +20,8 @@
 
         <activity
             android:name="com.rakuten.tech.mobile.testapp.ui.miniapplist.MiniAppListActivity"
-            android:launchMode="singleTop">
+            android:launchMode="singleTop"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <action android:name="android.intent.action.SEARCH" />
@@ -70,6 +71,7 @@
         <activity
             android:name="com.rakuten.tech.mobile.testapp.ui.deeplink.SchemeActivity"
             android:launchMode="singleTop"
+            android:exported="true"
             android:permission="android.permission.CAMERA"> <!-- Added camera permission so that only apps(i.e QRcode scanner) with camera permission can open demo app. -->
             <intent-filter
                 android:autoVerify="true"


### PR DESCRIPTION
# Description
Also needed to update Ad Mob SDK to 20.5.0 because previous versions do not support API 31. See https://developers.google.com/admob/android/rel-notes Also needed to update the Kotlin version in order to support API 31.

## Links
MINI-4600

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
