### PR TITLE
[MINI-5036] Remove dependency on SDK Utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 ## CHANGELOG
 
-### 4.2.0 (in progress)
+### 4.2.0 (release date TBD)
 **SDK**
 - **Feature:** Added support for base64 `data:` URIs to the File Download feature in `MiniAppFileDownloader`.
+- **Feature:** Added secure storage support for storing, getting and removing data for MiniApps safely. HostApp can clear secured data using `MiniApp.clearSecureStorage`.
+
+**Sample App**
+- **Feature:** Added a `Clear All` button to Settings/QA to remove all secure storages.
 
 ### 4.1.0 (2022-04-11)
 **SDK**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## CHANGELOG
+
+### 4.2.0 (in progress)
+**SDK**
+- **Feature:** Added support for base64 `data:` URIs to the File Download feature in `MiniAppFileDownloader`.
+
 ### 4.1.0 (2022-04-11)
 **SDK**
 - **Feature:** Added interface `MiniAppFileDownloader` to download files in device from miniapp.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,8 @@
 ## CHANGELOG
 
-### 4.2.0 (release date TBD)
+### 4.1.1 (release date TBD)
 **SDK**
-- **Feature:** Added support for base64 `data:` URIs to the File Download feature in `MiniAppFileDownloader`.
-- **Feature:** Added secure storage support for storing, getting and removing data for MiniApps safely. HostApp can clear secured data using `MiniApp.clearSecureStorage`.
-
-**Sample App**
-- **Feature:** Added a `Clear All` button to Settings/QA to remove all secure storages.
+- **Remove:** Removed `io.github.rakutentech.sdkutils` dependency and adopted the related changes to MiniApp SDK.
 
 ### 4.1.0 (2022-04-11)
 **SDK**

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ buildscript {
     ext.okhttp = '4.9.1'
     ext.manifest_config = '0.2.0'
     ext.mockito_kotlin = '3.2.0'
-    ext.sdk_utils = '0.2.0'
     ext.retrofit = '2.9.0'
     ext.robolectric = '4.7.3'
     ext.webkit = '1.4.0'

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -1016,7 +1016,6 @@ To avoid this, please add the following to your `build.gradle` in order to exclu
 configurations.all {
     exclude group: 'com.rakuten.tech.mobile', module: 'manifest-config-processor'
     exclude group: 'com.rakuten.tech.mobile', module: 'manifest-config-annotations'
-    exclude group: 'com.rakuten.tech.mobile.sdkutils', module: 'sdk-utils'
 }
 
 ```

--- a/miniapp/build.gradle
+++ b/miniapp/build.gradle
@@ -70,7 +70,6 @@ dependencies {
 
     kapt "io.github.rakutentech.manifestconfig:manifest-config-processor:$manifest_config"
     implementation "io.github.rakutentech.manifestconfig:manifest-config-annotations:$manifest_config"
-    implementation "io.github.rakutentech.sdkutils:sdk-utils:$sdk_utils"
 
     testImplementation "androidx.test.ext:junit:$androidx_test_ext"
     testImplementation "org.mockito:mockito-android:$mockito"

--- a/miniapp/src/main/AndroidManifest.xml
+++ b/miniapp/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.rakuten.tech.mobile.miniapp"
-    xmlns:tools="http://schemas.android.com/tools">
+    package="com.rakuten.tech.mobile.miniapp">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -12,14 +11,6 @@
             android:authorities="${applicationId}.MiniappSdkInitializer"
             android:exported="false"
             android:initOrder="99" />
-
-        <!-- Change init order for sdk-utils so it's initialized first -->
-        <provider
-            android:name="com.rakuten.tech.mobile.sdkutils.SdkUtilsInitProvider"
-            android:authorities="${applicationId}.SdkUtilsInitProvider"
-            android:exported="false"
-            android:initOrder="100"
-            tools:replace="android:initOrder" />
 
         <provider
             android:name="com.rakuten.tech.mobile.miniapp.display.MiniAppDefaultFileProvider"

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -13,6 +13,7 @@ import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 import com.rakuten.tech.mobile.miniapp.file.MiniAppFileChooser
 import com.rakuten.tech.mobile.miniapp.js.MessageBridgeRatDispatcher
+import com.rakuten.tech.mobile.miniapp.js.MiniAppSecureStorageDispatcher
 import com.rakuten.tech.mobile.miniapp.signatureverifier.SignatureVerifier
 import com.rakuten.tech.mobile.miniapp.storage.verifier.CachedMiniAppVerifier
 import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
@@ -170,6 +171,18 @@ abstract class MiniApp internal constructor() {
     abstract fun listDownloadedWithCustomPermissions(): List<Pair<MiniAppInfo, MiniAppCustomPermission>>
 
     /**
+     * Clears all secure storage items for all mini apps.
+     * Host App should call this when they want to clear all sensitive and session data such as when a user logs out.
+     */
+    abstract fun clearSecureStorage()
+
+    /**
+     * Clears the secure storage for a particular Mini App ID.
+     * @param miniAppId will be used to find the storage to be deleted.
+     */
+    abstract fun clearSecureStorage(miniAppId: String)
+
+    /**
      * Get the manifest information e.g. required and optional permissions.
      * @param appId mini app id.
      * @param versionId of mini app.
@@ -253,6 +266,7 @@ abstract class MiniApp internal constructor() {
                 initManifestVerifier = { MiniAppManifestVerifier(context) },
                 miniAppAnalytics = miniAppAnalytics,
                 ratDispatcher = MessageBridgeRatDispatcher(miniAppAnalytics = miniAppAnalytics),
+                secureStorageDispatcher = MiniAppSecureStorageDispatcher(miniAppSdkConfig.storageMaxSizeKB),
                 enableH5Ads = miniAppSdkConfig.enableH5Ads
             )
         }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -16,6 +16,7 @@ import kotlinx.android.parcel.Parcelize
  * @property miniAppAnalyticsConfigList List of analytic config to send events on.
  * @property sslPinningPublicKeyList List of SSL pinning public keys.
  * @property enableH5Ads Whether the host app wants to enable ad placement beta.
+ * @property storageMaxSizeKB Maximum size in KB for each Mini App is allowed to use for Secure Storage, Default is 5MB.
  */
 @Parcelize
 data class MiniAppSdkConfig(
@@ -28,7 +29,8 @@ data class MiniAppSdkConfig(
     val requireSignatureVerification: Boolean = false,
     val miniAppAnalyticsConfigList: List<MiniAppAnalyticsConfig> = emptyList(),
     val sslPinningPublicKeyList: List<String> = emptyList(),
-    val enableH5Ads: Boolean = false
+    val enableH5Ads: Boolean = false,
+    val storageMaxSizeKB: Int = 5000
 ) : Parcelable {
     internal val key = "$baseUrl-$isPreviewMode-$rasProjectId-$subscriptionKey"
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -67,6 +67,12 @@ class MiniappSdkInitializer : ContentProvider() {
          **/
         @MetaData(key = "com.rakuten.tech.mobile.miniapp.EnableH5Ads")
         fun enableH5Ads(): Boolean
+
+        /**
+         * Sets the maximum size in KB that each Mini App is allowed to use for Secure Storage.
+         **/
+        @MetaData(key = "com.rakuten.tech.mobile.miniapp.StorageMaxSizeKB")
+        fun storageMaxSizeKB(): Int
     }
 
     override fun onCreate(): Boolean {
@@ -92,7 +98,8 @@ class MiniappSdkInitializer : ContentProvider() {
         hostAppUserAgentInfo = manifestConfig.hostAppUserAgentInfo(),
         isPreviewMode = manifestConfig.isPreviewMode(),
         requireSignatureVerification = manifestConfig.requireSignatureVerification(),
-        enableH5Ads = manifestConfig.enableH5Ads()
+        enableH5Ads = manifestConfig.enableH5Ads(),
+        storageMaxSizeKB = manifestConfig.storageMaxSizeKB()
     )
 
     private fun executeMiniAppAnalytics(rasProjId: String) {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -9,6 +9,7 @@ import com.rakuten.tech.mobile.miniapp.display.Displayer
 import com.rakuten.tech.mobile.miniapp.file.MiniAppFileChooser
 import com.rakuten.tech.mobile.miniapp.js.MessageBridgeRatDispatcher
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
+import com.rakuten.tech.mobile.miniapp.js.MiniAppSecureStorageDispatcher
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermission
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
@@ -27,6 +28,7 @@ internal class RealMiniApp(
     initManifestVerifier: () -> MiniAppManifestVerifier,
     private var miniAppAnalytics: MiniAppAnalytics,
     private var ratDispatcher: MessageBridgeRatDispatcher,
+    private var secureStorageDispatcher: MiniAppSecureStorageDispatcher,
     private val enableH5Ads: Boolean
 ) : MiniApp() {
 
@@ -59,6 +61,11 @@ internal class RealMiniApp(
         }
     }
 
+    override fun clearSecureStorage() = secureStorageDispatcher.clearSecureStorage()
+
+    override fun clearSecureStorage(miniAppId: String) =
+        secureStorageDispatcher.clearSecureStorage(miniAppId)
+
     override suspend fun create(
         appId: String,
         miniAppMessageBridge: MiniAppMessageBridge,
@@ -86,6 +93,7 @@ internal class RealMiniApp(
                 queryParams,
                 miniAppAnalytics,
                 ratDispatcher,
+                secureStorageDispatcher,
                 enableH5Ads
             )
         }
@@ -118,6 +126,7 @@ internal class RealMiniApp(
                 queryParams,
                 miniAppAnalytics,
                 ratDispatcher,
+                secureStorageDispatcher,
                 enableH5Ads
             )
         }
@@ -143,6 +152,7 @@ internal class RealMiniApp(
                 queryParams,
                 miniAppAnalytics,
                 ratDispatcher,
+                secureStorageDispatcher,
                 enableH5Ads
             )
         }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/analytics/Type.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/analytics/Type.kt
@@ -30,5 +30,10 @@ internal enum class Actype(val value: String) {
     SEND_MESSAGE_TO_MULTIPLE_CONTACTS("mini_app_send_message_to_multiple_contacts"),
     GET_HOST_ENVIRONMENT_INFO("mini_app_get_host_environment_info"),
     FILE_DOWNLOAD("mini_app_download_file"),
+    SECURE_STORAGE_SET_ITEMS("mini_app_secure_storage_set_items"),
+    SECURE_STORAGE_GET_ITEM("mini_app_secure_storage_get_item"),
+    SECURE_STORAGE_REMOVE_ITEMS("mini_app_secure_storage_remove_items"),
+    SECURE_STORAGE_CLEAR("mini_app_secure_storage_clear"),
+    SECURE_STORAGE_SIZE("mini_app_secure_storage_size"),
     DEFAULT("")
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/analytics/Type.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/analytics/Type.kt
@@ -12,6 +12,8 @@ internal enum class Actype(val value: String) {
     SIGNATURE_VALIDATION_SUCCESS("mini_app_signature_validation_success"),
     SIGNATURE_VALIDATION_FAIL("mini_app_signature_validation_fail"),
     GET_UNIQUE_ID("mini_app_get_unique_id"),
+    GET_MESSAGING_UNIQUE_ID("mini_app_get_messaging_unique_id"),
+    GET_MAUID("mini_app_get_mauid"),
     REQUEST_PERMISSION("mini_app_request_permission"),
     REQUEST_CUSTOM_PERMISSIONS("mini_app_request_custom_permissions"),
     SHARE_INFO("mini_app_share_info"),
@@ -27,5 +29,6 @@ internal enum class Actype(val value: String) {
     SEND_MESSAGE_TO_CONTACT_ID("mini_app_send_message_to_contact_id"),
     SEND_MESSAGE_TO_MULTIPLE_CONTACTS("mini_app_send_message_to_multiple_contacts"),
     GET_HOST_ENVIRONMENT_INFO("mini_app_get_host_environment_info"),
+    FILE_DOWNLOAD("mini_app_download_file"),
     DEFAULT("")
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/Displayer.kt
@@ -7,6 +7,7 @@ import com.rakuten.tech.mobile.miniapp.analytics.MiniAppAnalytics
 import com.rakuten.tech.mobile.miniapp.js.MessageBridgeRatDispatcher
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
+import com.rakuten.tech.mobile.miniapp.js.MiniAppSecureStorageDispatcher
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
 
@@ -24,6 +25,7 @@ internal class Displayer(private val hostAppUserAgentInfo: String) {
         queryParams: String,
         miniAppAnalytics: MiniAppAnalytics,
         ratDispatcher: MessageBridgeRatDispatcher,
+        secureStorageDispatcher: MiniAppSecureStorageDispatcher,
         enableH5Ads: Boolean
     ): MiniAppDisplay = RealMiniAppDisplay(
         basePath = basePath,
@@ -37,6 +39,7 @@ internal class Displayer(private val hostAppUserAgentInfo: String) {
         queryParams = queryParams,
         miniAppAnalytics = miniAppAnalytics,
         ratDispatcher = ratDispatcher,
+        secureStorageDispatcher = secureStorageDispatcher,
         enableH5Ads = enableH5Ads
     )
 
@@ -50,6 +53,7 @@ internal class Displayer(private val hostAppUserAgentInfo: String) {
         queryParams: String,
         miniAppAnalytics: MiniAppAnalytics,
         ratDispatcher: MessageBridgeRatDispatcher,
+        secureStorageDispatcher: MiniAppSecureStorageDispatcher,
         enableH5Ads: Boolean
     ): MiniAppDisplay = RealMiniAppDisplay(
         appUrl = appUrl,
@@ -62,6 +66,7 @@ internal class Displayer(private val hostAppUserAgentInfo: String) {
         queryParams = queryParams,
         miniAppAnalytics = miniAppAnalytics,
         ratDispatcher = ratDispatcher,
+        secureStorageDispatcher = secureStorageDispatcher,
         enableH5Ads = enableH5Ads
     )
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
@@ -26,7 +26,8 @@ internal class MiniAppHttpWebView(
         context,
         miniAppInfo,
         miniAppCustomPermissionCache,
-        miniAppFileChooser
+        miniAppFileChooser,
+        miniAppMessageBridge
     ),
     queryParams: String,
     ratDispatcher: MessageBridgeRatDispatcher,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppHttpWebView.kt
@@ -7,6 +7,7 @@ import com.rakuten.tech.mobile.miniapp.MiniAppScheme
 import com.rakuten.tech.mobile.miniapp.file.MiniAppFileChooser
 import com.rakuten.tech.mobile.miniapp.js.MessageBridgeRatDispatcher
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
+import com.rakuten.tech.mobile.miniapp.js.MiniAppSecureStorageDispatcher
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
@@ -29,6 +30,7 @@ internal class MiniAppHttpWebView(
     ),
     queryParams: String,
     ratDispatcher: MessageBridgeRatDispatcher,
+    secureStorageDispatcher: MiniAppSecureStorageDispatcher,
     enableH5Ads: Boolean
 ) : MiniAppWebView(
     context,
@@ -43,6 +45,7 @@ internal class MiniAppHttpWebView(
     miniAppWebChromeClient,
     queryParams,
     ratDispatcher,
+    secureStorageDispatcher,
     enableH5Ads
 ) {
     init {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
@@ -2,6 +2,7 @@ package com.rakuten.tech.mobile.miniapp.display
 
 import android.app.Activity
 import android.content.Context
+import android.location.LocationManager
 import android.net.Uri
 import android.view.View
 import android.view.ViewGroup
@@ -13,6 +14,7 @@ import android.webkit.WebView
 import android.webkit.ValueCallback
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
+import androidx.core.location.LocationManagerCompat
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.file.MiniAppFileChooser
 import com.rakuten.tech.mobile.miniapp.js.DialogType
@@ -27,6 +29,8 @@ internal class MiniAppWebChromeClient(
     val miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
     private val miniAppFileChooser: MiniAppFileChooser?
 ) : WebChromeClient() {
+
+    private lateinit var locationManager: LocationManager
 
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
     @VisibleForTesting
@@ -47,10 +51,12 @@ internal class MiniAppWebChromeClient(
         origin: String?,
         callback: GeolocationPermissions.Callback?
     ) {
+        locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+        val isLocationEnabled = LocationManagerCompat.isLocationEnabled(locationManager)
         if (miniAppCustomPermissionCache.hasPermission(
                 miniAppInfo.id,
                 MiniAppCustomPermissionType.LOCATION
-            )
+            ) && isLocationEnabled
         ) callback?.invoke(origin, true, false)
         else callback?.invoke(origin, false, false)
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebChromeClient.kt
@@ -18,6 +18,7 @@ import androidx.core.location.LocationManagerCompat
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.file.MiniAppFileChooser
 import com.rakuten.tech.mobile.miniapp.js.DialogType
+import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
 import java.io.BufferedReader
@@ -27,7 +28,8 @@ internal class MiniAppWebChromeClient(
     private val context: Context,
     private val miniAppInfo: MiniAppInfo,
     val miniAppCustomPermissionCache: MiniAppCustomPermissionCache,
-    private val miniAppFileChooser: MiniAppFileChooser?
+    private val miniAppFileChooser: MiniAppFileChooser?,
+    private val miniAppMessageBridge: MiniAppMessageBridge
 ) : WebChromeClient() {
 
     private lateinit var locationManager: LocationManager
@@ -107,7 +109,7 @@ internal class MiniAppWebChromeClient(
     @VisibleForTesting
     internal fun doInjection(webView: WebView) {
         if (bridgeJs !== null) {
-            webView.evaluateJavascript(bridgeJs) {}
+            webView.evaluateJavascript(bridgeJs) { miniAppMessageBridge.onJsInjectionDone() }
         }
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -15,6 +15,7 @@ import com.rakuten.tech.mobile.miniapp.ads.MiniAppH5AdsProvider
 import com.rakuten.tech.mobile.miniapp.file.MiniAppFileChooser
 import com.rakuten.tech.mobile.miniapp.js.MessageBridgeRatDispatcher
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
+import com.rakuten.tech.mobile.miniapp.js.MiniAppSecureStorageDispatcher
 import com.rakuten.tech.mobile.miniapp.navigator.ExternalResultHandler
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppDownloadNavigator
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
@@ -46,6 +47,7 @@ internal open class MiniAppWebView(
     ),
     val queryParams: String,
     val ratDispatcher: MessageBridgeRatDispatcher,
+    val secureStorageDispatcher: MiniAppSecureStorageDispatcher,
     val enableH5Ads: Boolean
 ) : WebView(context), WebViewListener {
 
@@ -107,7 +109,8 @@ internal open class MiniAppWebView(
             customPermissionCache = miniAppCustomPermissionCache,
             downloadedManifestCache = downloadedManifestCache,
             miniAppId = miniAppId,
-            ratDispatcher = ratDispatcher
+            ratDispatcher = ratDispatcher,
+            secureStorageDispatcher = secureStorageDispatcher
         )
 
         settings.allowUniversalAccessFromFileURLs = true
@@ -156,6 +159,7 @@ internal open class MiniAppWebView(
     fun destroyView() {
         stopLoading()
         defaultFileDownloader.cleanup()
+        secureStorageDispatcher.cleanupSecureStorage()
         destroy()
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -43,7 +43,8 @@ internal open class MiniAppWebView(
         context,
         miniAppInfo,
         miniAppCustomPermissionCache,
-        miniAppFileChooser
+        miniAppFileChooser,
+        miniAppMessageBridge
     ),
     val queryParams: String,
     val ratDispatcher: MessageBridgeRatDispatcher,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
@@ -18,6 +18,7 @@ import com.rakuten.tech.mobile.miniapp.file.MiniAppFileChooser
 import com.rakuten.tech.mobile.miniapp.js.MessageBridgeRatDispatcher
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
+import com.rakuten.tech.mobile.miniapp.js.MiniAppSecureStorageDispatcher
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 import com.rakuten.tech.mobile.miniapp.sdkExceptionForNoActivityContext
 import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
@@ -37,6 +38,7 @@ internal class RealMiniAppDisplay(
     val queryParams: String,
     val miniAppAnalytics: MiniAppAnalytics,
     val ratDispatcher: MessageBridgeRatDispatcher,
+    val secureStorageDispatcher: MiniAppSecureStorageDispatcher,
     val enableH5Ads: Boolean
 ) : MiniAppDisplay {
 
@@ -58,6 +60,7 @@ internal class RealMiniAppDisplay(
         queryParams: String,
         miniAppAnalytics: MiniAppAnalytics,
         ratDispatcher: MessageBridgeRatDispatcher,
+        secureStorageDispatcher: MiniAppSecureStorageDispatcher,
         enableH5Ads: Boolean
     ) : this(
         "",
@@ -71,6 +74,7 @@ internal class RealMiniAppDisplay(
         queryParams,
         miniAppAnalytics,
         ratDispatcher,
+        secureStorageDispatcher,
         enableH5Ads
     ) {
         this.appUrl = appUrl
@@ -140,7 +144,8 @@ internal class RealMiniAppDisplay(
                     downloadedManifestCache = downloadedManifestCache,
                     queryParams = queryParams,
                     ratDispatcher = ratDispatcher,
-                    enableH5Ads = enableH5Ads
+                    secureStorageDispatcher = secureStorageDispatcher,
+                    enableH5Ads = enableH5Ads,
                 )
             } else {
                 miniAppWebView = MiniAppWebView(
@@ -155,6 +160,7 @@ internal class RealMiniAppDisplay(
                     downloadedManifestCache = downloadedManifestCache,
                     queryParams = queryParams,
                     ratDispatcher = ratDispatcher,
+                    secureStorageDispatcher = secureStorageDispatcher,
                     enableH5Ads = enableH5Ads
                 )
             }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppAccessTokenError.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppAccessTokenError.kt
@@ -1,8 +1,11 @@
 package com.rakuten.tech.mobile.miniapp.errors
 
+import androidx.annotation.Keep
+
 /**
  * A class to provide the custom errors specific for access token.
  */
+@Keep
 class MiniAppAccessTokenError(val type: String? = null, val message: String? = null) :
     MiniAppBridgeError(type, message) {
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppDownloadFileError.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppDownloadFileError.kt
@@ -1,8 +1,11 @@
 package com.rakuten.tech.mobile.miniapp.errors
 
+import androidx.annotation.Keep
+
 /**
  * A class to provide the custom errors specific for file download.
  */
+@Keep
 class MiniAppDownloadFileError(val type: String? = null, val message: String? = null, val code: Int? = null) :
     MiniAppBridgeError(type, message) {
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppDownloadFileError.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppDownloadFileError.kt
@@ -3,13 +3,14 @@ package com.rakuten.tech.mobile.miniapp.errors
 /**
  * A class to provide the custom errors specific for file download.
  */
-class MiniAppDownloadFileError(val type: String? = null, val message: String? = null) :
+class MiniAppDownloadFileError(val type: String? = null, val message: String? = null, val code: Int? = null) :
     MiniAppBridgeError(type, message) {
 
     companion object {
         private const val DownloadFailedError = "DownloadFailedError"
         private const val InvalidUrlError = "InvalidUrlError"
         private const val SaveFailureError = "SaveFailureError"
+        private const val DownloadHttpError = "DownloadHttpError"
 
         // Failed to download file.
         val downloadFailedError = MiniAppDownloadFileError(DownloadFailedError, errorDescription(DownloadFailedError))
@@ -19,12 +20,11 @@ class MiniAppDownloadFileError(val type: String? = null, val message: String? = 
 
         val saveFailureError = MiniAppDownloadFileError(SaveFailureError, errorDescription(SaveFailureError))
 
-        /**
-         *  send custom error message from host app.
-         *  @property code error code send to miniapp.
-         *  @property reason error message send to mini app.
-         */
-        fun custom(code: String, reason: String) = MiniAppDownloadFileError(code, reason)
+        internal fun httpError(code: Int, message: String) = MiniAppDownloadFileError(
+            type = DownloadHttpError,
+            code = code,
+            message = message
+        )
 
         private fun errorDescription(error: String): String {
             return when (error) {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppSecureStorageError.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppSecureStorageError.kt
@@ -1,0 +1,50 @@
+package com.rakuten.tech.mobile.miniapp.errors
+
+/**
+ * A class to provide the custom errors specific for secure storage.
+ */
+internal class MiniAppSecureStorageError(val type: String? = null, val message: String? = null) :
+    MiniAppBridgeError(type, message) {
+
+    companion object {
+        private const val SecureStorageFullError = "SecureStorageFullError"
+        private const val SecureStorageIOError = "SecureStorageIOError"
+        private const val SecureStorageUnavailableError = "SecureStorageUnavailableError"
+        private const val SecureStorageBusyError = "SecureStorageBusyError"
+
+        // Secure Storage is full.
+        val secureStorageFullError =
+            MiniAppSecureStorageError(
+                SecureStorageFullError,
+                errorDescription(SecureStorageFullError)
+            )
+
+        // Failed to read/write secure storage.
+        val secureStorageIOError =
+            MiniAppSecureStorageError(SecureStorageIOError, errorDescription(SecureStorageIOError))
+
+        // Secure storage unavailable.
+        val secureStorageUnavailableError =
+            MiniAppSecureStorageError(
+                SecureStorageUnavailableError,
+                errorDescription(SecureStorageUnavailableError)
+            )
+
+        // Error when storage is busy.
+        val secureStorageBusyError =
+            MiniAppSecureStorageError(
+                SecureStorageBusyError,
+                errorDescription(SecureStorageBusyError)
+            )
+
+        private fun errorDescription(error: String): String {
+            return when (error) {
+                SecureStorageFullError -> "Secure storage is full."
+                SecureStorageIOError -> "Failed to read/write secure storage."
+                SecureStorageUnavailableError -> "Secure storage unavailable."
+                SecureStorageBusyError -> "Storage is busy."
+                else -> ""
+            }
+        }
+    }
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppSecureStorageError.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/errors/MiniAppSecureStorageError.kt
@@ -1,8 +1,11 @@
 package com.rakuten.tech.mobile.miniapp.errors
 
+import androidx.annotation.Keep
+
 /**
  * A class to provide the custom errors specific for secure storage.
  */
+@Keep
 internal class MiniAppSecureStorageError(val type: String? = null, val message: String? = null) :
     MiniAppBridgeError(type, message) {
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileDownloader.kt
@@ -43,6 +43,7 @@ interface MiniAppFileDownloader {
  * @param requestCode of file downloading using an intent inside sdk, which will also be used
  * to retrieve the Uri of the file by [Activity.onActivityResult] in the HostApp.
  **/
+@SuppressWarnings("LargeClass")
 class MiniAppFileDownloaderDefault(var activity: Activity, var requestCode: Int) : MiniAppFileDownloader {
     private var okHttpClient: OkHttpClient? = null
     @VisibleForTesting

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MessageBridgeRatDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MessageBridgeRatDispatcher.kt
@@ -37,6 +37,11 @@ internal class MessageBridgeRatDispatcher(private val miniAppAnalytics: MiniAppA
             ActionType.SEND_MESSAGE_TO_MULTIPLE_CONTACTS.action -> Actype.SEND_MESSAGE_TO_MULTIPLE_CONTACTS
             ActionType.GET_HOST_ENVIRONMENT_INFO.action -> Actype.GET_HOST_ENVIRONMENT_INFO
             ActionType.FILE_DOWNLOAD.action -> Actype.FILE_DOWNLOAD
+            ActionType.SECURE_STORAGE_SET_ITEMS.action -> Actype.SECURE_STORAGE_SET_ITEMS
+            ActionType.SECURE_STORAGE_GET_ITEM.action -> Actype.SECURE_STORAGE_GET_ITEM
+            ActionType.SECURE_STORAGE_REMOVE_ITEMS.action -> Actype.SECURE_STORAGE_REMOVE_ITEMS
+            ActionType.SECURE_STORAGE_CLEAR.action -> Actype.SECURE_STORAGE_CLEAR
+            ActionType.SECURE_STORAGE_SIZE.action -> Actype.SECURE_STORAGE_SIZE
             else -> Actype.DEFAULT
         }
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MessageBridgeRatDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MessageBridgeRatDispatcher.kt
@@ -19,6 +19,8 @@ internal class MessageBridgeRatDispatcher(private val miniAppAnalytics: MiniAppA
     internal fun getAcType(action: String): Actype {
         return when (action) {
             ActionType.GET_UNIQUE_ID.action -> Actype.GET_UNIQUE_ID
+            ActionType.GET_MESSAGING_UNIQUE_ID.action -> Actype.GET_MESSAGING_UNIQUE_ID
+            ActionType.GET_MAUID.action -> Actype.GET_MAUID
             ActionType.REQUEST_PERMISSION.action -> Actype.REQUEST_PERMISSION
             ActionType.REQUEST_CUSTOM_PERMISSIONS.action -> Actype.REQUEST_CUSTOM_PERMISSIONS
             ActionType.SHARE_INFO.action -> Actype.SHARE_INFO
@@ -34,6 +36,7 @@ internal class MessageBridgeRatDispatcher(private val miniAppAnalytics: MiniAppA
             ActionType.SEND_MESSAGE_TO_CONTACT_ID.action -> Actype.SEND_MESSAGE_TO_CONTACT_ID
             ActionType.SEND_MESSAGE_TO_MULTIPLE_CONTACTS.action -> Actype.SEND_MESSAGE_TO_MULTIPLE_CONTACTS
             ActionType.GET_HOST_ENVIRONMENT_INFO.action -> Actype.GET_HOST_ENVIRONMENT_INFO
+            ActionType.FILE_DOWNLOAD.action -> Actype.FILE_DOWNLOAD
             else -> Actype.DEFAULT
         }
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -53,6 +53,7 @@ open class MiniAppMessageBridge {
     internal lateinit var ratDispatcher: MessageBridgeRatDispatcher
     private lateinit var screenBridgeDispatcher: ScreenBridgeDispatcher
     private var allowScreenOrientation = false
+    private lateinit var miniAppSecureStorageDispatcher: MiniAppSecureStorageDispatcher
 
     internal fun init(
         activity: Activity,
@@ -60,7 +61,8 @@ open class MiniAppMessageBridge {
         customPermissionCache: MiniAppCustomPermissionCache,
         downloadedManifestCache: DownloadedManifestCache,
         miniAppId: String,
-        ratDispatcher: MessageBridgeRatDispatcher
+        ratDispatcher: MessageBridgeRatDispatcher,
+        secureStorageDispatcher: MiniAppSecureStorageDispatcher
     ) {
         this.activity = activity
         this.miniAppId = miniAppId
@@ -70,9 +72,12 @@ open class MiniAppMessageBridge {
         this.screenBridgeDispatcher =
             ScreenBridgeDispatcher(activity, bridgeExecutor, allowScreenOrientation)
         this.ratDispatcher = ratDispatcher
+        this.miniAppSecureStorageDispatcher = secureStorageDispatcher
         adBridgeDispatcher.setBridgeExecutor(bridgeExecutor)
         miniAppFileDownloadDispatcher.setBridgeExecutor(activity, bridgeExecutor)
         miniAppFileDownloadDispatcher.setMiniAppComponents(miniAppId, customPermissionCache)
+        miniAppSecureStorageDispatcher.setBridgeExecutor(activity, bridgeExecutor)
+        miniAppSecureStorageDispatcher.setMiniAppComponents(miniAppId)
         userInfoBridge.setMiniAppComponents(
             bridgeExecutor,
             customPermissionCache,
@@ -216,6 +221,24 @@ open class MiniAppMessageBridge {
             ActionType.FILE_DOWNLOAD.action -> miniAppFileDownloadDispatcher.onFileDownload(
                 callbackObj.id,
                 jsonStr
+            )
+            ActionType.SECURE_STORAGE_SET_ITEMS.action -> miniAppSecureStorageDispatcher.onSetItems(
+                callbackObj.id,
+                jsonStr
+            )
+            ActionType.SECURE_STORAGE_GET_ITEM.action -> miniAppSecureStorageDispatcher.onGetItem(
+                callbackObj.id,
+                jsonStr
+            )
+            ActionType.SECURE_STORAGE_REMOVE_ITEMS.action -> miniAppSecureStorageDispatcher.onRemoveItems(
+                callbackObj.id,
+                jsonStr
+            )
+            ActionType.SECURE_STORAGE_CLEAR.action -> miniAppSecureStorageDispatcher.onClearAll(
+                callbackObj.id
+            )
+            ActionType.SECURE_STORAGE_SIZE.action -> miniAppSecureStorageDispatcher.onSize(
+                callbackObj.id
             )
         }
         if (this::ratDispatcher.isInitialized)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -2,13 +2,14 @@ package com.rakuten.tech.mobile.miniapp.js
 
 import android.app.Activity
 import android.content.Intent
+import android.location.LocationManager
 import android.webkit.JavascriptInterface
 import androidx.annotation.VisibleForTesting
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
-import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.CustomPermissionsNotImplementedException
 import com.rakuten.tech.mobile.miniapp.DevicePermissionsNotImplementedException
+import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.R
 import com.rakuten.tech.mobile.miniapp.ads.MiniAppAdDisplayer
 import com.rakuten.tech.mobile.miniapp.display.WebViewListener

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -89,6 +89,10 @@ open class MiniAppMessageBridge {
         miniAppViewInitialized = true
     }
 
+    internal fun onJsInjectionDone() {
+        miniAppSecureStorageDispatcher.onLoad()
+    }
+
     @VisibleForTesting
     internal fun createBridgeExecutor(webViewListener: WebViewListener) =
         MiniAppBridgeExecutor(webViewListener)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppSecureStorageDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppSecureStorageDispatcher.kt
@@ -30,7 +30,6 @@ internal class MiniAppSecureStorageDispatcher(
         this.miniAppId = miniAppId
         this.secureStorage = MiniAppSecureStorage(activity)
         secureStorage.storageState.observeForever(stateObserver)
-        onLoad()
     }
 
     @Suppress("ComplexCondition")
@@ -44,7 +43,7 @@ internal class MiniAppSecureStorageDispatcher(
         }
     }
 
-    private fun onLoad() = whenReady {
+    fun onLoad() = whenReady {
         val onSuccess = { items: Map<String, String> ->
             cachedItems = items
             bridgeExecutor.dispatchEvent(eventType = NativeEventType.MINIAPP_SECURE_STORAGE_READY.value)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppSecureStorageDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppSecureStorageDispatcher.kt
@@ -200,10 +200,7 @@ internal class MiniAppSecureStorageDispatcher(
             val storageSize = Gson().toJson(MiniAppSecureStorageSize(fileSize, maxSizeInBytes.toLong()))
             bridgeExecutor.postValue(callbackId, storageSize)
         }
-        val onFailed = { errorSecure: MiniAppSecureStorageError ->
-            bridgeExecutor.postError(callbackId, Gson().toJson(errorSecure))
-        }
-        secureStorage.secureStorageSize(miniAppId, onSuccess, onFailed)
+        secureStorage.secureStorageSize(miniAppId, onSuccess)
     }
 
     fun cleanupSecureStorage() {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppSecureStorageDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppSecureStorageDispatcher.kt
@@ -131,14 +131,10 @@ internal class MiniAppSecureStorageDispatcher(
                     val onSuccess = { itemValue: String ->
                         bridgeExecutor.postValue(callbackId, itemValue)
                     }
-                    val onFailed = { errorSecure: MiniAppSecureStorageError ->
-                        bridgeExecutor.postError(callbackId, Gson().toJson(errorSecure))
-                    }
                     secureStorage.getItem(
                         miniAppId,
                         callbackObj.param.secureStorageKey,
-                        onSuccess,
-                        onFailed
+                        onSuccess
                     )
                 }
             } else {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppSecureStorageDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppSecureStorageDispatcher.kt
@@ -1,0 +1,231 @@
+package com.rakuten.tech.mobile.miniapp.js
+
+import android.app.Activity
+import androidx.lifecycle.Observer
+import com.google.gson.Gson
+import com.rakuten.tech.mobile.miniapp.errors.MiniAppSecureStorageError
+import com.rakuten.tech.mobile.miniapp.storage.MiniAppSecureStorage
+import com.rakuten.tech.mobile.miniapp.storage.StorageState
+
+@Suppress("TooManyFunctions", "LargeClass")
+internal class MiniAppSecureStorageDispatcher(
+    private val storageMaxSizeKB: Int
+) {
+    private lateinit var bridgeExecutor: MiniAppBridgeExecutor
+    private lateinit var activity: Activity
+    private lateinit var miniAppId: String
+    private lateinit var secureStorage: MiniAppSecureStorage
+    private var cachedItems: Map<String, String>? = null
+    private var storageState: StorageState = StorageState.DEFAULT
+    private val stateObserver = Observer<StorageState> { state ->
+        storageState = state
+    }
+
+    fun setBridgeExecutor(activity: Activity, bridgeExecutor: MiniAppBridgeExecutor) {
+        this.activity = activity
+        this.bridgeExecutor = bridgeExecutor
+    }
+
+    fun setMiniAppComponents(miniAppId: String) {
+        this.miniAppId = miniAppId
+        this.secureStorage = MiniAppSecureStorage(activity)
+        secureStorage.storageState.observeForever(stateObserver)
+        onLoad()
+    }
+
+    @Suppress("ComplexCondition")
+    private fun <T> whenReady(callback: () -> T) {
+        if (this::bridgeExecutor.isInitialized &&
+            this::activity.isInitialized &&
+            this::miniAppId.isInitialized &&
+            this::secureStorage.isInitialized
+        ) {
+            callback.invoke()
+        }
+    }
+
+    private fun onLoad() = whenReady {
+        val onSuccess = { items: Map<String, String> ->
+            cachedItems = items
+            bridgeExecutor.dispatchEvent(eventType = NativeEventType.MINIAPP_SECURE_STORAGE_READY.value)
+        }
+        val onFailed = { errorSecure: MiniAppSecureStorageError ->
+            bridgeExecutor.dispatchEvent(
+                eventType = NativeEventType.MINIAPP_SECURE_STORAGE_LOAD_ERROR.value,
+                value = Gson().toJson(errorSecure)
+            )
+        }
+        secureStorage.load(miniAppId, onSuccess, onFailed)
+    }
+
+    @Suppress("TooGenericExceptionCaught", "SwallowedException", "ComplexMethod", "LongMethod")
+    fun onSetItems(callbackId: String, jsonStr: String) = whenReady {
+        if (secureStorage.isSecureStorageAvailable(miniAppId, storageMaxSizeKB)) {
+            try {
+                val callbackObj: SecureStorageCallbackObj? =
+                    Gson().fromJson(jsonStr, SecureStorageCallbackObj::class.java)
+                if (callbackObj != null) {
+                    val onSuccess = { items: Map<String, String> ->
+                        cachedItems = items
+                        bridgeExecutor.postValue(callbackId, SAVE_SUCCESS_SECURE_STORAGE)
+                    }
+                    val onFailed = { errorSecure: MiniAppSecureStorageError ->
+                        bridgeExecutor.postError(callbackId, Gson().toJson(errorSecure))
+                    }
+                    if (storageState != StorageState.LOCK) {
+                        cachedItems?.let {
+                            val mergedItems = it.toMutableMap().apply { putAll(callbackObj.param.secureStorageItems) }
+                            secureStorage.insertItems(
+                                miniAppId,
+                                mergedItems,
+                                onSuccess,
+                                onFailed
+                            )
+                        } ?: kotlin.run {
+                            secureStorage.insertItems(
+                                miniAppId,
+                                callbackObj.param.secureStorageItems,
+                                onSuccess,
+                                onFailed
+                            )
+                        }
+                    } else {
+                        bridgeExecutor.postError(
+                            callbackId,
+                            Gson().toJson(MiniAppSecureStorageError.secureStorageBusyError)
+                        )
+                    }
+                } else {
+                    bridgeExecutor.postError(callbackId, ERR_WRONG_JSON_FORMAT)
+                }
+            } catch (e: Exception) {
+                bridgeExecutor.postError(callbackId, ERR_WRONG_JSON_FORMAT)
+            }
+        } else {
+            bridgeExecutor.postError(
+                callbackId,
+                Gson().toJson(MiniAppSecureStorageError.secureStorageFullError)
+            )
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    fun onGetItem(callbackId: String, jsonStr: String) = whenReady {
+        try {
+            val callbackObj: GetItemCallbackObj? =
+                Gson().fromJson(jsonStr, GetItemCallbackObj::class.java)
+            if (callbackObj != null) {
+                cachedItems?.let {
+                    if (it.containsKey(callbackObj.param.secureStorageKey)) {
+                        bridgeExecutor.postValue(
+                            callbackId,
+                            it[callbackObj.param.secureStorageKey] ?: ""
+                        )
+                    } else {
+                        bridgeExecutor.postValue(
+                            callbackId,
+                            "null"
+                        )
+                    }
+                } ?: kotlin.run {
+                    val onSuccess = { itemValue: String ->
+                        bridgeExecutor.postValue(callbackId, itemValue)
+                    }
+                    val onFailed = { errorSecure: MiniAppSecureStorageError ->
+                        bridgeExecutor.postError(callbackId, Gson().toJson(errorSecure))
+                    }
+                    secureStorage.getItem(
+                        miniAppId,
+                        callbackObj.param.secureStorageKey,
+                        onSuccess,
+                        onFailed
+                    )
+                }
+            } else {
+                bridgeExecutor.postError(callbackId, ERR_WRONG_JSON_FORMAT)
+            }
+        } catch (e: Exception) {
+            bridgeExecutor.postError(callbackId, ERR_WRONG_JSON_FORMAT)
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    fun onRemoveItems(callbackId: String, jsonStr: String) = whenReady {
+        try {
+            val callbackObj: DeleteItemsCallbackObj? =
+                Gson().fromJson(jsonStr, DeleteItemsCallbackObj::class.java)
+            if (callbackObj != null) {
+                val onSuccess = { items: Map<String, String> ->
+                    cachedItems = items
+                    bridgeExecutor.postValue(callbackId, REMOVE_ITEMS_SUCCESS_SECURE_STORAGE)
+                }
+                val onFailed = { errorSecure: MiniAppSecureStorageError ->
+                    bridgeExecutor.postError(callbackId, Gson().toJson(errorSecure))
+                }
+                if (storageState != StorageState.LOCK)
+                    secureStorage.deleteItems(
+                        miniAppId,
+                        callbackObj.param.secureStorageKeyList,
+                        onSuccess,
+                        onFailed
+                    )
+                else
+                    bridgeExecutor.postError(
+                        callbackId,
+                        Gson().toJson(MiniAppSecureStorageError.secureStorageBusyError)
+                    )
+            } else {
+                bridgeExecutor.postError(callbackId, ERR_WRONG_JSON_FORMAT)
+            }
+        } catch (e: Exception) {
+            bridgeExecutor.postError(callbackId, ERR_WRONG_JSON_FORMAT)
+        }
+    }
+
+    fun onClearAll(callbackId: String) = whenReady {
+        val onSuccess = {
+            cachedItems = null
+            bridgeExecutor.postValue(callbackId, REMOVE_SUCCESS_SECURE_STORAGE)
+        }
+        val onFailed = { errorSecure: MiniAppSecureStorageError ->
+            bridgeExecutor.postError(callbackId, Gson().toJson(errorSecure))
+        }
+        secureStorage.delete(miniAppId, onSuccess, onFailed)
+    }
+
+    @Suppress("MagicNumber")
+    fun onSize(callbackId: String) = whenReady {
+        val onSuccess = { fileSize: Long ->
+            val maxSizeInBytes = storageMaxSizeKB * 1024
+            val storageSize = Gson().toJson(MiniAppSecureStorageSize(fileSize, maxSizeInBytes.toLong()))
+            bridgeExecutor.postValue(callbackId, storageSize)
+        }
+        val onFailed = { errorSecure: MiniAppSecureStorageError ->
+            bridgeExecutor.postError(callbackId, Gson().toJson(errorSecure))
+        }
+        secureStorage.secureStorageSize(miniAppId, onSuccess, onFailed)
+    }
+
+    fun cleanupSecureStorage() {
+        cachedItems = null
+        secureStorage.storageState.removeObserver(stateObserver)
+    }
+
+    /**
+     * Will be invoked by MiniApp.clearSecureStorage(miniAppId: String).
+     * @param miniAppId will be used to find the storage to be deleted.
+     */
+    fun clearSecureStorage(miniAppId: String) = secureStorage.clearSecureStorage(miniAppId)
+
+    /**
+     * Will be invoked by MiniApp.clearSecureStorage.
+     */
+    fun clearSecureStorage() = secureStorage.clearSecureStorage()
+
+    internal companion object {
+        const val ERR_WRONG_JSON_FORMAT = "Can not parse secure storage json object"
+        const val SAVE_SUCCESS_SECURE_STORAGE = "Items saved successfully."
+        const val REMOVE_ITEMS_SUCCESS_SECURE_STORAGE = "Items removed successfully."
+        const val REMOVE_SUCCESS_SECURE_STORAGE = "Storage removed successfully."
+    }
+}

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/Obj.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/Obj.kt
@@ -1,6 +1,7 @@
 package com.rakuten.tech.mobile.miniapp.js
 
 import androidx.annotation.Keep
+import com.rakuten.tech.mobile.miniapp.errors.MiniAppSecureStorageError
 import com.rakuten.tech.mobile.miniapp.permission.AccessTokenScope
 
 @Keep
@@ -11,10 +12,71 @@ internal data class CallbackObj(
 )
 
 @Keep
+internal data class FileDownloadCallbackObj(
+    var action: String,
+    val param: FileDownloadParams?,
+    var id: String
+)
+
+// region: Secure Storage
+@Keep
+internal data class SecureStorageCallbackObj(
+    var action: String,
+    val param: SecureStorageItems,
+    var id: String
+)
+
+@Keep
+internal data class SecureStorageItems(
+    val secureStorageItems: Map<String, String>
+)
+
+@Keep
+internal data class DeleteItemsCallbackObj(
+    var action: String,
+    val param: SecureStorageKeyList,
+    var id: String
+)
+
+@Keep
+internal data class SecureStorageKeyList(
+    val secureStorageKeyList: Set<String>
+)
+
+@Keep
+internal data class GetItemCallbackObj(
+    var action: String,
+    val param: SecureStorageKey,
+    var id: String
+)
+
+@Keep
+internal data class SecureStorageKey(
+    val secureStorageKey: String
+)
+
+@Keep
+internal data class SecureStorageReadyCallback(
+    var success: Boolean,
+    var errorSecure: MiniAppSecureStorageError? = null
+)
+
+@Keep
+internal data class MiniAppSecureStorageSize(
+    val used: Long,
+    val max: Long
+)
+// end region
+
+@Keep
 internal data class DevicePermission(val permission: String)
 
 @Keep
-internal data class FileDownloadParams(val filename: String, val url: String, val headers: Map<String, String>)
+internal data class FileDownloadParams(
+    val filename: String,
+    val url: String,
+    val headers: Map<String, String>
+)
 
 @Keep
 internal data class Screen(val action: String)
@@ -24,13 +86,6 @@ internal data class Screen(val action: String)
 internal data class CustomPermissionCallbackObj(
     var action: String,
     val param: CustomPermission?,
-    var id: String
-)
-
-@Keep
-internal data class FileDownloadCallbackObj(
-    var action: String,
-    val param: FileDownloadParams?,
     var id: String
 )
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/Type.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/Type.kt
@@ -2,6 +2,8 @@ package com.rakuten.tech.mobile.miniapp.js
 
 internal enum class ActionType(val action: String) {
     GET_UNIQUE_ID("getUniqueId"),
+    GET_MESSAGING_UNIQUE_ID("getMessagingUniqueId"),
+    GET_MAUID("getMauid"),
     REQUEST_PERMISSION("requestPermission"),
     REQUEST_CUSTOM_PERMISSIONS("requestCustomPermissions"),
     SHARE_INFO("shareInfo"),

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/Type.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/Type.kt
@@ -20,6 +20,11 @@ internal enum class ActionType(val action: String) {
     GET_POINTS("getPoints"),
     GET_HOST_ENVIRONMENT_INFO("getHostEnvironmentInfo"),
     FILE_DOWNLOAD("downloadFile"),
+    SECURE_STORAGE_SET_ITEMS("setSecureStorageItems"),
+    SECURE_STORAGE_GET_ITEM("getSecureStorageItem"),
+    SECURE_STORAGE_REMOVE_ITEMS("removeSecureStorageItems"),
+    SECURE_STORAGE_CLEAR("clearSecureStorage"),
+    SECURE_STORAGE_SIZE("getSecureStorageSize"),
 }
 
 internal enum class DialogType {
@@ -44,4 +49,6 @@ enum class NativeEventType(val value: String) {
     EXTERNAL_WEBVIEW_CLOSE("miniappwebviewclosed"),
     MINIAPP_ON_PAUSE("miniapppause"),
     MINIAPP_ON_RESUME("miniappresume"),
+    MINIAPP_SECURE_STORAGE_READY("miniappsecurestorageready"),
+    MINIAPP_SECURE_STORAGE_LOAD_ERROR("miniappsecurestorageloaderror")
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppSecureStorage.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppSecureStorage.kt
@@ -50,13 +50,12 @@ internal class MiniAppSecureStorage(private val activity: Activity) {
     fun secureStorageSize(
         miniAppId: String,
         onSuccess: (Long) -> Unit,
-        onFailed: (MiniAppSecureStorageError) -> Unit
     ) {
         if (isStorageAvailable(miniAppId)) {
             val sizeInBytes = File(secureStorageBasePath, "$miniAppId.txt").length()
             onSuccess(sizeInBytes)
         } else {
-            onFailed(MiniAppSecureStorageError.secureStorageUnavailableError)
+            onSuccess(0)
         }
     }
 
@@ -145,7 +144,7 @@ internal class MiniAppSecureStorage(private val activity: Activity) {
                 }
             }
         } else {
-            onFailed(MiniAppSecureStorageError.secureStorageUnavailableError)
+            onSuccess()
         }
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppSecureStorage.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppSecureStorage.kt
@@ -223,7 +223,6 @@ internal class MiniAppSecureStorage(private val activity: Activity) {
         miniAppId: String,
         key: String,
         onSuccess: (String) -> Unit,
-        onFailed: (MiniAppSecureStorageError) -> Unit
     ) {
         scope.launch {
             if (isStorageAvailable(miniAppId)) {
@@ -232,13 +231,13 @@ internal class MiniAppSecureStorage(private val activity: Activity) {
                     if (storedItems.containsKey(key)) {
                         onSuccess(storedItems[key] ?: "")
                     } else {
-                        onFailed(MiniAppSecureStorageError.secureStorageIOError)
+                        onSuccess("null")
                     }
                 } ?: kotlin.run {
-                    onFailed(MiniAppSecureStorageError.secureStorageIOError)
+                    onSuccess("null")
                 }
             } else {
-                onFailed(MiniAppSecureStorageError.secureStorageUnavailableError)
+                onSuccess("null")
             }
         }
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppSecureStorage.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppSecureStorage.kt
@@ -1,0 +1,280 @@
+package com.rakuten.tech.mobile.miniapp.storage
+
+import android.app.Activity
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.MutableLiveData
+import androidx.security.crypto.EncryptedFile
+import androidx.security.crypto.MasterKey
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.rakuten.tech.mobile.miniapp.errors.MiniAppSecureStorageError
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.io.File
+import java.nio.charset.StandardCharsets
+
+private const val SUB_DIR_MINIAPP = "miniapp"
+private const val SUB_DIR_SECURE_STORAGE = "secure-storage"
+
+internal enum class StorageState {
+    DEFAULT,
+    LOCK,
+    UNLOCK
+}
+
+@Suppress("TooManyFunctions", "LargeClass")
+internal class MiniAppSecureStorage(private val activity: Activity) {
+    private val hostAppBasePath = activity.filesDir
+    private val miniAppBasePath
+        get() = "$hostAppBasePath/$SUB_DIR_MINIAPP"
+    private val secureStorageBasePath
+        get() = "$miniAppBasePath/$SUB_DIR_SECURE_STORAGE/"
+    private var scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+    var storageState: MutableLiveData<StorageState> = MutableLiveData<StorageState>()
+
+    private fun makeDirectoryAvailable() {
+        val storageDir = File(secureStorageBasePath)
+        if (!storageDir.exists()) {
+            storageDir.mkdir()
+        }
+    }
+
+    @Suppress("StringLiteralDuplication")
+    private fun isStorageAvailable(miniAppId: String): Boolean {
+        val securedStorageFile = File(secureStorageBasePath, "$miniAppId.txt")
+        return securedStorageFile.exists()
+    }
+
+    @Suppress("MagicNumber")
+    fun secureStorageSize(
+        miniAppId: String,
+        onSuccess: (Long) -> Unit,
+        onFailed: (MiniAppSecureStorageError) -> Unit
+    ) {
+        if (isStorageAvailable(miniAppId)) {
+            val sizeInBytes = File(secureStorageBasePath, "$miniAppId.txt").length()
+            onSuccess(sizeInBytes)
+        } else {
+            onFailed(MiniAppSecureStorageError.secureStorageUnavailableError)
+        }
+    }
+
+    /**
+     * Check the usage of the secure storage.
+     */
+    @Suppress("MagicNumber")
+    fun isSecureStorageAvailable(miniAppId: String, storageMaxSizeKB: Int): Boolean {
+        return if (isStorageAvailable(miniAppId)) {
+            val maxSizeInBytes = storageMaxSizeKB * 1024
+            val usedSizeInBytes = File(secureStorageBasePath, "$miniAppId.txt").length()
+            !(usedSizeInBytes == maxSizeInBytes.toLong() || usedSizeInBytes > maxSizeInBytes)
+        } else {
+            true
+        }
+    }
+
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
+    private fun writeToEncryptedFile(
+        miniAppId: String,
+        content: String,
+        onSuccess: (Map<String, String>) -> Unit,
+        onFailed: (MiniAppSecureStorageError) -> Unit
+    ) = try {
+        makeDirectoryAvailable()
+        val fileToWrite = File(secureStorageBasePath, "$miniAppId.txt")
+        if (fileToWrite.exists()) {
+            fileToWrite.delete()
+        }
+        val encryptedFile = EncryptedFile.Builder(
+            activity,
+            fileToWrite,
+            MasterKey.Builder(activity).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build(),
+            EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
+        ).build()
+
+        val fileContent = content.toByteArray(StandardCharsets.UTF_8)
+        encryptedFile.openFileOutput().apply {
+            write(fileContent)
+            flush()
+            close()
+        }
+        onSuccess(deserializeItems(content))
+    } catch (e: Exception) {
+        onFailed(MiniAppSecureStorageError.secureStorageIOError)
+    }
+
+    @VisibleForTesting
+    @Suppress("SwallowedException", "TooGenericExceptionCaught", "ReturnCount")
+    private fun readFromEncryptedFile(miniAppId: String): Map<String, String>? {
+        try {
+            if (isStorageAvailable(miniAppId)) {
+                val encryptedFile = EncryptedFile.Builder(
+                    activity,
+                    File(secureStorageBasePath, "$miniAppId.txt"),
+                    MasterKey.Builder(activity).setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                        .build(),
+                    EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
+                ).build()
+
+                val inputStream = encryptedFile.openFileInput()
+                val plaintext: ByteArray = inputStream.readBytes()
+                val jsonToRead = plaintext.toString(Charsets.UTF_8)
+                return deserializeItems(jsonToRead)
+            } else {
+                return null
+            }
+        } catch (e: Exception) {
+            return null
+        }
+    }
+
+    fun delete(
+        miniAppId: String,
+        onSuccess: () -> Unit,
+        onFailed: (MiniAppSecureStorageError) -> Unit
+    ) {
+        if (isStorageAvailable(miniAppId)) {
+            scope.launch {
+                val file = File(secureStorageBasePath, "$miniAppId.txt")
+                file.delete()
+                if (!file.exists()) {
+                    onSuccess()
+                } else {
+                    onFailed(MiniAppSecureStorageError.secureStorageIOError)
+                }
+            }
+        } else {
+            onFailed(MiniAppSecureStorageError.secureStorageUnavailableError)
+        }
+    }
+
+    fun deleteItems(
+        miniAppId: String,
+        keySet: Set<String>,
+        onSuccess: (Map<String, String>) -> Unit,
+        onFailed: (MiniAppSecureStorageError) -> Unit
+    ) {
+        scope.launch {
+            storageState.postValue(StorageState.LOCK)
+            if (isStorageAvailable(miniAppId)) {
+                val storedItems = readFromEncryptedFile(miniAppId)
+                storedItems?.let { items ->
+                    val filterItems = items.filter { !keySet.contains(it.key) }
+                    if (storedItems.size == filterItems.size) {
+                        onFailed(MiniAppSecureStorageError.secureStorageIOError)
+                    } else {
+                        writeToEncryptedFile(
+                            miniAppId,
+                            serializedItems(filterItems),
+                            onSuccess,
+                            onFailed
+                        )
+                    }
+                } ?: kotlin.run {
+                    onFailed(MiniAppSecureStorageError.secureStorageIOError)
+                }
+            } else {
+                onFailed(MiniAppSecureStorageError.secureStorageUnavailableError)
+            }
+            storageState.postValue(StorageState.UNLOCK)
+        }
+    }
+
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
+    fun load(
+        miniAppId: String,
+        onSuccess: (Map<String, String>) -> Unit,
+        onFailed: (MiniAppSecureStorageError) -> Unit
+    ) {
+        scope.launch {
+            storageState.postValue(StorageState.LOCK)
+            try {
+                if (isStorageAvailable(miniAppId)) {
+                    val storedItems = readFromEncryptedFile(miniAppId)
+                    storedItems?.let {
+                        onSuccess(storedItems)
+                    } ?: kotlin.run {
+                        onSuccess(emptyMap())
+                    }
+                } else {
+                    onSuccess(emptyMap())
+                }
+            } catch (e: Exception) {
+                onFailed(MiniAppSecureStorageError.secureStorageUnavailableError)
+            }
+            storageState.postValue(StorageState.UNLOCK)
+        }
+    }
+
+    fun insertItems(
+        miniAppId: String,
+        items: Map<String, String>,
+        onSuccess: (Map<String, String>) -> Unit,
+        onFailed: (MiniAppSecureStorageError) -> Unit
+    ) {
+        scope.launch {
+            storageState.postValue(StorageState.LOCK)
+            writeToEncryptedFile(miniAppId, serializedItems(items), onSuccess, onFailed)
+            storageState.postValue(StorageState.UNLOCK)
+        }
+    }
+
+    fun getItem(
+        miniAppId: String,
+        key: String,
+        onSuccess: (String) -> Unit,
+        onFailed: (MiniAppSecureStorageError) -> Unit
+    ) {
+        scope.launch {
+            if (isStorageAvailable(miniAppId)) {
+                val storedItems = readFromEncryptedFile(miniAppId)
+                storedItems?.let {
+                    if (storedItems.containsKey(key)) {
+                        onSuccess(storedItems[key] ?: "")
+                    } else {
+                        onFailed(MiniAppSecureStorageError.secureStorageIOError)
+                    }
+                } ?: kotlin.run {
+                    onFailed(MiniAppSecureStorageError.secureStorageIOError)
+                }
+            } else {
+                onFailed(MiniAppSecureStorageError.secureStorageUnavailableError)
+            }
+        }
+    }
+
+    private fun deserializeItems(jsonToRead: String): Map<String, String> {
+        return Gson().fromJson(
+            jsonToRead,
+            object : TypeToken<Map<String, String>>() {}.type
+        )
+    }
+
+    private fun serializedItems(items: Map<String, String>): String = Gson().toJson(items)
+
+    /**
+     * Will be invoked by MiniApp.clearSecureStorage(miniAppId: String).
+     * @param miniAppId will be used to find the file to be deleted.
+     */
+    fun clearSecureStorage(miniAppId: String) {
+        if (isStorageAvailable(miniAppId)) {
+            scope.launch {
+                val file = File(secureStorageBasePath, "$miniAppId.txt")
+                file.delete()
+            }
+        }
+    }
+
+    /**
+     * Will be invoked by MiniApp.clearSecureStorage.
+     */
+    fun clearSecureStorage() {
+        val storageDir = File(secureStorageBasePath)
+        if (storageDir.exists()) {
+            scope.launch {
+                storageDir.deleteRecursively()
+            }
+        }
+    }
+}

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -6,6 +6,7 @@ import com.rakuten.tech.mobile.miniapp.display.Displayer
 import com.rakuten.tech.mobile.miniapp.file.MiniAppFileChooser
 import com.rakuten.tech.mobile.miniapp.js.MessageBridgeRatDispatcher
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
+import com.rakuten.tech.mobile.miniapp.js.MiniAppSecureStorageDispatcher
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 import com.rakuten.tech.mobile.miniapp.permission.*
 import com.rakuten.tech.mobile.miniapp.storage.CachedManifest
@@ -48,6 +49,7 @@ open class BaseRealMiniAppSpec {
     )
 
     internal var ratDispatcher = MessageBridgeRatDispatcher(miniAppAnalytics)
+    internal var secureStorageDispatcher: MiniAppSecureStorageDispatcher = mock()
 
     @Before
     fun setup() {
@@ -58,6 +60,7 @@ open class BaseRealMiniAppSpec {
                 initManifestVerifier = { manifestVerifier },
                 miniAppAnalytics = miniAppAnalytics,
                 ratDispatcher = ratDispatcher,
+                secureStorageDispatcher = secureStorageDispatcher,
                 enableH5Ads = false
             ))
 
@@ -149,6 +152,7 @@ class RealMiniAppSpec : BaseRealMiniAppSpec() {
                 "",
                 miniAppAnalytics,
                 ratDispatcher,
+                secureStorageDispatcher,
                 false
             )
         }
@@ -180,6 +184,7 @@ class RealMiniAppSpec : BaseRealMiniAppSpec() {
                 "",
                 miniAppAnalytics,
                 ratDispatcher,
+                secureStorageDispatcher,
                 false
             )
 
@@ -203,6 +208,7 @@ class RealMiniAppSpec : BaseRealMiniAppSpec() {
                 "",
                 miniAppAnalytics,
                 ratDispatcher,
+                secureStorageDispatcher,
                 false
             )
         }
@@ -241,6 +247,7 @@ class RealMiniAppSpec : BaseRealMiniAppSpec() {
                 "",
                 miniAppAnalytics,
                 ratDispatcher,
+                secureStorageDispatcher,
                 enableH5Ads = false
             )
         }
@@ -260,7 +267,7 @@ class RealMiniAppSpec : BaseRealMiniAppSpec() {
             verify(displayer).createMiniAppDisplay(
                 TEST_MA_URL, miniAppMessageBridge, null, null,
                 miniAppCustomPermissionCache, downloadedManifestCache, "", miniAppAnalytics,
-                ratDispatcher, false
+                ratDispatcher, secureStorageDispatcher, false
             )
         }
 
@@ -524,5 +531,17 @@ class RealMiniAppManifestSpec : BaseRealMiniAppSpec() {
     fun `getDownloadedManifest should read data from cache`() {
         realMiniApp.getDownloadedManifest(TEST_MA_ID)
         verify(downloadedManifestCache).readDownloadedManifest(TEST_MA_ID)
+    }
+
+    @Test
+    fun `clearSecureStorage should clear storage using dispatcher per MiniApp id`() {
+        realMiniApp.clearSecureStorage(TEST_MA_ID)
+        verify(secureStorageDispatcher).clearSecureStorage(TEST_MA_ID)
+    }
+
+    @Test
+    fun `clearSecureStorage should clear whole storage using dispatcher`() {
+        realMiniApp.clearSecureStorage()
+        verify(secureStorageDispatcher).clearSecureStorage()
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -12,7 +12,6 @@ import com.rakuten.tech.mobile.miniapp.permission.*
 import com.rakuten.tech.mobile.miniapp.storage.CachedManifest
 import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
 import com.rakuten.tech.mobile.miniapp.storage.verifier.MiniAppManifestVerifier
-import com.rakuten.tech.mobile.sdkutils.AppInfo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.*
@@ -293,7 +292,6 @@ class RealMiniAppSpec : BaseRealMiniAppSpec() {
 
     @Test
     fun `should create a new ApiClient when there is no cache`() {
-        AppInfo.instance = mock()
         val miniApp = Mockito.spy(realMiniApp)
         val miniAppSdkConfig = MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestActivity.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestActivity.kt
@@ -1,5 +1,10 @@
 package com.rakuten.tech.mobile.miniapp
 
 import android.app.Activity
+import java.io.File
 
 class TestActivity : Activity()
+
+class TestFilesDirActivity : Activity() {
+    override fun getFilesDir(): File = File("")
+}

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
@@ -3,7 +3,6 @@ package com.rakuten.tech.mobile.miniapp.api
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import com.rakuten.tech.mobile.miniapp.*
-import com.rakuten.tech.mobile.sdkutils.AppInfo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import okhttp3.ResponseBody
@@ -218,7 +217,6 @@ open class ApiClientSpec {
 
     @Test
     fun `should create ApiClient without error`() {
-        AppInfo.instance = mock()
         ApiClient(
             baseUrl = TEST_URL_HTTPS_2,
             rasProjectId = TEST_HA_ID_PROJECT,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtilsSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtilsSpec.kt
@@ -4,7 +4,6 @@ import com.rakuten.tech.mobile.miniapp.TEST_LIST_PUBLIC_KEY_SSL
 import com.rakuten.tech.mobile.miniapp.TEST_URL_HTTPS_1
 import org.mockito.kotlin.mock
 import com.rakuten.tech.mobile.miniapp.TEST_VALUE
-import com.rakuten.tech.mobile.sdkutils.RasSdkHeaders
 import okhttp3.CertificatePinner
 import okhttp3.mockwebserver.MockWebServer
 import org.amshove.kluent.*

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
@@ -2,7 +2,6 @@ package com.rakuten.tech.mobile.miniapp.api
 
 import org.mockito.kotlin.mock
 import com.rakuten.tech.mobile.miniapp.*
-import com.rakuten.tech.mobile.sdkutils.AppInfo
 import junit.framework.TestCase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
@@ -53,7 +52,6 @@ open class RetrofitRequestExecutorSpec private constructor(
     )
 
     internal fun spyRetrofitExecutor(): RetrofitRequestExecutor {
-        AppInfo.instance = mock()
         val retrofit = createRetrofitClient(
             baseUrl = TEST_URL_HTTPS_2,
             pubKeyList = TEST_LIST_PUBLIC_KEY_SSL,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/DisplayerSpec.kt
@@ -54,6 +54,7 @@ class DisplayerSpec {
             queryParams = TEST_URL_PARAMS,
             miniAppAnalytics = mock(),
             ratDispatcher = mock(),
+            secureStorageDispatcher = mock(),
             enableH5Ads = false
         )
 
@@ -67,6 +68,7 @@ class DisplayerSpec {
         queryParams = TEST_URL_PARAMS,
         miniAppAnalytics = mock(),
         ratDispatcher = mock(),
+        secureStorageDispatcher = mock(),
         enableH5Ads = false
     )
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -57,7 +57,8 @@ open class BaseWebViewSpec {
                     context,
                     TEST_MA,
                     miniAppCustomPermissionCache,
-                    miniAppFileChooser
+                    miniAppFileChooser,
+                    mock()
                 )
             )
             miniAppWebView = createMiniAppWebView()
@@ -451,7 +452,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
 
     @Test
     fun `bridge js should be null when js asset is inaccessible`() {
-        val webClient = MiniAppWebChromeClient(mock(), TEST_MA, mock(), mock())
+        val webClient = MiniAppWebChromeClient(mock(), TEST_MA, mock(), mock(), mock())
         webClient.bridgeJs shouldBe null
     }
 
@@ -504,7 +505,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
     @Test
     fun `should close custom view when exit`() {
         val context = getApplicationContext<Context>()
-        webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA, mock(), mock()))
+        webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA, mock(), mock(), mock()))
         webChromeClient.onShowCustomView(null, mock())
         webChromeClient.customView = mock()
         webChromeClient.onShowCustomView(mock(), mock())
@@ -514,7 +515,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
 
     @Test
     fun `should execute custom view flow without error`() {
-        val webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA, mock(), mock()))
+        val webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA, mock(), mock(), mock()))
 
         webChromeClient.onShowCustomView(View(context), mock())
         webChromeClient.updateControls()
@@ -524,7 +525,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
 
     @Test
     fun `should exit fullscreen when destroy miniapp view`() {
-        val webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA, mock(), mock()))
+        val webChromeClient = Mockito.spy(MiniAppWebChromeClient(context, TEST_MA, mock(), mock(), mock()))
         webChromeClient.onShowCustomView(View(context), mock())
         webChromeClient.onWebViewDetach()
 
@@ -536,7 +537,7 @@ class MiniAppWebChromeTest : BaseWebViewSpec() {
         val callback: ValueCallback<Array<Uri>>? = mock()
         val fileChooserParams: WebChromeClient.FileChooserParams? = mock()
         val webChromeClient =
-            Mockito.spy(MiniAppWebChromeClient(context, TEST_MA, mock(), miniAppFileChooser))
+            Mockito.spy(MiniAppWebChromeClient(context, TEST_MA, mock(), miniAppFileChooser, mock()))
         webChromeClient.onShowFileChooser(miniAppWebView, callback, fileChooserParams)
         verify(miniAppFileChooser).onShowFileChooser(callback, fileChooserParams, context)
     }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -82,6 +82,7 @@ open class BaseWebViewSpec {
         downloadedManifestCache = mock(),
         queryParams = TEST_URL_PARAMS,
         ratDispatcher = mock(),
+        secureStorageDispatcher = mock(),
         enableH5Ads = false
     )
 }
@@ -104,6 +105,7 @@ class MiniAppHTTPWebViewSpec : BaseWebViewSpec() {
                 downloadedManifestCache = mock(),
                 queryParams = TEST_URL_PARAMS,
                 ratDispatcher = mock(),
+                secureStorageDispatcher = mock(),
                 enableH5Ads = false
         )
     }
@@ -181,6 +183,7 @@ class MiniAppWebViewSpec : BaseWebViewSpec() {
             downloadedManifestCache = mock(),
             queryParams = TEST_URL_PARAMS,
             ratDispatcher = mock(),
+            secureStorageDispatcher = mock(),
             enableH5Ads = false
         )
         miniAppWebView.settings.userAgentString shouldNotEndWith TEST_HA_NAME
@@ -235,12 +238,13 @@ class MiniAppWebViewSpec : BaseWebViewSpec() {
             mock(),
             TEST_URL_PARAMS,
             mock(),
+            mock(),
             false
         )
         val miniAppWebViewForMiniapp2 = MiniAppWebView(
             context, miniAppWebView.basePath, TEST_MA.copy(id = "app-id-2"), miniAppMessageBridge,
             miniAppNavigator, miniAppFileChooser, TEST_HA_NAME, mock(), mock(), mock(), TEST_URL_PARAMS,
-            mock(), false)
+            mock(), mock(), false)
         miniAppWebViewForMiniapp1.url!! shouldNotBeEqualTo miniAppWebViewForMiniapp2.url!!
     }
 
@@ -371,6 +375,7 @@ class MiniAppWebClientSpec : BaseWebViewSpec() {
             downloadedManifestCache = mock(),
             queryParams = TEST_URL_PARAMS,
             ratDispatcher = mock(),
+            secureStorageDispatcher = mock(),
             enableH5Ads = false
         ))
         val miniAppNavigator = Mockito.spy(displayer.miniAppNavigator)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplaySpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplaySpec.kt
@@ -54,6 +54,7 @@ class RealMiniAppDisplaySpec {
                 queryParams = TEST_URL_PARAMS,
                 miniAppAnalytics = mock(),
                 ratDispatcher = mock(),
+                secureStorageDispatcher = mock(),
                 enableH5Ads = false
             )
         }
@@ -77,6 +78,7 @@ class RealMiniAppDisplaySpec {
             queryParams = TEST_URL_PARAMS,
             miniAppAnalytics = mock(),
             ratDispatcher = mock(),
+            secureStorageDispatcher = mock(),
             enableH5Ads = false
         )
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileDownloaderSpec.kt
@@ -1,5 +1,8 @@
 package com.rakuten.tech.mobile.miniapp.file
 
+import android.app.Activity
+import android.content.ContentResolver
+import android.content.Intent
 import android.net.Uri
 import android.webkit.MimeTypeMap
 import androidx.test.core.app.ActivityScenario
@@ -7,6 +10,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.gson.Gson
 import com.rakuten.tech.mobile.miniapp.TEST_CALLBACK_ID
 import com.rakuten.tech.mobile.miniapp.TestActivity
+import com.rakuten.tech.mobile.miniapp.errors.MiniAppDownloadFileError
 import com.rakuten.tech.mobile.miniapp.js.ActionType
 import com.rakuten.tech.mobile.miniapp.js.FileDownloadCallbackObj
 import com.rakuten.tech.mobile.miniapp.js.FileDownloadParams
@@ -14,17 +18,25 @@ import kotlinx.coroutines.test.TestCoroutineScope
 import okhttp3.Request
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import org.amshove.kluent.When
+import org.amshove.kluent.calling
+import org.amshove.kluent.itReturns
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
-import org.mockito.kotlin.verify
+import org.mockito.Mockito.timeout
+import org.mockito.kotlin.*
+import org.mockito.kotlin.mock
 import org.robolectric.Shadows
+import java.io.OutputStream
 import kotlin.test.assertEquals
 
 @RunWith(AndroidJUnit4::class)
+@Suppress("LargeClass")
 class MiniAppFileDownloaderSpec {
     private val TEST_IMAGE_MIME = "image/jpeg"
     private val TEST_FILENAME = "test.jpg"
@@ -36,7 +48,20 @@ class MiniAppFileDownloaderSpec {
         id = TEST_CALLBACK_ID
     )
     private val TEST_DEST_URI = Uri.parse("https://sample/com/test.jpg")
+    private val TEST_BASE64_DATA_URI = "data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAAAA" +
+            "ABzQ+pjAAAAC0lEQVQI12NgQAAAAAwAAeQ06mYAAAAASUVORK5CYII="
+    private val TEST_MIME_TYPE = "image/jpeg"
+    private val TEST_EXPECTED_BYTES = byteArrayOf(
+        -119, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82,
+        0, 0, 0, 3, 0, 0, 0, 3, 8, 0, 0, 0, 0, 115, 67, -22, 99, 0, 0, 0, 11, 73, 68, 65, 84, 8, -41, 99,
+        96, 64, 0, 0, 0, 12, 0, 1, -28, 52, -22, 102, 0, 0, 0, 0, 73, 69, 78, 68, -82, 66, 96, -126
+    )
     private val fileDownloadJsonStr = Gson().toJson(fileDownloadCallbackObj)
+    private lateinit var mockServer: MockWebServer
+    private val mockContentResolver: ContentResolver = mock()
+    private val mockActivity: Activity = mock {
+        on { contentResolver } itReturns mockContentResolver
+    }
     private lateinit var activity: TestActivity
 
     @Before
@@ -44,11 +69,17 @@ class MiniAppFileDownloaderSpec {
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
             this.activity = activity
         }
+        mockServer = MockWebServer()
 
         // setup for the MimeTypeMap
         val mtm = MimeTypeMap.getSingleton()
         Shadows.shadowOf(mtm).addExtensionMimeTypMapping("jpg", TEST_IMAGE_MIME)
         Shadows.shadowOf(mtm).addExtensionMimeTypMapping("jpeg", TEST_IMAGE_MIME)
+    }
+
+    @After
+    fun after() {
+        mockServer.shutdown()
     }
 
     @Test
@@ -78,7 +109,6 @@ class MiniAppFileDownloaderSpec {
 
     @Test
     fun `startDownloading should invoke success callback if request is successful`() {
-            val mockServer = MockWebServer()
             mockServer.enqueue(MockResponse().setBody(""))
             mockServer.start()
             val url: String = mockServer.url("/sample/com/test.jpg").toString()
@@ -95,13 +125,10 @@ class MiniAppFileDownloaderSpec {
 
             miniAppFileDownloader.onReceivedResult(TEST_DEST_URI)
             verify(miniAppFileDownloader).onDownloadSuccess
-
-            mockServer.shutdown()
         }
 
     @Test
     fun `startDownloading should invoke fail callback if request isn't successful`() {
-        val mockServer = MockWebServer()
         mockServer.enqueue(MockResponse().setResponseCode(400))
         mockServer.start()
         val url: String = mockServer.url("/sample/com/test.jpg").toString()
@@ -118,7 +145,100 @@ class MiniAppFileDownloaderSpec {
 
         miniAppFileDownloader.onReceivedResult(TEST_DEST_URI)
         verify(miniAppFileDownloader).onDownloadFailed
+    }
 
-        mockServer.shutdown()
+    @Test
+    fun `onStartFileDownload when called with data URI should launch an Intent to create a new document`() {
+        val miniAppFileDownloader = MiniAppFileDownloaderDefault(mockActivity, 100)
+
+        miniAppFileDownloader.onStartFileDownload(TEST_FILENAME, TEST_BASE64_DATA_URI, TEST_HEADER_OBJECT, {}, {})
+
+        verify(mockActivity).startActivityForResult(
+            argWhere { intent ->
+                intent.action == Intent.ACTION_CREATE_DOCUMENT &&
+                        intent.type == TEST_MIME_TYPE &&
+                        intent.extras!!.getString(Intent.EXTRA_TITLE) == TEST_FILENAME
+            },
+            eq(100)
+        )
+    }
+
+    @Test
+    fun `onStartFileDownload when called with an HTTPS URL should launch an Intent to create a new document`() {
+        val miniAppFileDownloader = MiniAppFileDownloaderDefault(mockActivity, 100)
+
+        miniAppFileDownloader.onStartFileDownload(TEST_FILENAME, TEST_FILE_URL, TEST_HEADER_OBJECT, {}, {})
+
+        verify(mockActivity).startActivityForResult(
+            argWhere { intent ->
+                intent.action == Intent.ACTION_CREATE_DOCUMENT &&
+                        intent.type == TEST_MIME_TYPE &&
+                        intent.extras!!.getString(Intent.EXTRA_TITLE) == TEST_FILENAME
+            },
+            eq(100)
+        )
+    }
+
+    @Test
+    fun `onStartFileDownload when called with invalid URL should return InvalidUrlError to onFailedDownload`() {
+        val onFailed: (MiniAppDownloadFileError) -> Unit = mock()
+        val miniAppFileDownloader = MiniAppFileDownloaderDefault(mockActivity, 100)
+
+        miniAppFileDownloader.onStartFileDownload(
+            TEST_FILENAME,
+            "test-invalid-url://test",
+            TEST_HEADER_OBJECT,
+            {},
+            onFailed
+        )
+
+        verify(onFailed).invoke(MiniAppDownloadFileError.invalidUrlError)
+    }
+
+    @Test
+    fun `onReceivedResult when called with data URI should call onSuccess`() {
+        val destinationUri: Uri = mock()
+        val miniAppFileDownloader = MiniAppFileDownloaderDefault(activity, 100)
+        val onSuccess: (String) -> Unit = mock()
+
+        miniAppFileDownloader.onStartFileDownload(
+            TEST_FILENAME,
+            TEST_BASE64_DATA_URI,
+            TEST_HEADER_OBJECT,
+            onSuccess,
+            {}
+        )
+        miniAppFileDownloader.onReceivedResult(destinationUri)
+
+        verify(onSuccess, timeout(100)).invoke(TEST_FILENAME)
+    }
+
+    @Test
+    fun `onReceivedResult when called with data URI should write the file data to the URI location chosen by user`() {
+        val destinationUri: Uri = mock()
+        val outputStream: OutputStream = mock()
+        val miniAppFileDownloader = MiniAppFileDownloaderDefault(mockActivity, 100)
+        When calling mockContentResolver.openOutputStream(destinationUri) itReturns outputStream
+
+        miniAppFileDownloader.onStartFileDownload(TEST_FILENAME, TEST_BASE64_DATA_URI, TEST_HEADER_OBJECT, {}, {})
+        miniAppFileDownloader.onReceivedResult(destinationUri)
+
+        verify(outputStream).write(argWhere {
+            val byteArray = it.copyOfRange(0, TEST_EXPECTED_BYTES.size) // trim buffer bytes from end
+            byteArray.contentEquals(TEST_EXPECTED_BYTES)
+        }, any(), any())
+    }
+
+    @Test
+    fun `onReceivedResult when fails to decode data URI should return error to onFailedDownload`() {
+        val invalidDataUri = "data:image/png;base64,12345"
+        val onFailed: (MiniAppDownloadFileError) -> Unit = mock()
+        val destinationUri: Uri = mock()
+        val miniAppFileDownloader = MiniAppFileDownloaderDefault(mockActivity, 100)
+
+        miniAppFileDownloader.onStartFileDownload(TEST_FILENAME, invalidDataUri, TEST_HEADER_OBJECT, {}, onFailed)
+        miniAppFileDownloader.onReceivedResult(destinationUri)
+
+        verify(onFailed).invoke(MiniAppDownloadFileError.saveFailureError)
     }
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MessageBridgeRatDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MessageBridgeRatDispatcherSpec.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import kotlin.test.assertEquals
 
@@ -34,7 +33,12 @@ class MessageBridgeRatDispatcherSpec {
         ActionType.SEND_MESSAGE_TO_CONTACT_ID.action to Actype.SEND_MESSAGE_TO_CONTACT_ID,
         ActionType.SEND_MESSAGE_TO_MULTIPLE_CONTACTS.action to Actype.SEND_MESSAGE_TO_MULTIPLE_CONTACTS,
         ActionType.GET_POINTS.action to Actype.GET_POINTS,
-        ActionType.GET_HOST_ENVIRONMENT_INFO.action to Actype.GET_HOST_ENVIRONMENT_INFO
+        ActionType.GET_HOST_ENVIRONMENT_INFO.action to Actype.GET_HOST_ENVIRONMENT_INFO,
+        ActionType.FILE_DOWNLOAD.action to Actype.FILE_DOWNLOAD,
+        ActionType.GET_UNIQUE_ID.action to Actype.GET_UNIQUE_ID,
+        ActionType.GET_MESSAGING_UNIQUE_ID.action to Actype.GET_MESSAGING_UNIQUE_ID,
+        ActionType.GET_MAUID.action to Actype.GET_MAUID
+
     )
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppBridgeSpec.kt
@@ -178,15 +178,18 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
 
     @Before
     fun setup() {
-        When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-        miniAppBridge.init(
-            activity = TestActivity(),
-            webViewListener = webViewListener,
-            customPermissionCache = mock(),
-            downloadedManifestCache = mock(),
-            miniAppId = TEST_MA_ID,
-            ratDispatcher = mock()
-        )
+        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
+            When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
+            miniAppBridge.init(
+                activity = activity,
+                webViewListener = webViewListener,
+                customPermissionCache = mock(),
+                downloadedManifestCache = mock(),
+                miniAppId = TEST_MA_ID,
+                ratDispatcher = mock(),
+                secureStorageDispatcher = mock()
+            )
+        }
     }
 
     @Test
