### PR TITLE
[MINI-5172] Separate API calls for preview mode

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -90,12 +90,23 @@ internal class ApiClient @VisibleForTesting constructor(
 
     @Throws(MiniAppSdkException::class)
     suspend fun fetchFileList(miniAppId: String, versionId: String): Pair<ManifestEntity, ManifestHeader> {
-        val request = manifestApi.fetchFileListFromManifest(
-            hostId = hostId,
-            miniAppId = miniAppId,
-            versionId = versionId,
-            testPath = testPath
-        )
+        val request = when {
+            testPath != "" -> {
+                manifestApi.fetchFileListFromManifestPreviewMode(
+                    hostId = hostId,
+                    miniAppId = miniAppId,
+                    versionId = versionId,
+                    testPath = testPath
+                )
+            }
+            else -> {
+                manifestApi.fetchFileListFromManifest(
+                    hostId = hostId,
+                    miniAppId = miniAppId,
+                    versionId = versionId,
+                )
+            }
+        }
         val response = requestExecutor.executeRequest(request)
         val manifestEntity = response.body() as ManifestEntity
         val manifestHeader = ManifestHeader(response.headers()["signature"])
@@ -104,13 +115,25 @@ internal class ApiClient @VisibleForTesting constructor(
 
     @Throws(MiniAppSdkException::class)
     suspend fun fetchMiniAppManifest(miniAppId: String, versionId: String, languageCode: String): MetadataEntity {
-        val request = metadataApi.fetchMetadata(
-            hostId = hostId,
-            miniAppId = miniAppId,
-            versionId = versionId,
-            testPath = testPath,
-            lang = languageCode
-        )
+        val request = when {
+            testPath != "" -> {
+                metadataApi.fetchMetadataPreviewMode(
+                    hostId = hostId,
+                    miniAppId = miniAppId,
+                    versionId = versionId,
+                    testPath = testPath,
+                    lang = languageCode
+                )
+            }
+            else -> {
+                metadataApi.fetchMetadata(
+                    hostId = hostId,
+                    miniAppId = miniAppId,
+                    versionId = versionId,
+                    lang = languageCode
+                )
+            }
+        }
         return requestExecutor.executeRequest(request).body() as MetadataEntity
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -91,21 +91,17 @@ internal class ApiClient @VisibleForTesting constructor(
     @Throws(MiniAppSdkException::class)
     suspend fun fetchFileList(miniAppId: String, versionId: String): Pair<ManifestEntity, ManifestHeader> {
         val request = when {
-            testPath != "" -> {
-                manifestApi.fetchFileListFromManifestPreviewMode(
-                    hostId = hostId,
-                    miniAppId = miniAppId,
-                    versionId = versionId,
-                    testPath = testPath
-                )
-            }
-            else -> {
-                manifestApi.fetchFileListFromManifest(
-                    hostId = hostId,
-                    miniAppId = miniAppId,
-                    versionId = versionId,
-                )
-            }
+            testPath != "" -> manifestApi.fetchFileListFromManifestPreviewMode(
+                hostId = hostId,
+                miniAppId = miniAppId,
+                versionId = versionId,
+                testPath = testPath
+            )
+            else -> manifestApi.fetchFileListFromManifest(
+                hostId = hostId,
+                miniAppId = miniAppId,
+                versionId = versionId,
+            )
         }
         val response = requestExecutor.executeRequest(request)
         val manifestEntity = response.body() as ManifestEntity
@@ -116,23 +112,19 @@ internal class ApiClient @VisibleForTesting constructor(
     @Throws(MiniAppSdkException::class)
     suspend fun fetchMiniAppManifest(miniAppId: String, versionId: String, languageCode: String): MetadataEntity {
         val request = when {
-            testPath != "" -> {
-                metadataApi.fetchMetadataPreviewMode(
-                    hostId = hostId,
-                    miniAppId = miniAppId,
-                    versionId = versionId,
-                    testPath = testPath,
-                    lang = languageCode
-                )
-            }
-            else -> {
-                metadataApi.fetchMetadata(
-                    hostId = hostId,
-                    miniAppId = miniAppId,
-                    versionId = versionId,
-                    lang = languageCode
-                )
-            }
+            testPath != "" -> metadataApi.fetchMetadataPreviewMode(
+                hostId = hostId,
+                miniAppId = miniAppId,
+                versionId = versionId,
+                testPath = testPath,
+                lang = languageCode
+            )
+            else -> metadataApi.fetchMetadata(
+                hostId = hostId,
+                miniAppId = miniAppId,
+                versionId = versionId,
+                lang = languageCode
+            )
         }
         return requestExecutor.executeRequest(request).body() as MetadataEntity
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ManifestApi.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ManifestApi.kt
@@ -7,6 +7,7 @@ import retrofit2.http.GET
 import retrofit2.http.Path
 
 internal interface ManifestApi {
+    @Suppress("FunctionMaxLength")
     @GET("host/{hostId}/miniapp/{miniappId}/version/{versionId}/{testPath}/manifest")
     fun fetchFileListFromManifestPreviewMode(
         @Path("hostId") hostId: String,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ManifestApi.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ManifestApi.kt
@@ -7,13 +7,19 @@ import retrofit2.http.GET
 import retrofit2.http.Path
 
 internal interface ManifestApi {
-    // double slash is okay
     @GET("host/{hostId}/miniapp/{miniappId}/version/{versionId}/{testPath}/manifest")
-    fun fetchFileListFromManifest(
+    fun fetchFileListFromManifestPreviewMode(
         @Path("hostId") hostId: String,
         @Path("miniappId") miniAppId: String,
         @Path("versionId") versionId: String,
         @Path("testPath") testPath: String = ""
+    ): Call<ManifestEntity>
+
+    @GET("host/{hostId}/miniapp/{miniappId}/version/{versionId}/manifest")
+    fun fetchFileListFromManifest(
+        @Path("hostId") hostId: String,
+        @Path("miniappId") miniAppId: String,
+        @Path("versionId") versionId: String,
     ): Call<ManifestEntity>
 }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/MetadataApi.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/MetadataApi.kt
@@ -10,11 +10,19 @@ import retrofit2.http.Query
 
 internal interface MetadataApi {
     @GET("host/{hostId}/miniapp/{miniappId}/version/{versionId}/{testPath}/metadata")
-    fun fetchMetadata(
+    fun fetchMetadataPreviewMode(
         @Path("hostId") hostId: String,
         @Path("miniappId") miniAppId: String,
         @Path("versionId") versionId: String,
         @Path("testPath") testPath: String = "",
+        @Query("lang") lang: String
+    ): Call<MetadataEntity>
+
+    @GET("host/{hostId}/miniapp/{miniappId}/version/{versionId}/metadata")
+    fun fetchMetadata(
+        @Path("hostId") hostId: String,
+        @Path("miniappId") miniAppId: String,
+        @Path("versionId") versionId: String,
         @Query("lang") lang: String
     ): Call<MetadataEntity>
 }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ApiClientSpec.kt
@@ -60,7 +60,7 @@ open class ApiClientSpec {
             Response.success(ManifestEntity(fileList, TEST_PUBLIC_KEY_ID))
         When calling
                 mockManifestApi
-                    .fetchFileListFromManifest(any(), any(), any(), any()) itReturns mockCall
+                    .fetchFileListFromManifest(any(), any(), any()) itReturns mockCall
         When calling
                 mockRequestExecutor
                     .executeRequest(mockCall) itReturns response
@@ -85,7 +85,7 @@ open class ApiClientSpec {
 
         When calling
                 mockManifestApi
-                    .fetchFileListFromManifest(any(), any(), any(), any()) itReturns mockCall
+                    .fetchFileListFromManifest(any(), any(), any()) itReturns mockCall
         When calling
                 mockRequestExecutor
                     .executeRequest(mockCall) itReturns response
@@ -174,7 +174,7 @@ open class ApiClientSpec {
         val response: Response<MetadataEntity> = Response.success(metadataEntity)
 
         When calling mockMetadataApi.fetchMetadata(TEST_HA_ID_PROJECT, TEST_MA_ID,
-            TEST_MA_VERSION_ID, "", TEST_LANG_MANIFEST_DEFAULT) itReturns mockCall
+            TEST_MA_VERSION_ID, TEST_LANG_MANIFEST_DEFAULT) itReturns mockCall
         When calling mockRequestExecutor.executeRequest(mockCall) itReturns response
 
         val apiClient = createApiClient(metadataApi = mockMetadataApi)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/ManifestApiSpec.kt
@@ -60,7 +60,7 @@ class ManifestApiRequestSpec : ManifestApiSpec() {
     fun `should have test endpoint when in test mode`() {
         mockServer.enqueue(createResponse())
         retrofit.create(ManifestApi::class.java)
-            .fetchFileListFromManifest(
+            .fetchFileListFromManifestPreviewMode(
                 hostId = TEST_HA_ID_PROJECT,
                 miniAppId = TEST_ID_MINIAPP,
                 versionId = TEST_ID_MINIAPP_VERSION,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/MetadataApiSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/api/MetadataApiSpec.kt
@@ -69,7 +69,7 @@ class MetadataApiRequestSpec : MetadataApiSpec() {
     fun `should have test endpoint when in test mode`() {
         mockServer.enqueue(createResponse())
         retrofit.create(MetadataApi::class.java)
-            .fetchMetadata(
+            .fetchMetadataPreviewMode(
                 hostId = TEST_HA_ID_PROJECT,
                 miniAppId = TEST_ID_MINIAPP,
                 versionId = TEST_ID_MINIAPP_VERSION,


### PR DESCRIPTION
# Description
if {testPath} value is a empty string then the get api became invalid because of `//` in the link, so seprate the api call for preview mode, {testPath} at the end is ok as it has no effect.

## Links
MINI-5172

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
