### PR TITLE
[MINI-4754][MINI-4755][MINI-4756] Fix some appcenter crash

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/AppHelper.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/AppHelper.kt
@@ -3,6 +3,7 @@ package com.rakuten.tech.mobile.testapp.helper
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.AlertDialog
+import android.app.Application
 import android.content.Context
 import android.text.InputType
 import android.util.Patterns
@@ -97,23 +98,41 @@ fun setResizableSoftInputMode(activity: Activity){
     activity.window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE + WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
 }
 
-fun getAdapterDataObserver(observeUIState: () -> Unit): RecyclerView.AdapterDataObserver =
-        object : RecyclerView.AdapterDataObserver() {
-            @SuppressLint("SyntheticAccessor")
-            override fun onChanged() {
-                super.onChanged()
-                observeUIState()
-            }
-
-            @SuppressLint("SyntheticAccessor")
-            override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
-                super.onItemRangeInserted(positionStart, itemCount)
-                observeUIState()
-            }
-
-            @SuppressLint("SyntheticAccessor")
-            override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
-                super.onItemRangeRemoved(positionStart, itemCount)
-                observeUIState()
+/**
+ * Return true if this [Context] is available.
+ * Availability is defined as the following:
+ * + [Context] is not null
+ * + [Context] is not destroyed/finishing (tested with [Activity.isDestroyed] && [Activity.isFinishing])
+ */
+val Context?.isAvailable: Boolean
+    get() {
+        if (this == null) {
+            return false
+        } else if (this !is Application) {
+            if (this is Activity) {
+                return !this.isDestroyed && !this.isFinishing
             }
         }
+        return true
+    }
+
+fun getAdapterDataObserver(observeUIState: () -> Unit): RecyclerView.AdapterDataObserver =
+    object : RecyclerView.AdapterDataObserver() {
+        @SuppressLint("SyntheticAccessor")
+        override fun onChanged() {
+            super.onChanged()
+            observeUIState()
+        }
+
+        @SuppressLint("SyntheticAccessor")
+        override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
+            super.onItemRangeInserted(positionStart, itemCount)
+            observeUIState()
+        }
+
+        @SuppressLint("SyntheticAccessor")
+        override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
+            super.onItemRangeRemoved(positionStart, itemCount)
+            observeUIState()
+        }
+    }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/AppHelper.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/AppHelper.kt
@@ -109,9 +109,7 @@ val Context?.isAvailable: Boolean
         if (this == null) {
             return false
         } else if (this !is Application) {
-            if (this is Activity) {
-                return !this.isDestroyed && !this.isFinishing
-            }
+            return this is Activity && (!this.isDestroyed && !this.isFinishing)
         }
         return true
     }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppViewModel.kt