@@ -198,21 +201,24 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
 
     @Test
     fun `postError should be called when cannot get unique id`() {
-        val errMsg = "Cannot get unique id: null"
-        val webViewListener = createErrorWebViewListener("${ErrorBridgeMessage.ERR_UNIQUE_ID} null")
-        val bridgeExecutor = Mockito.spy(miniAppBridge.createBridgeExecutor(webViewListener))
-        When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-        miniAppBridge.init(
-            activity = TestActivity(),
-            webViewListener = webViewListener,
-            customPermissionCache = mock(),
-            downloadedManifestCache = mock(),
-            miniAppId = TEST_MA_ID,
-            ratDispatcher = mock()
-        )
-        miniAppBridge.postMessage(uniqueIdJsonStr)
+        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
+            val errMsg = "Cannot get unique id: null"
+            val webViewListener = createErrorWebViewListener("${ErrorBridgeMessage.ERR_UNIQUE_ID} null")
+            val bridgeExecutor = Mockito.spy(miniAppBridge.createBridgeExecutor(webViewListener))
+            When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
+            miniAppBridge.init(
+                activity = activity,
+                webViewListener = webViewListener,
+                customPermissionCache = mock(),
+                downloadedManifestCache = mock(),
+                miniAppId = TEST_MA_ID,
+                ratDispatcher = mock(),
+                secureStorageDispatcher = mock()
+            )
+            miniAppBridge.postMessage(uniqueIdJsonStr)
 
-        verify(bridgeExecutor).postError(TEST_CALLBACK_ID, errMsg)
+            verify(bridgeExecutor).postError(TEST_CALLBACK_ID, errMsg)
+        }
     }
 
     @Test
