### PR TITLE
[MINI-5008] Show null when get item failed After clear storage

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppAccessTokenError.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppAccessTokenError.kt
@@ -1,8 +1,11 @@
 package com.rakuten.tech.mobile.miniapp.errors
 
+import androidx.annotation.Keep
+
 /**
  * A class to provide the custom errors specific for access token.
  */
+@Keep
 class MiniAppAccessTokenError(val type: String? = null, val message: String? = null) :
     MiniAppBridgeError(type, message) {
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppDownloadFileError.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppDownloadFileError.kt
@@ -1,8 +1,11 @@
 package com.rakuten.tech.mobile.miniapp.errors
 
+import androidx.annotation.Keep
+
 /**
  * A class to provide the custom errors specific for file download.
  */
+@Keep
 class MiniAppDownloadFileError(val type: String? = null, val message: String? = null, val code: Int? = null) :
     MiniAppBridgeError(type, message) {
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppSecureStorageError.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppSecureStorageError.kt
@@ -1,8 +1,11 @@
 package com.rakuten.tech.mobile.miniapp.errors
 
+import androidx.annotation.Keep
+
 /**
  * A class to provide the custom errors specific for secure storage.
  */
+@Keep
 internal class MiniAppSecureStorageError(val type: String? = null, val message: String? = null) :
     MiniAppBridgeError(type, message) {
 


### PR DESCRIPTION
# Description
Able to fetch null value for key's post clear storage from inside miniapp.

## Links
MINI-5007, MINI-5008,  MINI-5009

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