@@ -47,14 +47,23 @@ class PreloadMiniAppViewModel(private val miniApp: MiniApp) : ViewModel() {
 
     private fun isManifestEqual(apiManifest: MiniAppManifest, downloadedManifest: MiniAppManifest): Boolean {
         val changedRequiredPermissions =
-            (apiManifest.requiredPermissions + downloadedManifest.requiredPermissions).groupBy { it.first.type }
-                .filter { it.value.size == 1 }
-                .flatMap { it.value }
+            try {
+                (apiManifest.requiredPermissions + downloadedManifest.requiredPermissions)
+                    .groupBy { it.first.type }
+                    .filter { it.value.size == 1 }
+                    .flatMap { it.value }
+            } catch (e: Exception) {
+                emptyList()
+            }
 
         val changedOptionalPermissions =
-            (apiManifest.optionalPermissions + downloadedManifest.optionalPermissions).groupBy { it.first.type }
+            try {
+                (apiManifest.optionalPermissions + downloadedManifest.optionalPermissions).groupBy { it.first.type }
                 .filter { it.value.size == 1 }
                 .flatMap { it.value }
+            } catch (e: Exception) {
+                emptyList()
+            }
 
         return changedRequiredPermissions.isEmpty() && changedOptionalPermissions.isEmpty() &&
                 apiManifest.customMetaData == downloadedManifest.customMetaData

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
@@ -20,6 +20,7 @@ import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.WindowPreloadMiniappBinding
+import com.rakuten.tech.mobile.testapp.helper.isAvailable
 import com.rakuten.tech.mobile.testapp.helper.load
 import java.lang.StringBuilder
 
@@ -75,7 +76,11 @@ class PreloadMiniAppWindow(
 
         // set data to ui
         if (miniAppInfo != null) {
-            miniAppInfo?.icon?.let { binding.preloadAppIcon.load(context, it, R.drawable.r_logo) }
+            miniAppInfo?.icon?.let {
+               // if(context.isAvailable) {
+                    binding.preloadAppIcon.load(context, it, R.drawable.r_logo)
+              //  }
+            }
             binding.preloadMiniAppName.text = miniAppInfo?.displayName.toString()
             binding.preloadMiniAppVersion.text = LABEL_VERSION + miniAppInfo?.version?.versionTag.toString()
         } else {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
@@ -77,9 +77,9 @@ class PreloadMiniAppWindow(
         // set data to ui
         if (miniAppInfo != null) {
             miniAppInfo?.icon?.let {
-               // if(context.isAvailable) {
+                if (context.isAvailable) {
                     binding.preloadAppIcon.load(context, it, R.drawable.r_logo)
-              //  }
+                }
             }
             binding.preloadMiniAppName.text = miniAppInfo?.displayName.toString()
             binding.preloadMiniAppVersion.text = LABEL_VERSION + miniAppInfo?.version?.versionTag.toString()

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
@@ -17,6 +17,7 @@ import com.rakuten.tech.mobile.miniapp.testapp.databinding.SettingsMenuActivityB
 import com.rakuten.tech.mobile.testapp.AppScreen.MINI_APP_INPUT_ACTIVITY
 import com.rakuten.tech.mobile.testapp.AppScreen.MINI_APP_LIST_ACTIVITY
 import com.rakuten.tech.mobile.testapp.BuildVariant
+import com.rakuten.tech.mobile.testapp.helper.isAvailable
 import com.rakuten.tech.mobile.testapp.helper.isInputEmpty
 import com.rakuten.tech.mobile.testapp.helper.isInvalidUuid
 import com.rakuten.tech.mobile.testapp.helper.showAlertDialog
@@ -88,7 +89,9 @@ class SettingsMenuActivity : BaseActivity() {
     }
 
     private fun onSaveAction() {
-        settingsProgressDialog.show()
+        if (this@SettingsMenuActivity.isAvailable) {
+            settingsProgressDialog.show()
+        }
 
         updateSettings(
             binding.editProjectId.text.toString(),
@@ -214,7 +217,9 @@ class SettingsMenuActivity : BaseActivity() {
 
                 settings.isSettingSaved = true
                 runOnUiThread {
-                    settingsProgressDialog.cancel()
+                    if (this@SettingsMenuActivity.isAvailable) {
+                        settingsProgressDialog.cancel()
+                    }
                     navigateToPreviousScreen()
                 }
             } catch (error: MiniAppSdkException) {
@@ -256,7 +261,9 @@ class SettingsMenuActivity : BaseActivity() {
         settings.isPreviewMode = isPreviewModeHolder
         settings.requireSignatureVerification = requireSignatureVerificationHolder
         runOnUiThread {
-            settingsProgressDialog.cancel()
+            if (this@SettingsMenuActivity.isAvailable) {
+                settingsProgressDialog.cancel()
+            }
             showAlertDialog(this@SettingsMenuActivity, errTitle, errMsg)
         }
     }
@@ -275,6 +282,13 @@ class SettingsMenuActivity : BaseActivity() {
                 raceExecutor.run { launchActivity<MiniAppInputActivity>() }
             }
             else -> finish()
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        if (settingsProgressDialog != null && settingsProgressDialog.isShowing) {
+            settingsProgressDialog.dismiss()
         }
     }
 }


### PR DESCRIPTION
# Description
Addded some checks and try catch to fix some appcenter crash.
`java.lang.IllegalArgumentException: You cannot start a load for a destroyed activity`
`IllegalArgumentException: SettingsMenuActivity - not attached to window manager`
`kotlin.TypeCastException: null cannot be cast to non-null type android.view.ViewGroup`

## Links
MINI-4754, MINI-4755, MINI-4756

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