@@ -224,21 +230,25 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
 
     @Test
     fun `postError should be called when cannot get contact id`() {
-        val errMsg = "Cannot get messaging unique id: null"
-        val webViewListener = createErrorWebViewListener("${ErrorBridgeMessage.ERR_MESSAGING_UNIQUE_ID} null")
-        val bridgeExecutor = Mockito.spy(miniAppBridge.createBridgeExecutor(webViewListener))
-        When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-        miniAppBridge.init(
-            activity = TestActivity(),
-            webViewListener = webViewListener,
-            customPermissionCache = mock(),
-            downloadedManifestCache = mock(),
-            miniAppId = TEST_MA_ID,
-            ratDispatcher = mock()
-        )
-        miniAppBridge.postMessage(messagingUniqueIdJsonStr)
+        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
+            val errMsg = "Cannot get messaging unique id: null"
+            val webViewListener =
+                createErrorWebViewListener("${ErrorBridgeMessage.ERR_MESSAGING_UNIQUE_ID} null")
+            val bridgeExecutor = Mockito.spy(miniAppBridge.createBridgeExecutor(webViewListener))
+            When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
+            miniAppBridge.init(
+                activity = activity,
+                webViewListener = webViewListener,
+                customPermissionCache = mock(),
+                downloadedManifestCache = mock(),
+                miniAppId = TEST_MA_ID,
+                ratDispatcher = mock(),
+                secureStorageDispatcher = mock()
+            )
+            miniAppBridge.postMessage(messagingUniqueIdJsonStr)
 
-        verify(bridgeExecutor).postError(TEST_CALLBACK_ID, errMsg)
+            verify(bridgeExecutor).postError(TEST_CALLBACK_ID, errMsg)
+        }
     }
 
     @Test
