### PR TITLE
[MINI-5036] Remove SDK Utils dependency from MiniApp SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## CHANGELOG
+### 4.1.1 (release date TBD)
+**SDK**
+- **Remove:** Removed `io.github.rakutentech.sdkutils` dependency and adopted the related changes to MiniApp SDK.
+
 ### 4.1.0 (2022-04-11)
 **SDK**
 - **Feature:** Added interface `MiniAppFileDownloader` to download files in device from miniapp.

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ buildscript {
     ext.okhttp = '4.9.1'
     ext.manifest_config = '0.2.0'
     ext.mockito_kotlin = '3.2.0'
-    ext.sdk_utils = '0.2.0'
     ext.retrofit = '2.9.0'
     ext.robolectric = '4.7.3'
     ext.webkit = '1.4.0'

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -1016,7 +1016,6 @@ To avoid this, please add the following to your `build.gradle` in order to exclu
 configurations.all {
     exclude group: 'com.rakuten.tech.mobile', module: 'manifest-config-processor'
     exclude group: 'com.rakuten.tech.mobile', module: 'manifest-config-annotations'
-    exclude group: 'com.rakuten.tech.mobile.sdkutils', module: 'sdk-utils'
 }
 
 ```

--- a/miniapp/build.gradle
+++ b/miniapp/build.gradle
@@ -70,7 +70,6 @@ dependencies {
 
     kapt "io.github.rakutentech.manifestconfig:manifest-config-processor:$manifest_config"
     implementation "io.github.rakutentech.manifestconfig:manifest-config-annotations:$manifest_config"
-    implementation "io.github.rakutentech.sdkutils:sdk-utils:$sdk_utils"
 
     testImplementation "androidx.test.ext:junit:$androidx_test_ext"
     testImplementation "org.mockito:mockito-android:$mockito"

--- a/miniapp/src/main/AndroidManifest.xml
+++ b/miniapp/src/main/AndroidManifest.xml
@@ -13,14 +13,6 @@
             android:exported="false"
             android:initOrder="99" />
 
-        <!-- Change init order for sdk-utils so it's initialized first -->
-        <provider
-            android:name="com.rakuten.tech.mobile.sdkutils.SdkUtilsInitProvider"
-            android:authorities="${applicationId}.SdkUtilsInitProvider"
-            android:exported="false"
-            android:initOrder="100"
-            tools:replace="android:initOrder" />
-
         <provider
             android:name="com.rakuten.tech.mobile.miniapp.display.MiniAppDefaultFileProvider"
             android:authorities="${applicationId}.miniapp.defaultfileprovider"

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -11,7 +11,6 @@ import com.rakuten.tech.mobile.miniapp.permission.*
 import com.rakuten.tech.mobile.miniapp.storage.CachedManifest
 import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
 import com.rakuten.tech.mobile.miniapp.storage.verifier.MiniAppManifestVerifier
-import com.rakuten.tech.mobile.sdkutils.AppInfo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.*
@@ -286,7 +285,6 @@ class RealMiniAppSpec : BaseRealMiniAppSpec() {
 
     @Test
     fun `should create a new ApiClient when there is no cache`() {
-        AppInfo.instance = mock()
         val miniApp = Mockito.spy(realMiniApp)
         val miniAppSdkConfig = MiniAppSdkConfig(
             baseUrl = TEST_URL_HTTPS_2,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
@@ -3,7 +3,6 @@ package com.rakuten.tech.mobile.miniapp.api
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import com.rakuten.tech.mobile.miniapp.*
-import com.rakuten.tech.mobile.sdkutils.AppInfo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import okhttp3.ResponseBody
@@ -218,7 +217,6 @@ open class ApiClientSpec {
 
     @Test
     fun `should create ApiClient without error`() {
-        AppInfo.instance = mock()
         ApiClient(
             baseUrl = TEST_URL_HTTPS_2,
             rasProjectId = TEST_HA_ID_PROJECT,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtilsSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitCreatorUtilsSpec.kt
@@ -4,7 +4,6 @@ import com.rakuten.tech.mobile.miniapp.TEST_LIST_PUBLIC_KEY_SSL
 import com.rakuten.tech.mobile.miniapp.TEST_URL_HTTPS_1
 import org.mockito.kotlin.mock
 import com.rakuten.tech.mobile.miniapp.TEST_VALUE
-import com.rakuten.tech.mobile.sdkutils.RasSdkHeaders
 import okhttp3.CertificatePinner
 import okhttp3.mockwebserver.MockWebServer
 import org.amshove.kluent.*

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/RetrofitRequestExecutorSpec.kt
@@ -2,7 +2,6 @@ package com.rakuten.tech.mobile.miniapp.api
 
 import org.mockito.kotlin.mock
 import com.rakuten.tech.mobile.miniapp.*
-import com.rakuten.tech.mobile.sdkutils.AppInfo
 import junit.framework.TestCase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
@@ -53,7 +52,6 @@ open class RetrofitRequestExecutorSpec private constructor(
     )
 
     internal fun spyRetrofitExecutor(): RetrofitRequestExecutor {
-        AppInfo.instance = mock()
         val retrofit = createRetrofitClient(
             baseUrl = TEST_URL_HTTPS_2,
             pubKeyList = TEST_LIST_PUBLIC_KEY_SSL,


### PR DESCRIPTION
# Description
Remove the SDK dependency on `"io.github.rakutentech.sdkutils:sdk-utils"` from MiniApp SDK.
It's currently being used only to append some specific RAS headers to RAS requests. This PR aims to move those functionality directly into the Mini App SDK.

## Links
- MINI-5036

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
