### PR TITLE
fix: Unable to launch mini app when device offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## CHANGELOG
 
+### 3.9.1 (2021-12-20)
+
+**SDK**
+- **Fix:** Unable to launch a mini app while the device is offline
+
 ### 3.9.0 (2021-12-17)
 **SDK**
 - **Feature:** Added `languageCode` parameter in `MiniApp.getMiniAppManifest` to support for internationalized manifest.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
@@ -67,7 +67,13 @@ class RequiredPermissionsNotGrantedException(appId: String, versionId: String) :
     MiniAppSdkException("Mini App has not been granted all of the required permissions " +
             "for the provided Mini App Id: $appId and the version id: $versionId")
 
-internal class MiniAppNetException(message: String, cause: Throwable?) : MiniAppSdkException(message, cause) {
+/**
+ * Exception indicating that there was an issue with network connectivity.
+ *
+ * This usually means the device doesn't have internet access currently,
+ * so you should display the cached mini app version.
+ */
+class MiniAppNetException(message: String, cause: Throwable?) : MiniAppSdkException(message, cause) {
 
     constructor(e: Exception) : this("Found some problem, ${e.message}", e)
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.miniapp
 
+import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.rakuten.tech.mobile.miniapp.analytics.MiniAppAnalytics
 import com.rakuten.tech.mobile.miniapp.api.ApiClient
@@ -162,7 +163,14 @@ internal class RealMiniApp(
     @VisibleForTesting
     suspend fun verifyManifest(appId: String, versionId: String) {
         val cachedManifest = downloadedManifestCache.readDownloadedManifest(appId)
-        checkToDownloadManifest(appId, versionId, cachedManifest)
+
+        try {
+            checkToDownloadManifest(appId, versionId, cachedManifest)
+        } catch (e: MiniAppNetException) {
+            Log.e("RealMiniApp", "Unable to retrieve latest manifest due to device being offline. " +
+                    "Skipping manifest download.", e)
+        }
+
         val manifestFile = downloadedManifestCache.getManifestFile(appId)
         if (cachedManifest != null && manifestVerifier.verify(appId, manifestFile)) {
             val customPermissions = miniAppCustomPermissionCache.readPermissions(appId)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppViewModel.kt
@@ -3,6 +3,7 @@ package com.rakuten.tech.mobile.testapp.ui.display.preload
 import androidx.lifecycle.*
 import com.rakuten.tech.mobile.miniapp.MiniApp
 import com.rakuten.tech.mobile.miniapp.MiniAppManifest
+import com.rakuten.tech.mobile.miniapp.MiniAppNetException
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermission
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionResult
@@ -21,16 +22,26 @@ class PreloadMiniAppViewModel(private val miniApp: MiniApp) : ViewModel() {
         get() = _manifestErrorData
 
     fun checkMiniAppManifest(miniAppId: String, versionId: String) = viewModelScope.launch(Dispatchers.IO) {
+        val downloadedManifest = miniApp.getDownloadedManifest(miniAppId)
         try {
             val miniAppManifest = miniApp.getMiniAppManifest(miniAppId, versionId, Locale.getDefault().language)
-            val downloadedManifest = miniApp.getDownloadedManifest(miniAppId)
             if (downloadedManifest != null && isManifestEqual(miniAppManifest, downloadedManifest) &&
                 isAcceptedRequiredPermissions(miniAppId, miniAppManifest))
                 _miniAppManifest.postValue(null)
             else
                 _miniAppManifest.postValue(miniAppManifest)
         } catch (error: MiniAppSdkException) {
-            _manifestErrorData.postValue(error.message)
+            when {
+                error is MiniAppNetException && downloadedManifest !== null -> {
+                    if (isAcceptedRequiredPermissions(miniAppId, downloadedManifest))
+                        _miniAppManifest.postValue(null)
+                    else
+                        _miniAppManifest.postValue(downloadedManifest)
+                }
+                else -> {
+                    _manifestErrorData.postValue(error.message)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
# Description
This fixes a case where the the mini app is unable to be launched when the device is offline. The check being done on the manifest was failing when offline. We missed this case earlier because it only occurs when testing with multiple mini apps - we cache the manifest for the last launched mini app using ManifestApiCache

## Links
MINI-4635

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