@@ -250,63 +260,77 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
 
     @Test
     fun `postError should be called when cannot get mauid`() {
-        val errMsg = "Cannot get mauid: null"
-        val webViewListener = createErrorWebViewListener("${ErrorBridgeMessage.ERR_MAUID} null")
-        val bridgeExecutor = Mockito.spy(miniAppBridge.createBridgeExecutor(webViewListener))
-        When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-        miniAppBridge.init(
-            activity = TestActivity(),
-            webViewListener = webViewListener,
-            customPermissionCache = mock(),
-            downloadedManifestCache = mock(),
-            miniAppId = TEST_MA_ID,
-            ratDispatcher = mock()
-        )
-        miniAppBridge.postMessage(mauIdJsonStr)
+        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
 
-        verify(bridgeExecutor).postError(TEST_CALLBACK_ID, errMsg)
+            val errMsg = "Cannot get mauid: null"
+            val webViewListener = createErrorWebViewListener("${ErrorBridgeMessage.ERR_MAUID} null")
+            val bridgeExecutor = Mockito.spy(miniAppBridge.createBridgeExecutor(webViewListener))
+            When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
+            miniAppBridge.init(
+                activity = activity,
+                webViewListener = webViewListener,
+                customPermissionCache = mock(),
+                downloadedManifestCache = mock(),
+                miniAppId = TEST_MA_ID,
+                ratDispatcher = mock(),
+                secureStorageDispatcher = mock()
+            )
+            miniAppBridge.postMessage(mauIdJsonStr)
+
+            verify(bridgeExecutor).postError(TEST_CALLBACK_ID, errMsg)
+        }
     }
 
     /** region: device permission */
     @Test
     fun `postError should be called when device permission granted is false`() {
-        val miniAppBridge = Mockito.spy(createMiniAppMessageBridge(false))
-        val errMsg = "Denied"
-        val webViewListener = createErrorWebViewListener("dummy message")
-        When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-        miniAppBridge.init(
-            activity = TestActivity(),
-            webViewListener = webViewListener,
-            customPermissionCache = mock(),
-            downloadedManifestCache = mock(),
-            miniAppId = TEST_MA_ID,
-            ratDispatcher = mock()
-        )
+        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
+            val miniAppBridge = Mockito.spy(createMiniAppMessageBridge(false))
+            val errMsg = "Denied"
+            val webViewListener = createErrorWebViewListener("dummy message")
+            When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
+            miniAppBridge.init(
+                activity = activity,
+                webViewListener = webViewListener,
+                customPermissionCache = mock(),
+                downloadedManifestCache = mock(),
+                miniAppId = TEST_MA_ID,
+                ratDispatcher = mock(),
+                secureStorageDispatcher = mock()
+            )
 
-        miniAppBridge.postMessage(permissionJsonStr)
+            miniAppBridge.postMessage(permissionJsonStr)
 
-        verify(bridgeExecutor).postError(permissionCallbackObj.id, errMsg)
+            verify(bridgeExecutor).postError(permissionCallbackObj.id, errMsg)
+        }
     }
 
     @Test
     fun `postValue should be called when device permission is granted`() {
-        val isPermissionGranted = true
-        val miniAppBridge = Mockito.spy(createMiniAppMessageBridge(isPermissionGranted))
-        val webViewListener = createErrorWebViewListener("${ErrorBridgeMessage.ERR_REQ_DEVICE_PERMISSION} null")
-        When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-        miniAppBridge.init(
-            activity = TestActivity(),
-            webViewListener = webViewListener,
-            customPermissionCache = mock(),
-            downloadedManifestCache = mock(),
-            miniAppId = TEST_MA_ID,
-            ratDispatcher = mock()
-        )
+        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
+            val isPermissionGranted = true
+            val miniAppBridge = Mockito.spy(createMiniAppMessageBridge(isPermissionGranted))
+            val webViewListener =
+                createErrorWebViewListener("${ErrorBridgeMessage.ERR_REQ_DEVICE_PERMISSION} null")
+            When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
+            miniAppBridge.init(
+                activity = activity,
+                webViewListener = webViewListener,
+                customPermissionCache = mock(),
+                downloadedManifestCache = mock(),
+                miniAppId = TEST_MA_ID,
+                ratDispatcher = mock(),
+                secureStorageDispatcher = mock()
+            )
 
-        miniAppBridge.postMessage(permissionJsonStr)
+            miniAppBridge.postMessage(permissionJsonStr)
 
-        verify(bridgeExecutor)
-            .postValue(permissionCallbackObj.id, MiniAppDevicePermissionResult.getValue(isPermissionGranted).type)
+            verify(bridgeExecutor)
+                .postValue(
+                    permissionCallbackObj.id,
+                    MiniAppDevicePermissionResult.getValue(isPermissionGranted).type
+                )
+        }
     }
 
     @Test
