### PR TITLE
[MINI-4670] Improve HostEnvironmentInfo to update locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### 4.0.0 (In progress)
+**SDK**
+- **Update:** Update `HostEnvironmentInfo` data class.
+
 ### 3.9.1 (2022-01-20)
 
 **SDK**

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -149,14 +149,7 @@ open class MiniAppMessageBridge {
         if (!locale.isValidLocale())
             locale = ""
 
-        val hostEnvironmentInfo = HostEnvironmentInfo(
-                platformVersion = Build.VERSION.RELEASE,
-                hostVersion = activity.packageManager.getPackageInfo(
-                        activity.packageName, 0
-                ).versionName,
-                sdkVersion = BuildConfig.VERSION_NAME,
-                hostLocale = locale
-        )
+        val hostEnvironmentInfo = HostEnvironmentInfo(activity = activity, hostLocale = locale)
 
         onSuccess.invoke(hostEnvironmentInfo)
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -2,12 +2,10 @@ package com.rakuten.tech.mobile.miniapp.js
 
 import android.app.Activity
 import android.content.Intent
-import android.os.Build
 import android.webkit.JavascriptInterface
 import androidx.annotation.VisibleForTesting
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
-import com.rakuten.tech.mobile.miniapp.BuildConfig
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.R
 import com.rakuten.tech.mobile.miniapp.CustomPermissionsNotImplementedException

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostEnvironmentInfo.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostEnvironmentInfo.kt
@@ -12,7 +12,7 @@ data class HostEnvironmentInfo constructor(
     val hostVersion: String,
     val sdkVersion: String,
     val hostLocale: String
-){
+) {
     constructor(
         activity: Activity,
         hostLocale: String

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostEnvironmentInfo.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostEnvironmentInfo.kt
@@ -1,12 +1,27 @@
 package com.rakuten.tech.mobile.miniapp.js.hostenvironment
 
+import android.app.Activity
+import android.os.Build
 import androidx.annotation.Keep
+import com.rakuten.tech.mobile.miniapp.BuildConfig
 
 /** HostEnvironmentInfo object for miniapp. */
 @Keep
-data class HostEnvironmentInfo(
+data class HostEnvironmentInfo constructor(
     val platformVersion: String,
     val hostVersion: String,
     val sdkVersion: String,
     val hostLocale: String
-)
+){
+    constructor(
+        activity: Activity,
+        hostLocale: String
+    ) : this (
+        platformVersion = Build.VERSION.RELEASE,
+        hostVersion = activity.packageManager.getPackageInfo(
+            activity.packageName, 0
+        ).versionName,
+        sdkVersion = BuildConfig.VERSION_NAME,
+        hostLocale = hostLocale
+    )
+}


### PR DESCRIPTION
# Description
Previously we have to send all the version static info's to update locale, now only locale can be passed for updating.

## Links
MINI-4670

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
