### PR TITLE
[MINI-4778] Retrieve mini-app directly from cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - **Update:** Removed admob 19 support.
 - **Feature:** Added [Ad placement beta](https://developers.google.com/ad-placement) support. Please see user-guide.
 - **Update:** Renamed `AdMobDisplayer20` to `AdMobDisplayer`.
+- **Update:** Updated create method with optional fromCache variable that helps to load the mini-app from cache.
 
 **Sample App**
 - **Upgraded:** Target SDK is now API 31

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -53,6 +53,7 @@ abstract class MiniApp internal constructor() {
      * @param miniAppNavigator allow host app to handle specific urls such as external link.
      * @param miniAppFileChooser allow host app to get the file path while choosing file inside the webview.
      * @param queryParams the parameters will be appended with the miniapp url scheme.
+     * @param fromCache allow host app to load miniapp from cache.
      * @throws [MiniAppNotFoundException] when the specified project ID does not have any mini app exist on the server.
      * @throws [MiniAppHasNoPublishedVersionException] when the specified mini app ID exists on the
      * server but has no published versions
@@ -71,7 +72,8 @@ abstract class MiniApp internal constructor() {
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator? = null,
         miniAppFileChooser: MiniAppFileChooser? = null,
-        queryParams: String = ""
+        queryParams: String = "",
+        fromCache: Boolean = false
     ): MiniAppDisplay
 
     /**
@@ -83,6 +85,7 @@ abstract class MiniApp internal constructor() {
      * @param miniAppNavigator allow host app to handle specific urls such as external link.
      * @param miniAppFileChooser allow host app to get the file path while choosing file inside the webview.
      * @param queryParams the parameters will be appended with the miniapp url scheme.
+     * @param fromCache allow host app to load miniapp from cache.
      * @throws [MiniAppNotFoundException] when the specified project ID does not have any mini app exist on the server.
      * @throws [MiniAppHasNoPublishedVersionException] when the specified mini app ID exists on the
      * server but has no published versions
@@ -101,7 +104,8 @@ abstract class MiniApp internal constructor() {
         miniAppMessageBridge: MiniAppMessageBridge,
         miniAppNavigator: MiniAppNavigator? = null,
         miniAppFileChooser: MiniAppFileChooser? = null,
-        queryParams: String = ""
+        queryParams: String = "",
+        fromCache: Boolean = false
     ): MiniAppDisplay
 
     /**

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -115,7 +115,8 @@ internal class MiniAppDownloader(
 
         if (!apiClient.isPreviewMode && miniAppStatus.isVersionDownloaded(
                 miniAppInfo.id,
-                miniAppInfo.version.versionId, versionPath
+                miniAppInfo.version.versionId,
+                versionPath
             )
         ) {
             return if (verifier.verify(miniAppInfo.version.versionId, File(versionPath)))
@@ -268,8 +269,37 @@ internal class MiniAppDownloader(
         this.requireSignatureVerification = isRequired
     }
 
+    fun getCachedMiniApp(appId: String): Pair<String, MiniAppInfo> {
+        val miniAppInfo = miniAppStatus.getDownloadedMiniApp(appId)
+        return if (miniAppInfo != null) {
+            onGetCachedMiniApp(miniAppInfo)
+        } else {
+            throw MiniAppNotFoundException(MINIAPP_NOT_FOUND_OR_CORRUPTED)
+        }
+    }
+
+    fun getCachedMiniApp(appInfo: MiniAppInfo): Pair<String, MiniAppInfo> {
+        if (miniAppStatus.isVersionDownloaded(
+                appId = appInfo.id,
+                versionId = appInfo.version.versionId,
+                versionPath = storage.getMiniAppVersionPath(appInfo.id, appInfo.version.versionId)
+            )
+        ) {
+            return onGetCachedMiniApp(appInfo)
+        }
+        return throw MiniAppNotFoundException(MINIAPP_NOT_FOUND_OR_CORRUPTED)
+    }
+
+    private fun onGetCachedMiniApp(appInfo: MiniAppInfo): Pair<String, MiniAppInfo> {
+        return Pair(
+            storage.getMiniAppVersionPath(appId = appInfo.id, appInfo.version.versionId),
+            appInfo
+        )
+    }
+
     companion object {
         private const val TAG = "MiniAppDownloader"
         private const val SIGNATURE_VERIFICATION_ERR = "Failed to verify the signature of MiniApp's zip."
+        internal const val MINIAPP_NOT_FOUND_OR_CORRUPTED = "Mini app is not downloaded properly or corrupted"
     }
 }


### PR DESCRIPTION
# Description
* Retrieve mini-app from cache directly using `fromCache` variable.
  * Offline support is enable already, however SDK is trying to fetch the info of a mini-app when `create()` is called. This change would provide an option to the Host app to directly fetch the mini-app from cache.

## Links
MINI-4778

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