@@ -340,12 +364,13 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
             val webViewListener = createErrorWebViewListener("${ErrorBridgeMessage.ERR_REQ_DEVICE_PERMISSION} null")
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
             miniAppBridge.init(
-                activity = TestActivity(),
+                activity = activity,
                 webViewListener = webViewListener,
                 customPermissionCache = mock(),
                 downloadedManifestCache = mock(),
                 miniAppId = TEST_MA_ID,
-                ratDispatcher = mock()
+                ratDispatcher = mock(),
+                secureStorageDispatcher = mock()
             )
             val info = HostEnvironmentInfo(activity, "en")
             miniAppBridge.onGetHostEnvironmentInfo(hostEnvInfoCallbackObj.id)
@@ -383,15 +408,18 @@ class ShareContentBridgeSpec : BridgeCommon() {
 
     @Before
     fun setupShareInfo() {
-        When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-        miniAppBridge.init(
-            activity = TestActivity(),
-            webViewListener = webViewListener,
-            customPermissionCache = mock(),
-            downloadedManifestCache = mock(),
-            miniAppId = TEST_MA_ID,
-            ratDispatcher = mock()
-        )
+        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
+            When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
+            miniAppBridge.init(
+                activity = activity,
+                webViewListener = webViewListener,
+                customPermissionCache = mock(),
+                downloadedManifestCache = mock(),
+                miniAppId = TEST_MA_ID,
+                ratDispatcher = mock(),
+                secureStorageDispatcher = mock()
+            )
+        }
     }
 
     private val shareContentJsonStr = createShareCallbackJsonStr("This is content")
