### PR TITLE
build: Update dokka to 1.16.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     ext.androidx_test_ext = '1.1.4-alpha03'
     ext.androidx_activity = '1.2.4'
     ext.detekt = '1.1.1'
-    ext.dokka_version = '0.10.0'
+    ext.dokka_version = '1.6.10'
     ext.glide = '4.12.0'
     ext.jsr250 = '1.0'
     ext.junit = '4.13.2'

--- a/miniapp/build.gradle
+++ b/miniapp/build.gradle
@@ -119,10 +119,10 @@ tasks.withType(Test) {
 }
 
 apply from: '../config/documentation/dokka/android.gradle'
-dokka {
-    configuration {
-        sourceRoot {
-            path = "miniapp/src/main"
+dokkaGfm.configure {
+    dokkaSourceSets {
+        named("main") {
+            sourceRoots.from(file("src/main/java"))
         }
     }
 }


### PR DESCRIPTION
# Description
The older version of Dokka was not compatible with Kotlin 1.4.0+.
Also updated the android-buildconfig module.

## Links
MINI-4845

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
