### PR TITLE
fix: Send secure storage load event after JS injection

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
@@ -26,7 +26,8 @@ internal class MiniAppHttpWebView(
         context,
         miniAppInfo,
         miniAppCustomPermissionCache,
-        miniAppFileChooser
+        miniAppFileChooser,
+        miniAppMessageBridge
     ),
     queryParams: String,
     ratDispatcher: MessageBridgeRatDispatcher,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
@@ -18,6 +18,7 @@ import androidx.core.location.LocationManagerCompat
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.file.MiniAppFileChooser
 import com.rakuten.tech.mobile.miniapp.js.DialogType
+import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
 import java.io.BufferedReader
@@ -27,7 +28,8 @@ internal class MiniAppWebChromeClient(
     private val context: Context,
     private val miniAppInfo: MiniAppInfo,
     val miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
-    private val miniAppFileChooser: MiniAppFileChooser?
+    private val miniAppFileChooser: MiniAppFileChooser?,
+    private val miniAppMessageBridge: MiniAppMessageBridge
 ) : WebChromeClient() {
 
     private lateinit var locationManager: LocationManager
@@ -107,7 +109,7 @@ internal class MiniAppWebChromeClient(
     @VisibleForTesting
     internal fun doInjection(webView: WebView) {
         if (bridgeJs !== null) {
-            webView.evaluateJavascript(bridgeJs) {}
+            webView.evaluateJavascript(bridgeJs) { miniAppMessageBridge.onJsInjectionDone() }
         }
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -43,7 +43,8 @@ internal open class MiniAppWebView(
         context,
         miniAppInfo,
         miniAppCustomPermissionCache,
-        miniAppFileChooser
+        miniAppFileChooser,
+        miniAppMessageBridge
     ),
     val queryParams: String,
     val ratDispatcher: MessageBridgeRatDispatcher,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -89,6 +89,10 @@ open class MiniAppMessageBridge {
         miniAppViewInitialized = true
     }
 
+    internal fun onJsInjectionDone() {
+        miniAppSecureStorageDispatcher.onLoad()
+    }
+
     @VisibleForTesting
     internal fun createBridgeExecutor(webViewListener: WebViewListener) =
         MiniAppBridgeExecutor(webViewListener)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppSecureStorageDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppSecureStorageDispatcher.kt
@@ -30,7 +30,6 @@ internal class MiniAppSecureStorageDispatcher(
         this.miniAppId = miniAppId
         this.secureStorage = MiniAppSecureStorage(activity)
         secureStorage.storageState.observeForever(stateObserver)
-        onLoad()
     }
 
     @Suppress("ComplexCondition")
@@ -44,7 +43,7 @@ internal class MiniAppSecureStorageDispatcher(
         }
     }
 
-    private fun onLoad() = whenReady {
+    fun onLoad() = whenReady {
         val onSuccess = { items: Map<String, String> ->
             cachedItems = items
             bridgeExecutor.dispatchEvent(eventType = NativeEventType.MINIAPP_SECURE_STORAGE_READY.value)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -57,7 +57,8 @@ open class BaseWebViewSpec {
                     context,
                     TEST_MA,
                     miniAppCustomPermissionCache,
-                    miniAppFileChooser
+                    miniAppFileChooser,
+                    mock()
                 )
             )
             miniAppWebView = createMiniAppWebView()
@@ -451,7 +452,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
 
     @Test
     fun `bridge js should be null when js asset is inaccessible`() {
-        val webClient = MiniAppWebChromeClient(mock(), TEST_MA, mock(), mock())
+        val webClient = MiniAppWebChromeClient(mock(), TEST_MA, mock(), mock(), mock())
         webClient.bridgeJs shouldBe null
     }
 
@@ -504,7 +505,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
     @Test
     fun `should close custom view when exit`() {
         val context = getApplicationContext<Context>()
-        webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA, mock(), mock()))
+        webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA, mock(), mock(), mock()))
         webChromeClient.onShowCustomView(null, mock())
         webChromeClient.customView = mock()
         webChromeClient.onShowCustomView(mock(), mock())
@@ -514,7 +515,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
 
     @Test
     fun `should execute custom view flow without error`() {
-        val webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA, mock(), mock()))
+        val webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA, mock(), mock(), mock()))
 
         webChromeClient.onShowCustomView(View(context), mock())
         webChromeClient.updateControls()
@@ -524,7 +525,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
 
     @Test
     fun `should exit fullscreen when destroy miniapp view`() {
-        val webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA, mock(), mock()))
+        val webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA, mock(), mock(), mock()))
         webChromeClient.onShowCustomView(View(context), mock())
         webChromeClient.onWebViewDetach()
 
@@ -536,7 +537,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
         val callback: ValueCallback<Array<Uri>>? = mock()
         val fileChooserParams: WebChromeClient.FileChooserParams? = mock()
         val webChromeClient =
-            Mockito.spy(MiniAppWebChromeClient(context, TEST_MA, mock(), miniAppFileChooser))
+            Mockito.spy(MiniAppWebChromeClient(context, TEST_MA, mock(), miniAppFileChooser, mock()))
         webChromeClient.onShowFileChooser(miniAppWebView, callback, fileChooserParams)
         verify(miniAppFileChooser).onShowFileChooser(callback, fileChooserParams, context)
     }


### PR DESCRIPTION
# Description
The secure storage loading is finishing before the JS injection has happened, so the load event was not able to be properly received by the mini app

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