@@ -417,7 +445,8 @@ class ShareContentBridgeSpec : BridgeCommon() {
                 customPermissionCache = mock(),
                 downloadedManifestCache = mock(),
                 miniAppId = TEST_MA_ID,
-                ratDispatcher = mock()
+                ratDispatcher = mock(),
+                secureStorageDispatcher = mock()
             )
             miniAppBridge.postMessage(shareContentJsonStr)
 
@@ -436,7 +465,8 @@ class ShareContentBridgeSpec : BridgeCommon() {
                 customPermissionCache = mock(),
                 downloadedManifestCache = mock(),
                 miniAppId = TEST_MA_ID,
-                ratDispatcher = mock()
+                ratDispatcher = mock(),
+                secureStorageDispatcher = mock()
             )
             miniAppBridge.dispatchNativeEvent(NativeEventType.EXTERNAL_WEBVIEW_CLOSE, "")
 
@@ -456,7 +486,8 @@ class ShareContentBridgeSpec : BridgeCommon() {
                 customPermissionCache = mock(),
                 downloadedManifestCache = mock(),
                 miniAppId = TEST_MA_ID,
-                ratDispatcher = mock()
+                ratDispatcher = mock(),
+                secureStorageDispatcher = mock()
             )
             miniAppBridge.dispatchNativeEvent(NativeEventType.EXTERNAL_WEBVIEW_CLOSE, "")
 
