### PR TITLE
[MINI-5007] Fix Size and Clear Storage Display on first launch

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppSecureStorageDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppSecureStorageDispatcher.kt
@@ -200,10 +200,7 @@ internal class MiniAppSecureStorageDispatcher(
             val storageSize = Gson().toJson(MiniAppSecureStorageSize(fileSize, maxSizeInBytes.toLong()))
             bridgeExecutor.postValue(callbackId, storageSize)
         }
-        val onFailed = { errorSecure: MiniAppSecureStorageError ->
-            bridgeExecutor.postError(callbackId, Gson().toJson(errorSecure))
-        }
-        secureStorage.secureStorageSize(miniAppId, onSuccess, onFailed)
+        secureStorage.secureStorageSize(miniAppId, onSuccess)
     }
 
     fun cleanupSecureStorage() {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppSecureStorage.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppSecureStorage.kt
@@ -50,13 +50,12 @@ internal class MiniAppSecureStorage(private val activity: Activity) {
     fun secureStorageSize(
         miniAppId: String,
         onSuccess: (Long) -> Unit,
-        onFailed: (MiniAppSecureStorageError) -> Unit
     ) {
         if (isStorageAvailable(miniAppId)) {
             val sizeInBytes = File(secureStorageBasePath, "$miniAppId.txt").length()
             onSuccess(sizeInBytes)
         } else {
-            onFailed(MiniAppSecureStorageError.secureStorageUnavailableError)
+            onSuccess(0)
         }
     }
 
@@ -145,7 +144,7 @@ internal class MiniAppSecureStorage(private val activity: Activity) {
                 }
             }
         } else {
-            onFailed(MiniAppSecureStorageError.secureStorageUnavailableError)
+            onSuccess()
         }
     }
 


### PR DESCRIPTION
# Description
Show Get Size 0 and Clear storage success on first launch.
![Screen Shot 2022-05-09 at 10 35 00 AM](https://user-images.githubusercontent.com/84305007/167326192-26a0ebb4-590f-4dc5-93cf-125121bc1e2e.png)

## Links
MINI-5007

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
