### PR TITLE
feat: Add support for base64 data URIs to File Download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## CHANGELOG
+
+### 4.2.0 (in progress)
+**SDK**
+- **Feature:** Added support for base64 `data:` URIs to the File Download feature in `MiniAppFileDownloader`.
+
 ### 4.1.0 (2022-04-11)
 **SDK**
 - **Feature:** Added interface `MiniAppFileDownloader` to download files in device from miniapp.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppDownloadFileError.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppDownloadFileError.kt
@@ -3,13 +3,14 @@ package com.rakuten.tech.mobile.miniapp.errors
 /**
  * A class to provide the custom errors specific for file download.
  */
-class MiniAppDownloadFileError(val type: String? = null, val message: String? = null) :
+class MiniAppDownloadFileError(val type: String? = null, val message: String? = null, val code: Int? = null) :
     MiniAppBridgeError(type, message) {
 
     companion object {
         private const val DownloadFailedError = "DownloadFailedError"
         private const val InvalidUrlError = "InvalidUrlError"
         private const val SaveFailureError = "SaveFailureError"
+        private const val DownloadHttpError = "DownloadHttpError"
 
         // Failed to download file.
         val downloadFailedError = MiniAppDownloadFileError(DownloadFailedError, errorDescription(DownloadFailedError))
@@ -19,12 +20,11 @@ class MiniAppDownloadFileError(val type: String? = null, val message: String? = 
 
         val saveFailureError = MiniAppDownloadFileError(SaveFailureError, errorDescription(SaveFailureError))
 
-        /**
-         *  send custom error message from host app.
-         *  @property code error code send to miniapp.
-         *  @property reason error message send to mini app.
-         */
-        fun custom(code: String, reason: String) = MiniAppDownloadFileError(code, reason)
+        internal fun httpError(code: Int, message: String) = MiniAppDownloadFileError(
+            type = DownloadHttpError,
+            code = code,
+            message = message
+        )
 
         private fun errorDescription(error: String): String {
             return when (error) {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileDownloaderSpec.kt
@@ -1,5 +1,8 @@
 package com.rakuten.tech.mobile.miniapp.file
 
+import android.app.Activity
+import android.content.ContentResolver
+import android.content.Intent
 import android.net.Uri
 import android.webkit.MimeTypeMap
 import androidx.test.core.app.ActivityScenario
@@ -7,6 +10,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.gson.Gson
 import com.rakuten.tech.mobile.miniapp.TEST_CALLBACK_ID
 import com.rakuten.tech.mobile.miniapp.TestActivity
+import com.rakuten.tech.mobile.miniapp.errors.MiniAppDownloadFileError
 import com.rakuten.tech.mobile.miniapp.js.ActionType
 import com.rakuten.tech.mobile.miniapp.js.FileDownloadCallbackObj
 import com.rakuten.tech.mobile.miniapp.js.FileDownloadParams
@@ -14,17 +18,25 @@ import kotlinx.coroutines.test.TestCoroutineScope
 import okhttp3.Request
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import org.amshove.kluent.When
+import org.amshove.kluent.calling
+import org.amshove.kluent.itReturns
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
-import org.mockito.kotlin.verify
+import org.mockito.Mockito.timeout
+import org.mockito.kotlin.*
+import org.mockito.kotlin.mock
 import org.robolectric.Shadows
+import java.io.OutputStream
 import kotlin.test.assertEquals
 
 @RunWith(AndroidJUnit4::class)
+@Suppress("LargeClass")
 class MiniAppFileDownloaderSpec {
     private val TEST_IMAGE_MIME = "image/jpeg"
     private val TEST_FILENAME = "test.jpg"
@@ -36,7 +48,20 @@ class MiniAppFileDownloaderSpec {
         id = TEST_CALLBACK_ID
     )
     private val TEST_DEST_URI = Uri.parse("https://sample/com/test.jpg")
+    private val TEST_BASE64_DATA_URI = "data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAAAA" +
+            "ABzQ+pjAAAAC0lEQVQI12NgQAAAAAwAAeQ06mYAAAAASUVORK5CYII="
+    private val TEST_MIME_TYPE = "image/jpeg"
+    private val TEST_EXPECTED_BYTES = byteArrayOf(
+        -119, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82,
+        0, 0, 0, 3, 0, 0, 0, 3, 8, 0, 0, 0, 0, 115, 67, -22, 99, 0, 0, 0, 11, 73, 68, 65, 84, 8, -41, 99,
+        96, 64, 0, 0, 0, 12, 0, 1, -28, 52, -22, 102, 0, 0, 0, 0, 73, 69, 78, 68, -82, 66, 96, -126
+    )
     private val fileDownloadJsonStr = Gson().toJson(fileDownloadCallbackObj)
+    private lateinit var mockServer: MockWebServer
+    private val mockContentResolver: ContentResolver = mock()
+    private val mockActivity: Activity = mock {
+        on { contentResolver } itReturns mockContentResolver
+    }
     private lateinit var activity: TestActivity
 
     @Before
@@ -44,11 +69,17 @@ class MiniAppFileDownloaderSpec {
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
             this.activity = activity
         }
+        mockServer = MockWebServer()
 
         // setup for the MimeTypeMap
         val mtm = MimeTypeMap.getSingleton()
         Shadows.shadowOf(mtm).addExtensionMimeTypMapping("jpg", TEST_IMAGE_MIME)
         Shadows.shadowOf(mtm).addExtensionMimeTypMapping("jpeg", TEST_IMAGE_MIME)
+    }
+
+    @After
+    fun after() {
+        mockServer.shutdown()
     }
 
     @Test
@@ -78,7 +109,6 @@ class MiniAppFileDownloaderSpec {
 
     @Test
     fun `startDownloading should invoke success callback if request is successful`() {
-            val mockServer = MockWebServer()
             mockServer.enqueue(MockResponse().setBody(""))
             mockServer.start()
             val url: String = mockServer.url("/sample/com/test.jpg").toString()
@@ -95,13 +125,10 @@ class MiniAppFileDownloaderSpec {
 
             miniAppFileDownloader.onReceivedResult(TEST_DEST_URI)
             verify(miniAppFileDownloader).onDownloadSuccess
-
-            mockServer.shutdown()
         }
 
     @Test
     fun `startDownloading should invoke fail callback if request isn't successful`() {
-        val mockServer = MockWebServer()
         mockServer.enqueue(MockResponse().setResponseCode(400))
         mockServer.start()
         val url: String = mockServer.url("/sample/com/test.jpg").toString()
@@ -118,7 +145,100 @@ class MiniAppFileDownloaderSpec {
 
         miniAppFileDownloader.onReceivedResult(TEST_DEST_URI)
         verify(miniAppFileDownloader).onDownloadFailed
+    }
 
-        mockServer.shutdown()
+    @Test
+    fun `onStartFileDownload when called with data URI should launch an Intent to create a new document`() {
+        val miniAppFileDownloader = MiniAppFileDownloaderDefault(mockActivity, 100)
+
+        miniAppFileDownloader.onStartFileDownload(TEST_FILENAME, TEST_BASE64_DATA_URI, TEST_HEADER_OBJECT, {}, {})
+
+        verify(mockActivity).startActivityForResult(
+            argWhere { intent ->
+                intent.action == Intent.ACTION_CREATE_DOCUMENT &&
+                        intent.type == TEST_MIME_TYPE &&
+                        intent.extras!!.getString(Intent.EXTRA_TITLE) == TEST_FILENAME
+            },
+            eq(100)
+        )
+    }
+
+    @Test
+    fun `onStartFileDownload when called with an HTTPS URL should launch an Intent to create a new document`() {
+        val miniAppFileDownloader = MiniAppFileDownloaderDefault(mockActivity, 100)
+
+        miniAppFileDownloader.onStartFileDownload(TEST_FILENAME, TEST_FILE_URL, TEST_HEADER_OBJECT, {}, {})
+
+        verify(mockActivity).startActivityForResult(
+            argWhere { intent ->
+                intent.action == Intent.ACTION_CREATE_DOCUMENT &&
+                        intent.type == TEST_MIME_TYPE &&
+                        intent.extras!!.getString(Intent.EXTRA_TITLE) == TEST_FILENAME
+            },
+            eq(100)
+        )
+    }
+
+    @Test
+    fun `onStartFileDownload when called with invalid URL should return InvalidUrlError to onFailedDownload`() {
+        val onFailed: (MiniAppDownloadFileError) -> Unit = mock()
+        val miniAppFileDownloader = MiniAppFileDownloaderDefault(mockActivity, 100)
+
+        miniAppFileDownloader.onStartFileDownload(
+            TEST_FILENAME,
+            "test-invalid-url://test",
+            TEST_HEADER_OBJECT,
+            {},
+            onFailed
+        )
+
+        verify(onFailed).invoke(MiniAppDownloadFileError.invalidUrlError)
+    }
+
+    @Test
+    fun `onReceivedResult when called with data URI should call onSuccess`() {
+        val destinationUri: Uri = mock()
+        val miniAppFileDownloader = MiniAppFileDownloaderDefault(activity, 100)
+        val onSuccess: (String) -> Unit = mock()
+
+        miniAppFileDownloader.onStartFileDownload(
+            TEST_FILENAME,
+            TEST_BASE64_DATA_URI,
+            TEST_HEADER_OBJECT,
+            onSuccess,
+            {}
+        )
+        miniAppFileDownloader.onReceivedResult(destinationUri)
+
+        verify(onSuccess, timeout(100)).invoke(TEST_FILENAME)
+    }
+
+    @Test
+    fun `onReceivedResult when called with data URI should write the file data to the URI location chosen by user`() {
+        val destinationUri: Uri = mock()
+        val outputStream: OutputStream = mock()
+        val miniAppFileDownloader = MiniAppFileDownloaderDefault(mockActivity, 100)
+        When calling mockContentResolver.openOutputStream(destinationUri) itReturns outputStream
+
+        miniAppFileDownloader.onStartFileDownload(TEST_FILENAME, TEST_BASE64_DATA_URI, TEST_HEADER_OBJECT, {}, {})
+        miniAppFileDownloader.onReceivedResult(destinationUri)
+
+        verify(outputStream).write(argWhere {
+            val byteArray = it.copyOfRange(0, TEST_EXPECTED_BYTES.size) // trim buffer bytes from end
+            byteArray.contentEquals(TEST_EXPECTED_BYTES)
+        }, any(), any())
+    }
+
+    @Test
+    fun `onReceivedResult when fails to decode data URI should return error to onFailedDownload`() {
+        val invalidDataUri = "data:image/png;base64,12345"
+        val onFailed: (MiniAppDownloadFileError) -> Unit = mock()
+        val destinationUri: Uri = mock()
+        val miniAppFileDownloader = MiniAppFileDownloaderDefault(mockActivity, 100)
+
+        miniAppFileDownloader.onStartFileDownload(TEST_FILENAME, invalidDataUri, TEST_HEADER_OBJECT, {}, onFailed)
+        miniAppFileDownloader.onReceivedResult(destinationUri)
+
+        verify(onFailed).invoke(MiniAppDownloadFileError.saveFailureError)
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppBridgeSpec.kt
@@ -140,7 +140,7 @@ open class BridgeCommon {
 }
 
 @RunWith(AndroidJUnit4::class)
-@Suppress("LongMethod")
+@Suppress("LongMethod", "LargeClass")
 class MiniAppMessageBridgeSpec : BridgeCommon() {
     private val miniAppBridge: MiniAppMessageBridge = Mockito.spy(
         createMiniAppMessageBridge(false)


### PR DESCRIPTION
# Description
Added support for `data:` URIs to `MiniAppFileDownloader`.

## Links
MINI-4979

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