@@ -473,26 +504,38 @@ class ShareContentBridgeSpec : BridgeCommon() {
 
     @Test
     fun `postError should be called when cannot share content`() {
-        val miniAppBridge = Mockito.spy(createMiniAppMessageBridge(false))
-        val errMsg = "${ErrorBridgeMessage.ERR_SHARE_CONTENT} null"
-        val webViewListener = createErrorWebViewListener(errMsg)
-        val bridgeExecutor = Mockito.spy(miniAppBridge.createBridgeExecutor(webViewListener))
-        When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-        miniAppBridge.init(
-            activity = TestActivity(),
-            webViewListener = webViewListener,
-            customPermissionCache = mock(),
-            downloadedManifestCache = mock(),
-            miniAppId = TEST_MA_ID,
-            ratDispatcher = mock()
-        )
-        miniAppBridge.postMessage(shareContentJsonStr)
+        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
+            val miniAppBridge = Mockito.spy(createMiniAppMessageBridge(false))
+            val errMsg = "${ErrorBridgeMessage.ERR_SHARE_CONTENT} null"
+            val webViewListener = createErrorWebViewListener(errMsg)
+            val bridgeExecutor = Mockito.spy(miniAppBridge.createBridgeExecutor(webViewListener))
+            When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
+            miniAppBridge.init(
+                activity = activity,
+                webViewListener = webViewListener,
+                customPermissionCache = mock(),
+                downloadedManifestCache = mock(),
+                miniAppId = TEST_MA_ID,
+                ratDispatcher = mock(),
+                secureStorageDispatcher = mock()
+            )
+            miniAppBridge.postMessage(shareContentJsonStr)
 
-        verify(bridgeExecutor).postError(TEST_CALLBACK_ID, errMsg)
+            verify(bridgeExecutor).postError(TEST_CALLBACK_ID, errMsg)
+        }
     }
 
     @Test
     fun `postValue should not be called when using default method without Activity`() {
+        miniAppBridge.init(
+            activity = TestFilesDirActivity(),
+            webViewListener = webViewListener,
+            customPermissionCache = mock(),
+            downloadedManifestCache = mock(),
+            miniAppId = TEST_MA_ID,
+            ratDispatcher = mock(),
+            secureStorageDispatcher = mock()
+        )
         miniAppBridge.postMessage(shareContentJsonStr)
 
         verify(bridgeExecutor, times(0)).postValue(TEST_CALLBACK_ID, SUCCESS)
@@ -507,6 +550,7 @@ class ShareContentBridgeSpec : BridgeCommon() {
     }
 }
 
+@RunWith(AndroidJUnit4::class)
 class AdBridgeSpec : BridgeCommon() {
     private lateinit var miniAppBridge: MiniAppMessageBridge
     private lateinit var miniAppBridgeWithAdMob: MiniAppMessageBridge
@@ -529,14 +573,17 @@ class AdBridgeSpec : BridgeCommon() {
         AdMobClassName = adMobCheckedClass
         val miniAppBridge = Mockito.spy(createDefaultMiniAppMessageBridge())
         When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-        miniAppBridge.init(
-            activity = TestActivity(),
-            webViewListener = webViewListener,
-            customPermissionCache = mock(),
-            downloadedManifestCache = mock(),
-            miniAppId = TEST_MA_ID,
-            ratDispatcher = mock()
-        )
+        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
+            miniAppBridge.init(
+                activity = activity,
+                webViewListener = webViewListener,
+                customPermissionCache = mock(),
+                downloadedManifestCache = mock(),
+                miniAppId = TEST_MA_ID,
+                ratDispatcher = mock(),
+                secureStorageDispatcher = mock()
+            )
+        }
         miniAppBridge.setAdMobDisplayer(TestAdMobDisplayer())
         return miniAppBridge
     }
@@ -587,16 +634,19 @@ class ScreenBridgeSpec : BridgeCommon() {
 
     @Before
     fun setupScreenBridgeDispatcher() {
-        When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-        miniAppBridge.allowScreenOrientation(false)
-        miniAppBridge.init(
-            activity = TestActivity(),
-            webViewListener = webViewListener,
-            customPermissionCache = mock(),
-            downloadedManifestCache = mock(),
-            miniAppId = TEST_MA_ID,
-            ratDispatcher = mock()
-        )
+        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
+            When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
+            miniAppBridge.allowScreenOrientation(false)
+            miniAppBridge.init(
+                activity = activity,
+                webViewListener = webViewListener,
+                customPermissionCache = mock(),
+                downloadedManifestCache = mock(),
+                miniAppId = TEST_MA_ID,
+                ratDispatcher = mock(),
+                secureStorageDispatcher = mock()
+            )
+        }
     }
 
     private fun createCallbackJsonStr(orientation: ScreenOrientation) = Gson().toJson(
@@ -613,7 +663,7 @@ class ScreenBridgeSpec : BridgeCommon() {
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
             val miniAppBridge = Mockito.spy(createDefaultMiniAppMessageBridge())
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.init(activity, webViewListener, mock(), mock(), TEST_MA_ID, mock())
+            miniAppBridge.init(activity, webViewListener, mock(), mock(), TEST_MA_ID, mock(), mock())
             miniAppBridge.allowScreenOrientation(true)
             miniAppBridge.postMessage(createCallbackJsonStr(ScreenOrientation.LOCK_PORTRAIT))
             miniAppBridge.postMessage(createCallbackJsonStr(ScreenOrientation.LOCK_LANDSCAPE))

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppBridgeSpec.kt
@@ -47,6 +47,20 @@ open class BridgeCommon {
                 onSuccess(TEST_CALLBACK_VALUE)
             }
 
+            override fun getMessagingUniqueId(
+                onSuccess: (uniqueId: String) -> Unit,
+                onError: (message: String) -> Unit
+            ) {
+                onSuccess(TEST_CALLBACK_VALUE)
+            }
+
+            override fun getMauid(
+                onSuccess: (mauId: String) -> Unit,
+                onError: (message: String) -> Unit
+            ) {
+                onSuccess(TEST_CALLBACK_VALUE)
+            }
+
             override fun requestDevicePermission(
                 miniAppPermissionType: MiniAppDevicePermissionType,
                 callback: (isGranted: Boolean) -> Unit
@@ -82,6 +96,20 @@ open class BridgeCommon {
 
         override fun getUniqueId(
             onSuccess: (uniqueId: String) -> Unit,
+            onError: (message: String) -> Unit
+        ) {
+            onSuccess(TEST_CALLBACK_VALUE)
+        }
+
+        override fun getMessagingUniqueId(
+            onSuccess: (uniqueId: String) -> Unit,
+            onError: (message: String) -> Unit
+        ) {
+            onSuccess(TEST_CALLBACK_VALUE)
+        }
+
+        override fun getMauid(
+            onSuccess: (mauId: String) -> Unit,
             onError: (message: String) -> Unit
         ) {
             onSuccess(TEST_CALLBACK_VALUE)
@@ -123,6 +151,18 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
         param = null,
         id = TEST_CALLBACK_ID)
     private val uniqueIdJsonStr = Gson().toJson(uniqueIdCallbackObj)
+
+    private val messagingUniqueIdCallbackObj = CallbackObj(
+        action = ActionType.GET_MESSAGING_UNIQUE_ID.action,
+        param = null,
+        id = TEST_CALLBACK_ID)
+    private val messagingUniqueIdJsonStr = Gson().toJson(messagingUniqueIdCallbackObj)
+
+    private val mauIdCallbackObj = CallbackObj(
+        action = ActionType.GET_MAUID.action,
+        param = null,
+        id = TEST_CALLBACK_ID)
+    private val mauIdJsonStr = Gson().toJson(mauIdCallbackObj)
 
     private val permissionCallbackObj = CallbackObj(
         action = ActionType.REQUEST_PERMISSION.action,
@@ -171,6 +211,58 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
             ratDispatcher = mock()
         )
         miniAppBridge.postMessage(uniqueIdJsonStr)
+
+        verify(bridgeExecutor).postError(TEST_CALLBACK_ID, errMsg)
+    }
+
+    @Test
+    fun `should be able to return contact id to miniapp`() {
+        miniAppBridge.postMessage(messagingUniqueIdJsonStr)
+
+        verify(bridgeExecutor).postValue(TEST_CALLBACK_ID, TEST_CALLBACK_VALUE)
+    }
+
+    @Test
+    fun `postError should be called when cannot get contact id`() {
+        val errMsg = "Cannot get messaging unique id: null"
+        val webViewListener = createErrorWebViewListener("${ErrorBridgeMessage.ERR_MESSAGING_UNIQUE_ID} null")
+        val bridgeExecutor = Mockito.spy(miniAppBridge.createBridgeExecutor(webViewListener))
+        When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
+        miniAppBridge.init(
+            activity = TestActivity(),
+            webViewListener = webViewListener,
+            customPermissionCache = mock(),
+            downloadedManifestCache = mock(),
+            miniAppId = TEST_MA_ID,
+            ratDispatcher = mock()
+        )
+        miniAppBridge.postMessage(messagingUniqueIdJsonStr)
+
+        verify(bridgeExecutor).postError(TEST_CALLBACK_ID, errMsg)
+    }
+
+    @Test
+    fun `should be able to return mauid to miniapp`() {
+        miniAppBridge.postMessage(mauIdJsonStr)
+
+        verify(bridgeExecutor).postValue(TEST_CALLBACK_ID, TEST_CALLBACK_VALUE)
+    }
+
+    @Test
+    fun `postError should be called when cannot get mauid`() {
+        val errMsg = "Cannot get mauid: null"
+        val webViewListener = createErrorWebViewListener("${ErrorBridgeMessage.ERR_MAUID} null")
+        val bridgeExecutor = Mockito.spy(miniAppBridge.createBridgeExecutor(webViewListener))
+        When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
+        miniAppBridge.init(
+            activity = TestActivity(),
+            webViewListener = webViewListener,
+            customPermissionCache = mock(),
+            downloadedManifestCache = mock(),
+            miniAppId = TEST_MA_ID,
+            ratDispatcher = mock()
+        )
+        miniAppBridge.postMessage(mauIdJsonStr)
 
         verify(bridgeExecutor).postError(TEST_CALLBACK_ID, errMsg)
     }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppBridgeSpec.kt
@@ -140,7 +140,7 @@ open class BridgeCommon {
 }
 
 @RunWith(AndroidJUnit4::class)
-@Suppress("LongMethod")
+@Suppress("LongMethod", "LargeClass")
 class MiniAppMessageBridgeSpec : BridgeCommon() {
     private val miniAppBridge: MiniAppMessageBridge = Mockito.spy(
         createMiniAppMessageBridge(false)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/chat/ChatBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/chat/ChatBridgeDispatcherSpec.kt
@@ -1,5 +1,7 @@
 package com.rakuten.tech.mobile.miniapp.js.chat
 
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.gson.Gson
 import org.mockito.kotlin.*
 import com.rakuten.tech.mobile.miniapp.TestActivity
@@ -21,6 +23,7 @@ import org.amshove.kluent.itReturns
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.Mockito
 
 open class BaseChatBridgeDispatcherSpec {
@@ -48,15 +51,18 @@ open class BaseChatBridgeDispatcherSpec {
     @Before
     fun setup() {
         miniAppBridge = Mockito.spy(createMessageBridge())
-        When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-        miniAppBridge.init(
-            activity = TestActivity(),
-            webViewListener = webViewListener,
-            customPermissionCache = customPermissionCache,
-            downloadedManifestCache = downloadedManifestCache,
-            miniAppId = TEST_MA.id,
-            ratDispatcher = mock()
-        )
+        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
+            When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
+            miniAppBridge.init(
+                activity = activity,
+                webViewListener = webViewListener,
+                customPermissionCache = customPermissionCache,
+                downloadedManifestCache = downloadedManifestCache,
+                miniAppId = TEST_MA.id,
+                ratDispatcher = mock(),
+                secureStorageDispatcher = mock()
+            )
+        }
     }
 
     protected fun createChatMessageBridgeDispatcher(
@@ -164,6 +170,7 @@ open class BaseChatBridgeDispatcherSpec {
     )
 }
 
+@RunWith(AndroidJUnit4::class)
 class ChatBridgeDispatcherSpec : BaseChatBridgeDispatcherSpec() {
     @Test
     fun `postError should be called when hostapp doesn't implement the chat dispatcher for single chat`() {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostEnvironmentInfoBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostEnvironmentInfoBridgeSpec.kt
@@ -25,15 +25,18 @@ class HostEnvironmentInfoBridgeSpec : BridgeCommon() {
 
     @Before
     fun setup() {
-        When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-        miniAppBridge.init(
-                activity = TestActivity(),
+        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
+            When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
+            miniAppBridge.init(
+                activity = activity,
                 webViewListener = webViewListener,
                 customPermissionCache = mock(),
                 downloadedManifestCache = mock(),
                 miniAppId = TEST_MA_ID,
-                ratDispatcher = mock()
-        )
+                ratDispatcher = mock(),
+                secureStorageDispatcher = mock()
+            )
+        }
     }
 
     private val hostEnvCallbackObj = CallbackObj(
@@ -60,7 +63,8 @@ class HostEnvironmentInfoBridgeSpec : BridgeCommon() {
                     customPermissionCache = mock(),
                     downloadedManifestCache = mock(),
                     miniAppId = TEST_MA_ID,
-                    ratDispatcher = mock()
+                    ratDispatcher = mock(),
+                    secureStorageDispatcher = mock()
             )
             miniAppBridge.postMessage(hostEnvJsonStr)
             verify(bridgeExecutor).postValue(hostEnvCallbackObj.id, Gson().toJson(hostEnvironmentInfo))
@@ -69,22 +73,26 @@ class HostEnvironmentInfoBridgeSpec : BridgeCommon() {
 
     @Test
     fun `postError should be called when cannot retrieve environment info`() {
-        val miniAppBridge = Mockito.spy(createMiniAppMessageBridge(false))
-        val infoErrMessage = "{\"type\":\"{\\\"type\\\":\\\"Cannot get host environment info: error_message\\\"}\"}"
-        val webViewListener = createErrorWebViewListener(infoErrMessage)
-        val bridgeExecutor = Mockito.spy(miniAppBridge.createBridgeExecutor(webViewListener))
-        When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-        miniAppBridge.init(
-                activity = TestActivity(),
+        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
+            val miniAppBridge = Mockito.spy(createMiniAppMessageBridge(false))
+            val infoErrMessage =
+                "{\"type\":\"{\\\"type\\\":\\\"Cannot get host environment info: error_message\\\"}\"}"
+            val webViewListener = createErrorWebViewListener(infoErrMessage)
+            val bridgeExecutor = Mockito.spy(miniAppBridge.createBridgeExecutor(webViewListener))
+            When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
+            miniAppBridge.init(
+                activity = activity,
                 webViewListener = webViewListener,
                 customPermissionCache = mock(),
                 downloadedManifestCache = mock(),
                 miniAppId = TEST_MA_ID,
-                ratDispatcher = mock()
-        )
-        miniAppBridge.postMessage(hostEnvJsonStr)
+                ratDispatcher = mock(),
+                secureStorageDispatcher = mock()
+            )
+            miniAppBridge.postMessage(hostEnvJsonStr)
 
-        verify(bridgeExecutor).postError(TEST_CALLBACK_ID, infoErrMessage)
+            verify(bridgeExecutor).postError(TEST_CALLBACK_ID, infoErrMessage)
+        }
     }
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.miniapp.js.userinfo
 
+import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.gson.Gson
 import org.mockito.kotlin.*
@@ -76,16 +77,19 @@ class UserInfoBridgeSpec {
 
     @Before
     fun setup() {
-        miniAppBridge = Mockito.spy(createMessageBridge())
-        When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-        miniAppBridge.init(
-            activity = TestActivity(),
-            webViewListener = webViewListener,
-            customPermissionCache = customPermissionCache,
-            downloadedManifestCache = downloadedManifestCache,
-            miniAppId = TEST_MA.id,
-            ratDispatcher = ratDispatcher
-        )
+        ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
+            miniAppBridge = Mockito.spy(createMessageBridge())
+            When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
+            miniAppBridge.init(
+                activity = activity,
+                webViewListener = webViewListener,
+                customPermissionCache = customPermissionCache,
+                downloadedManifestCache = downloadedManifestCache,
+                miniAppId = TEST_MA.id,
+                ratDispatcher = ratDispatcher,
+                secureStorageDispatcher = mock()
+            )
+        }
 
         whenever(customPermissionCache.hasPermission(
             miniAppInfo.id, MiniAppCustomPermissionType.USER_NAME)

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -58,6 +58,7 @@ android {
             sslPublicKey            : property("CERTIFICATE_PUBLIC_KEY") ?: "",
             sslPublicKeyBackup      : property("CERTIFICATE_PUBLIC_KEY_BACKUP") ?: "",
             enableH5Ads             : property("ENABLE_H5_ADS") ?: true,
+            storageMaxSizeKB        : property("STORAGE_MAX_SIZE_KB") ?: 5000,
     ] + commonPlaceholders
     def stagingManifestPlaceholders = debugManifestPlaceholders.clone()
     stagingManifestPlaceholders.appName = defaultAppName + " STG"
@@ -74,6 +75,7 @@ android {
             sslPublicKey            : property("PROD_CERTIFICATE_PUBLIC_KEY") ?: "",
             sslPublicKeyBackup      : property("PROD_CERTIFICATE_PUBLIC_KEY_BACKUP") ?: "",
             enableH5Ads             : property("ENABLE_H5_ADS") ?: true,
+            storageMaxSizeKB        : property("STORAGE_MAX_SIZE_KB") ?: 5000,
     ] + commonPlaceholders
 
     def buildVersion = System.getenv("CIRCLE_BUILD_NUM") ?: new Date().format('yyMMddHHmm')

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -125,6 +125,9 @@
         <meta-data
             android:name="com.rakuten.tech.mobile.miniapp.EnableH5Ads"
             android:value="${enableH5Ads}" />
+        <meta-data
+            android:name="com.rakuten.tech.mobile.miniapp.StorageMaxSizeKB"
+            android:value="${storageMaxSizeKB}" />
     </application>
 
 </manifest>

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/MiniAppListStore.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/MiniAppListStore.kt
@@ -7,7 +7,6 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
-import java.lang.IllegalStateException
 
 class MiniAppListStore private constructor(context: Context) {
 
@@ -40,7 +39,7 @@ class MiniAppListStore private constructor(context: Context) {
             prefs.getString(miniAppList, ""),
             object : TypeToken<List<MiniAppInfo>>() {}.type
         )
-    } catch (error: IllegalStateException) {
+    } catch (error: Exception) {
         emptyList()
     }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -249,6 +249,24 @@ class MiniAppDisplayActivity : BaseActivity() {
                 else onSuccess(AppSettings.instance.uniqueId)
             }
 
+            override fun getMessagingUniqueId(
+                onSuccess: (uniqueId: String) -> Unit,
+                onError: (message: String) -> Unit
+            ) {
+                val errorMsg = AppSettings.instance.uniqueIdError
+                if (errorMsg.isNotEmpty()) onError(errorMsg)
+                else onSuccess("TEST-MESSAGE_UNIQUE-ID-01234")
+            }
+
+            override fun getMauid(
+                onSuccess: (mauid: String) -> Unit,
+                onError: (message: String) -> Unit
+            ) {
+                val errorMsg = AppSettings.instance.mauIdError
+                if (errorMsg.isNotEmpty()) onError(errorMsg)
+                else onSuccess("TEST-MAUID-01234-56789")
+            }
+
             override fun requestDevicePermission(
                 miniAppPermissionType: MiniAppDevicePermissionType,
                 callback: (isGranted: Boolean) -> Unit

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/MiniAppDownloadedListActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/permission/MiniAppDownloadedListActivity.kt
@@ -47,8 +47,6 @@ class MiniAppDownloadedListActivity(private val miniApp: MiniApp) : BaseActivity
         executeLoadingList()
     }
 
-
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         showBackIcon()

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -73,6 +73,18 @@ class AppSettings private constructor(context: Context) {
             cache.uniqueIdError = uniqueIdError
         }
 
+    var messagingUniqueIdError: String
+        get() = cache.messagingUniqueIdError ?: ""
+        set(messagingUniqueIdError) {
+            cache.messagingUniqueIdError = messagingUniqueIdError
+        }
+
+    var mauIdError: String
+        get() = cache.mauIdError ?: ""
+        set(mauIdError) {
+            cache.mauIdError = mauIdError
+        }
+
     var isSettingSaved: Boolean
         get() = cache.isSettingSaved
         set(isSettingSaved) {
@@ -220,6 +232,15 @@ private class Settings(context: Context) {
         get() = prefs.getString(UNIQUE_ID_ERROR, null)
         set(uniqueIdError) = prefs.edit().putString(UNIQUE_ID_ERROR, uniqueIdError).apply()
 
+    var messagingUniqueIdError: String?
+        get() = prefs.getString(MESSAGING_UNIQUE_ID_ERROR, null)
+        set(messagingUniqueIdError) = prefs.edit()
+            .putString(MESSAGING_UNIQUE_ID_ERROR, messagingUniqueIdError).apply()
+
+    var mauIdError: String?
+        get() = prefs.getString(MAUID_ERROR, null)
+        set(mauIdError) = prefs.edit().putString(MAUID_ERROR, mauIdError).apply()
+
     var isSettingSaved: Boolean
         get() = prefs.getBoolean(IS_SETTING_SAVED, false)
         set(isSettingSaved) = prefs.edit().putBoolean(IS_SETTING_SAVED, isSettingSaved).apply()
@@ -293,6 +314,8 @@ private class Settings(context: Context) {
         private const val SUBSCRIPTION_KEY = "subscription_key"
         private const val UNIQUE_ID = "unique_id"
         private const val UNIQUE_ID_ERROR = "unique_id_error"
+        private const val MESSAGING_UNIQUE_ID_ERROR = "messaging_unique_id_error"
+        private const val MAUID_ERROR = "mauid_error"
         private const val IS_SETTING_SAVED = "is_setting_saved"
         private const val PROFILE_NAME = "profile_name"
         private const val PROFILE_PICTURE_URL = "profile_picture_url"

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
@@ -1,6 +1,8 @@
 package com.rakuten.tech.mobile.testapp.ui.userdata
 
 import android.app.Activity
+import android.app.AlertDialog
+import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
@@ -8,6 +10,7 @@ import android.view.MenuItem
 import android.widget.CompoundButton
 import android.widget.Toast
 import androidx.databinding.DataBindingUtil
+import com.rakuten.tech.mobile.miniapp.MiniApp
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppAccessTokenError
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.QaSettingsActivityBinding
@@ -21,6 +24,7 @@ class QASettingsActivity : BaseActivity() {
     private lateinit var settings: AppSettings
     private lateinit var binding: QaSettingsActivityBinding
     private var accessTokenErrorCacheData: MiniAppAccessTokenError? = null
+    private val miniApp = MiniApp.instance(AppSettings.instance.miniAppSettings)
 
     companion object {
         fun start(activity: Activity) {
@@ -92,7 +96,6 @@ class QASettingsActivity : BaseActivity() {
 
         // mauid
         binding.edtMauidError.setText(settings.mauIdError)
-
     }
 
     private fun startListeners(){
@@ -101,6 +104,31 @@ class QASettingsActivity : BaseActivity() {
         binding.switchUniqueIdError.setOnCheckedChangeListener { _, isChecked ->
             binding.edtUniqueIdError.isEnabled = isChecked
         }
+        binding.btnClearAllSecureStorage.setOnClickListener {
+            clearAllSecureStorage()
+        }
+    }
+
+    private fun clearAllSecureStorage() {
+        val dialogClickListener =
+            DialogInterface.OnClickListener { dialog, which ->
+                when (which) {
+                    DialogInterface.BUTTON_POSITIVE -> {
+                        miniApp.clearSecureStorage()
+                        Toast.makeText(
+                            this@QASettingsActivity,
+                            "Successfully cleared all secured storage!",
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
+                }
+                dialog.dismiss()
+            }
+
+        val builder: AlertDialog.Builder = AlertDialog.Builder(this@QASettingsActivity)
+        builder.setMessage("Are you sure to clear all secure storage?")
+            .setPositiveButton("Yes", dialogClickListener)
+            .setNegativeButton("No", dialogClickListener).show()
     }
 
     private val accessTokenListener =

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
@@ -86,6 +86,13 @@ class QASettingsActivity : BaseActivity() {
         binding.edtUniqueIdError.isEnabled = settings.uniqueIdError.isNotEmpty()
         binding.edtUniqueIdError.setText(settings.uniqueIdError)
         binding.switchUniqueIdError.isChecked = settings.uniqueIdError.isNotEmpty()
+
+        // messaging unique id
+        binding.edtMessagingUniqueIdError.setText(settings.messagingUniqueIdError)
+
+        // mauid
+        binding.edtMauidError.setText(settings.mauIdError)
+
     }
 
     private fun startListeners(){
@@ -140,6 +147,20 @@ class QASettingsActivity : BaseActivity() {
                 return
             } else settings.uniqueIdError = binding.edtUniqueIdError.text.toString()
         } else settings.uniqueIdError = ""
+
+        //Save contact ID error response
+        if (binding.edtMessagingUniqueIdError.text.isNullOrEmpty()) {
+            settings.messagingUniqueIdError = ""
+        } else {
+            settings.messagingUniqueIdError = binding.edtMessagingUniqueIdError.text.toString()
+        }
+
+        //Save mauID error response
+        if (binding.edtMauidError.text.isNullOrEmpty()) {
+            settings.mauIdError = ""
+        } else {
+            settings.mauIdError = binding.edtMauidError.text.toString()
+        }
 
         // post tasks
         hideSoftKeyboard(binding.root)

--- a/testapp/src/main/res/layout/qa_settings_activity.xml
+++ b/testapp/src/main/res/layout/qa_settings_activity.xml
@@ -103,7 +103,7 @@
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="@dimen/small_8">
+            android:padding="@dimen/small_4">
 
             <androidx.appcompat.widget.AppCompatEditText
                 android:id="@+id/edtUniqueIdError"
@@ -111,6 +111,34 @@
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/small_4"
                 android:hint="@string/hint_unique_id_error"
+                android:imeOptions="actionDone"
+                android:inputType="text" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/small_4">
+
+            <androidx.appcompat.widget.AppCompatEditText
+                android:id="@+id/edtMessagingUniqueIdError"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_messaging_unique_id_error"
+                android:imeOptions="actionDone"
+                android:inputType="text" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/small_4">
+
+            <androidx.appcompat.widget.AppCompatEditText
+                android:id="@+id/edtMauidError"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_mauid_error"
                 android:imeOptions="actionDone"
                 android:inputType="text" />
         </com.google.android.material.textfield.TextInputLayout>

--- a/testapp/src/main/res/layout/qa_settings_activity.xml
+++ b/testapp/src/main/res/layout/qa_settings_activity.xml
@@ -143,5 +143,30 @@
                 android:inputType="text" />
         </com.google.android.material.textfield.TextInputLayout>
 
+        <androidx.appcompat.widget.AppCompatTextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/bg_section"
+            android:paddingStart="@dimen/medium_16"
+            android:paddingTop="@dimen/small_4"
+            android:paddingEnd="@dimen/medium_16"
+            android:paddingBottom="@dimen/small_4"
+            android:text="@string/lb_secure_storage" />
+
+        <com.rakuten.tech.mobile.testapp.analytics.rat_wrapper.RATButton
+            android:id="@+id/btnClearAllSecureStorage"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/large_44"
+            android:layout_margin="@dimen/medium_16"
+            android:background="@drawable/bg_red_curve"
+            android:gravity="center"
+            android:padding="@dimen/small_4"
+            android:text="@string/action_clear_all"
+            android:textColor="@android:color/white"
+            android:textSize="@dimen/text_large_16"
+            app:actionType="change_status"
+            app:pageName="QA"
+            app:siteSection="Settings" />
+
     </LinearLayout>
 </layout>

--- a/testapp/src/main/res/values/dimens.xml
+++ b/testapp/src/main/res/values/dimens.xml
@@ -16,6 +16,7 @@
     <dimen name="medium_16">16dp</dimen>
     <dimen name="large_24">24dp</dimen>
     <dimen name="large_32">32dp</dimen>
+    <dimen name="large_44">44dp</dimen>
     <dimen name="large_52">52dp</dimen>
     <dimen name="large_72">72dp</dimen>
 

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -21,6 +21,8 @@
 
     <string name="lb_unique_id_error">Always Generate Unique ID Error</string>
     <string name="hint_unique_id_error">Unique ID Error Message</string>
+    <string name="hint_messaging_unique_id_error">Messaging Unique ID Error Message</string>
+    <string name="hint_mauid_error">MAUID Error Message</string>
 
     <string name="hint_points_standard">Points (Standard)</string>
     <string name="hint_points_time_limited">Points (Time-Limited)</string>

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="lb_display_input">Display by Input</string>
     <string name="lb_unique_id">Unique ID</string>
     <string name="lb_filter_view_miniapp">Open MiniApp</string>
+    <string name="lb_secure_storage">Secure Storage</string>
 
     <string name="lb_auth_failure_error">Always Generate Authorization Error</string>
     <string name="lb_other_error">Always Generate Custom Error</string>
@@ -67,6 +68,7 @@
     <string name="action_custom_permissions">Custom Permissions</string>
     <string name="action_first_time_accept">Accept</string>
     <string name="action_message_send">SEND</string>
+    <string name="action_clear_all">Clear All</string>
 
     <string name="hint_host_project_id">Host Project ID</string>
     <string name="hint_subscription_key">Subscription Key</string>


### PR DESCRIPTION
# Description
Remove the SDK dependency on `"io.github.rakutentech.sdkutils:sdk-utils"` from MiniApp SDK.
It's currently being used only to append some specific RAS headers to RAS requests. This PR aims to move those functionality directly into the Mini App SDK.

## Links
- MINI-5036

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
