### PR TITLE
[MINI 4952] Add support for HTTP error status 429 (Too many requests)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 - **Feature:** Added support for base64 `data:` URIs to the File Download feature in `MiniAppFileDownloader`.
 - **Feature:** Added secure storage support for storing, getting and removing data for MiniApps safely. HostApp can clear secured data using `MiniApp.clearSecureStorage`.
 - **Feature:** Added `MiniAppMessageBridge.miniAppShouldClose()` function which would help the host app to check if any alert need to be displayed before closing the MiniApp.
+- **Feature:** Added `MiniAppTooManyRequestsError` which will be thrown from SDK if any API from platform sends `429` status code.
 
 **Sample App**
 - **Feature:** Added a `Clear All` button to Settings/QA to remove all secure storages.
+- **Feature:** Added support to display error popup when there is `MiniAppTooManyRequestsError`.
 
 ### 4.1.1 (2022-05-16)
 **SDK**

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -159,6 +159,7 @@ internal class MiniAppDownloader(
         versionId: String
     ) = apiClient.fetchFileList(appId, versionId)
 
+    @SuppressWarnings("NestedBlockDepth")
     @Throws(MiniAppSdkException::class)
     suspend fun fetchMiniAppManifest(appId: String, versionId: String, languageCode: String): MiniAppManifest {
         if (versionId.isEmpty()) throw MiniAppSdkException("Provided Mini App Version ID is invalid.")
@@ -210,7 +211,7 @@ internal class MiniAppDownloader(
         return pairs
     }
 
-    @SuppressWarnings("LongMethod", "NestedBlockDepth")
+    @SuppressWarnings("LongMethod", "NestedBlockDepth", "ComplexMethod", "ThrowsCount")
     private suspend fun downloadMiniApp(
         miniAppInfo: MiniAppInfo,
         manifest: Pair<ManifestEntity, ManifestHeader>

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDownloader.kt
@@ -48,7 +48,13 @@ internal class MiniAppDownloader(
     private val signatureVerifier: SignatureVerifier? by lazy { initSignatureVerifier() }
 
     suspend fun getMiniApp(appId: String): Pair<String, MiniAppInfo> = try {
-        val miniAppInfo = apiClient.fetchInfo(appId)
+        val miniAppInfo: MiniAppInfo
+        try {
+            miniAppInfo = apiClient.fetchInfo(appId)
+        } catch (error: MiniAppTooManyRequestsError) {
+            removeMiniApp(appId, "", TOO_MANY_REQUEST_ERR_LOG)
+            throw MiniAppTooManyRequestsError(error.message)
+        }
         onGetMiniApp(miniAppInfo)
     } catch (netError: MiniAppNetException) {
         onNetworkError(miniAppStatus.getDownloadedMiniApp(appId))
@@ -122,22 +128,23 @@ internal class MiniAppDownloader(
             return if (verifier.verify(miniAppInfo.version.versionId, File(versionPath)))
                 versionPath
             else {
-                removeMiniApp(miniAppInfo, "Failed to verify the hash of the cached files. " +
-                        "The files will be deleted and the Mini App re-downloaded.")
+                removeMiniApp(
+                    miniAppInfo.id,
+                    miniAppInfo.version.versionId,
+                    "Failed to verify the hash of the cached files. " +
+                            "The files will be deleted and the Mini App re-downloaded."
+                )
                 null
             }
         }
         return null
     }
 
-    private fun removeMiniApp(miniAppInfo: MiniAppInfo, log: String) {
+    internal fun removeMiniApp(appId: String, versionId: String = "", log: String) {
         Log.e(TAG, log)
-        storage.removeApp(miniAppInfo.id)
-        miniAppStatus.setVersionDownloaded(
-                miniAppInfo.id,
-                miniAppInfo.version.versionId,
-                false
-        )
+        storage.removeApp(appId)
+        if (versionId.isNotEmpty())
+            miniAppStatus.setVersionDownloaded(appId, versionId, false)
     }
 
     @VisibleForTesting
@@ -156,20 +163,25 @@ internal class MiniAppDownloader(
     suspend fun fetchMiniAppManifest(appId: String, versionId: String, languageCode: String): MiniAppManifest {
         if (versionId.isEmpty()) throw MiniAppSdkException("Provided Mini App Version ID is invalid.")
         else {
-            return if (apiClient.isPreviewMode) {
-                // every version should have it's own manifest information and it can be changed
-                val apiResponse = apiClient.fetchMiniAppManifest(appId, versionId, languageCode)
-                prepareMiniAppManifest(apiResponse, versionId)
-            } else {
-                // every version should have it's own manifest information or null
-                val cachedLatestManifest = manifestApiCache.readManifest(appId, versionId)
-                if (cachedLatestManifest != null) cachedLatestManifest
-                else {
+            try {
+                return if (apiClient.isPreviewMode) {
+                    // every version should have it's own manifest information and it can be changed
                     val apiResponse = apiClient.fetchMiniAppManifest(appId, versionId, languageCode)
-                    val latestManifest = prepareMiniAppManifest(apiResponse, versionId)
-                    manifestApiCache.storeManifest(appId, versionId, latestManifest)
-                    latestManifest
+                    prepareMiniAppManifest(apiResponse, versionId)
+                } else {
+                    // every version should have it's own manifest information or null
+                    val cachedLatestManifest = manifestApiCache.readManifest(appId, versionId)
+                    if (cachedLatestManifest != null) cachedLatestManifest
+                    else {
+                        val apiResponse = apiClient.fetchMiniAppManifest(appId, versionId, languageCode)
+                        val latestManifest = prepareMiniAppManifest(apiResponse, versionId)
+                        manifestApiCache.storeManifest(appId, versionId, latestManifest)
+                        latestManifest
+                    }
                 }
+            } catch (error: MiniAppTooManyRequestsError) {
+                removeMiniApp(appId, versionId, TOO_MANY_REQUEST_ERR_LOG)
+                throw MiniAppTooManyRequestsError(error.message)
             }
         }
     }
@@ -209,26 +221,31 @@ internal class MiniAppDownloader(
         when {
             doesManifestFileExist(manifest.first) -> {
                 for (file in manifest.first.files) {
-                    if (isSignatureValid(apiClient.downloadFile(file).byteStream(), versionId, manifest)) {
-                        miniAppAnalytics.sendAnalytics(
-                            eType = Etype.CLICK,
-                            actype = Actype.SIGNATURE_VALIDATION_SUCCESS,
-                            miniAppInfo = miniAppInfo
-                        )
-                    } else {
-                        miniAppAnalytics.sendAnalytics(
-                            eType = Etype.CLICK,
-                            actype = Actype.SIGNATURE_VALIDATION_FAIL,
-                            miniAppInfo = miniAppInfo
-                        )
-                        if (requireSignatureVerification) {
-                            removeMiniApp(miniAppInfo, "$SIGNATURE_VERIFICATION_ERR " +
-                                    "The files will be deleted.")
-                            throw MiniAppVerificationException(SIGNATURE_VERIFICATION_ERR)
+                    try {
+                        if (isSignatureValid(apiClient.downloadFile(file).byteStream(), versionId, manifest)) {
+                            miniAppAnalytics.sendAnalytics(
+                                eType = Etype.CLICK,
+                                actype = Actype.SIGNATURE_VALIDATION_SUCCESS,
+                                miniAppInfo = miniAppInfo
+                            )
+                        } else {
+                            miniAppAnalytics.sendAnalytics(
+                                eType = Etype.CLICK,
+                                actype = Actype.SIGNATURE_VALIDATION_FAIL,
+                                miniAppInfo = miniAppInfo
+                            )
+                            if (requireSignatureVerification) {
+                                removeMiniApp(appId, versionId, "$SIGNATURE_VERIFICATION_ERR " +
+                                        "The files will be deleted.")
+                                throw MiniAppVerificationException(SIGNATURE_VERIFICATION_ERR)
+                            }
                         }
-                    }
 
-                    storage.saveFile(file, baseSavePath, apiClient.downloadFile(file).byteStream())
+                        storage.saveFile(file, baseSavePath, apiClient.downloadFile(file).byteStream())
+                    } catch (error: MiniAppTooManyRequestsError) {
+                        removeMiniApp(appId, versionId, TOO_MANY_REQUEST_ERR_LOG)
+                        throw MiniAppTooManyRequestsError(error.message)
+                    }
                 }
                 if (!apiClient.isPreviewMode) {
                     withContext(coroutineDispatcher) {
@@ -296,5 +313,6 @@ internal class MiniAppDownloader(
         private const val TAG = "MiniAppDownloader"
         private const val SIGNATURE_VERIFICATION_ERR = "Failed to verify the signature of MiniApp's zip."
         internal const val MINIAPP_NOT_FOUND_OR_CORRUPTED = "Mini app is not downloaded properly or corrupted"
+        internal const val TOO_MANY_REQUEST_ERR_LOG = "The files will be deleted for too many requests error."
     }
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkException.kt
@@ -80,6 +80,12 @@ class MiniAppNetException(message: String, cause: Throwable?) : MiniAppSdkExcept
     constructor(message: String) : this(message, null)
 }
 
+/**
+ * Exception which is thrown when there are too many requests for a MiniApp.
+ */
+class MiniAppTooManyRequestsError(message: String?) :
+    MiniAppSdkException("Too many requests for this MiniApp: $message")
+
 @Suppress("FunctionMaxLength")
 internal fun sdkExceptionForInternalServerError() = MiniAppSdkException("Internal server error")
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -40,7 +40,18 @@ internal class RealMiniApp(
 
     override suspend fun fetchInfo(appId: String): MiniAppInfo = when {
         appId.isBlank() -> throw sdkExceptionForInvalidArguments()
-        else -> miniAppInfoFetcher.getInfo(appId)
+        else -> {
+            try {
+                miniAppInfoFetcher.getInfo(appId)
+            } catch (error: MiniAppTooManyRequestsError) {
+                miniAppDownloader.removeMiniApp(
+                    appId,
+                    "",
+                    MiniAppDownloader.TOO_MANY_REQUEST_ERR_LOG
+                )
+                throw MiniAppTooManyRequestsError(error.message)
+            }
+        }
     }
 
     override suspend fun getMiniAppInfoByPreviewCode(previewCode: String): PreviewMiniAppInfo = when {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -38,6 +38,7 @@ internal class RealMiniApp(
 
     override suspend fun listMiniApp(): List<MiniAppInfo> = miniAppInfoFetcher.fetchMiniAppList()
 
+    @SuppressWarnings("SwallowedException", "OptionalWhenBraces")
     override suspend fun fetchInfo(appId: String): MiniAppInfo = when {
         appId.isBlank() -> throw sdkExceptionForInvalidArguments()
         else -> {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -2,9 +2,16 @@ package com.rakuten.tech.mobile.miniapp.api
 
 import androidx.annotation.VisibleForTesting
 import com.google.gson.annotations.SerializedName
-import com.rakuten.tech.mobile.miniapp.*
+import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
+import com.rakuten.tech.mobile.miniapp.MiniAppHasNoPublishedVersionException
+import com.rakuten.tech.mobile.miniapp.MiniAppNotFoundException
+import com.rakuten.tech.mobile.miniapp.MiniAppInfo
+import com.rakuten.tech.mobile.miniapp.PreviewMiniAppInfo
+import com.rakuten.tech.mobile.miniapp.MiniAppHostException
+import com.rakuten.tech.mobile.miniapp.MiniAppNetException
 import com.rakuten.tech.mobile.miniapp.MiniAppTooManyRequestsError
 import com.rakuten.tech.mobile.miniapp.sdkExceptionForInternalServerError
+import com.rakuten.tech.mobile.miniapp.SSLCertificatePinningException
 import kotlinx.coroutines.delay
 import okhttp3.ResponseBody
 import retrofit2.Call

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/api/ApiClient.kt
@@ -2,15 +2,9 @@ package com.rakuten.tech.mobile.miniapp.api
 
 import androidx.annotation.VisibleForTesting
 import com.google.gson.annotations.SerializedName
-import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
-import com.rakuten.tech.mobile.miniapp.MiniAppHasNoPublishedVersionException
-import com.rakuten.tech.mobile.miniapp.MiniAppNotFoundException
-import com.rakuten.tech.mobile.miniapp.MiniAppInfo
-import com.rakuten.tech.mobile.miniapp.PreviewMiniAppInfo
-import com.rakuten.tech.mobile.miniapp.MiniAppHostException
-import com.rakuten.tech.mobile.miniapp.MiniAppNetException
+import com.rakuten.tech.mobile.miniapp.*
+import com.rakuten.tech.mobile.miniapp.MiniAppTooManyRequestsError
 import com.rakuten.tech.mobile.miniapp.sdkExceptionForInternalServerError
-import com.rakuten.tech.mobile.miniapp.SSLCertificatePinningException
 import kotlinx.coroutines.delay
 import okhttp3.ResponseBody
 import retrofit2.Call
@@ -194,6 +188,7 @@ internal class RetrofitRequestExecutor(
             )
             404 -> throw MiniAppNotFoundException(response.message())
             400 -> throw MiniAppHostException(response.message())
+            429 -> throw MiniAppTooManyRequestsError(response.message())
             else -> throw MiniAppSdkException(
                 convertStandardHttpErrorToMsg(
                     response, errorData, createErrorConverter(retrofit)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/AppHelper.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/AppHelper.kt
@@ -18,12 +18,9 @@ import androidx.appcompat.widget.AppCompatEditText
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.rakuten.tech.mobile.miniapp.testapp.R
-import java.lang.IllegalArgumentException
 import java.text.ParseException
 import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
-import java.util.UUID
+import java.util.*
 
 private const val UUID_LENGTH = 36
 fun String.isInvalidUuid(): Boolean = try {
@@ -80,6 +77,17 @@ fun showAlertDialog(activity: Activity, title: String = "Alert", content: String
         dialog.dismiss()
     }
     alertDialog.create().show()
+}
+
+fun showErrorDialog(
+    context: Context,
+    description: String
+) {
+    val builder = AlertDialog.Builder(context)
+    builder.setMessage(description)
+        .setNegativeButton("Close") { _, _ -> }
+    val alert = builder.create()
+    alert.show()
 }
 
 fun ImageView.load(context: Context, res: String, placeholder: Int = R.drawable.ic_default) = Glide.with(context)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -19,7 +19,6 @@ import android.widget.Toast
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.rakuten.tech.mobile.miniapp.MiniApp
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
@@ -44,6 +43,7 @@ import com.rakuten.tech.mobile.miniapp.testapp.databinding.MiniAppDisplayActivit
 import com.rakuten.tech.mobile.testapp.helper.AppPermission
 import com.rakuten.tech.mobile.testapp.helper.setResizableSoftInputMode
 import com.rakuten.tech.mobile.testapp.helper.showAlertDialog
+import com.rakuten.tech.mobile.testapp.helper.showErrorDialog
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import com.rakuten.tech.mobile.testapp.ui.chat.ChatWindow
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
@@ -167,7 +167,7 @@ class MiniAppDisplayActivity : BaseActivity() {
         }
 
         //Three different ways to get miniapp.
-        appInfo = intent.getParcelableExtra<MiniAppInfo>(miniAppTag)
+        appInfo = intent.getParcelableExtra(miniAppTag)
         val appId = intent.getStringExtra(appIdTag) ?: appInfo?.id
         val appUrl = intent.getStringExtra(appUrlTag)
         var miniAppSdkConfig = intent.getParcelableExtra<MiniAppSdkConfig>(sdkConfigTag)
@@ -180,7 +180,7 @@ class MiniAppDisplayActivity : BaseActivity() {
 
         val factory = MiniAppDisplayViewModelFactory(MiniApp.instance(miniAppSdkConfig, updateType))
         viewModel = ViewModelProvider(this, factory).get(MiniAppDisplayViewModel::class.java).apply {
-            miniAppView.observe(this@MiniAppDisplayActivity, Observer {
+            miniAppView.observe(this@MiniAppDisplayActivity) {
                 if (ApplicationInfo.FLAG_DEBUGGABLE == 2)
                     WebView.setWebContentsDebuggingEnabled(true)
 
@@ -188,15 +188,22 @@ class MiniAppDisplayActivity : BaseActivity() {
                 addLifeCycleObserver(lifecycle)
                 (binding.root.parent as ViewGroup).removeAllViews()
                 setContentView(it)
-            })
+            }
 
-            errorData.observe(this@MiniAppDisplayActivity, Observer {
+            errorData.observe(this@MiniAppDisplayActivity) {
                 Toast.makeText(this@MiniAppDisplayActivity, it, Toast.LENGTH_LONG).show()
-            })
+            }
 
-            isLoading.observe(this@MiniAppDisplayActivity, Observer {
+            isLoading.observe(this@MiniAppDisplayActivity) {
                 toggleProgressLoading(it)
-            })
+            }
+
+            containTooManyRequestsError.observe(this@MiniAppDisplayActivity) {
+                showErrorDialog(
+                    this@MiniAppDisplayActivity,
+                    getString(R.string.error_desc_miniapp_too_many_request)
+                )
+            }
         }
 
         setupMiniAppMessageBridge()

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayViewModel.kt
@@ -22,6 +22,7 @@ class MiniAppDisplayViewModel constructor(
     private val _miniAppView = MutableLiveData<View>()
     private val _errorData = MutableLiveData<String>()
     private val _isLoading = MutableLiveData<Boolean>()
+    private val _containTooManyRequestsError = MutableLiveData<Boolean>()
 
     val miniAppView: LiveData<View>
         get() = _miniAppView
@@ -29,6 +30,8 @@ class MiniAppDisplayViewModel constructor(
         get() = _errorData
     val isLoading: LiveData<Boolean>
         get() = _isLoading
+    val containTooManyRequestsError: LiveData<Boolean>
+        get() = _containTooManyRequestsError
 
     fun obtainMiniAppDisplay(
         context: Context,
@@ -50,6 +53,8 @@ class MiniAppDisplayViewModel constructor(
                     _errorData.postValue("No published version for the provided Mini App ID.")
                 is MiniAppNotFoundException ->
                     _errorData.postValue("No Mini App found for the provided Project ID.")
+                is MiniAppTooManyRequestsError ->
+                    _containTooManyRequestsError.postValue(true)
                 else ->{
                     //try to load MiniApp from cache
                     try {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppViewModel.kt
@@ -1,10 +1,7 @@
 package com.rakuten.tech.mobile.testapp.ui.display.preload
 
 import androidx.lifecycle.*
-import com.rakuten.tech.mobile.miniapp.MiniApp
-import com.rakuten.tech.mobile.miniapp.MiniAppManifest
-import com.rakuten.tech.mobile.miniapp.MiniAppNetException
-import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
+import com.rakuten.tech.mobile.miniapp.*
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermission
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionResult
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionType
@@ -15,11 +12,14 @@ import java.util.Locale
 class PreloadMiniAppViewModel(private val miniApp: MiniApp) : ViewModel() {
     private val _miniAppManifest = MutableLiveData<MiniAppManifest>()
     private val _manifestErrorData = MutableLiveData<String>()
+    private val _containTooManyRequestsError = MutableLiveData<Boolean>()
 
     val miniAppManifest: LiveData<MiniAppManifest>
         get() = _miniAppManifest
     val manifestErrorData: LiveData<String>
         get() = _manifestErrorData
+    val containTooManyRequestsError: LiveData<Boolean>
+        get() = _containTooManyRequestsError
 
     fun checkMiniAppManifest(miniAppId: String, versionId: String) = viewModelScope.launch(Dispatchers.IO) {
         val downloadedManifest = miniApp.getDownloadedManifest(miniAppId)
@@ -38,6 +38,8 @@ class PreloadMiniAppViewModel(private val miniApp: MiniApp) : ViewModel() {
                     else
                         _miniAppManifest.postValue(downloadedManifest)
                 }
+                error is MiniAppTooManyRequestsError ->
+                    _containTooManyRequestsError.postValue(true)
                 else -> {
                     _manifestErrorData.postValue(error.message)
                 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
@@ -22,6 +22,7 @@ import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.WindowPreloadMiniappBinding
 import com.rakuten.tech.mobile.testapp.helper.isAvailable
 import com.rakuten.tech.mobile.testapp.helper.load
+import com.rakuten.tech.mobile.testapp.helper.showErrorDialog
 import java.lang.StringBuilder
 
 class PreloadMiniAppWindow(
@@ -105,6 +106,13 @@ class PreloadMiniAppWindow(
                     manifestErrorData.observe(lifecycleOwner, Observer {
                         Toast.makeText(context, it, Toast.LENGTH_LONG).show()
                     })
+
+                    containTooManyRequestsError.observe(lifecycleOwner) {
+                        showErrorDialog(
+                            context,
+                            context.getString(R.string.error_desc_miniapp_too_many_request)
+                        )
+                    }
                 }
 
         viewModel.checkMiniAppManifest(miniAppId, versionId)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/input/MiniAppInputActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/input/MiniAppInputActivity.kt
@@ -7,12 +7,12 @@ import android.text.TextWatcher
 import android.webkit.URLUtil
 import android.widget.Toast
 import androidx.databinding.DataBindingUtil
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.MiniAppInputActivityBinding
 import com.rakuten.tech.mobile.testapp.AppScreen.MINI_APP_INPUT_ACTIVITY
 import com.rakuten.tech.mobile.testapp.helper.isInvalidUuid
+import com.rakuten.tech.mobile.testapp.helper.showErrorDialog
 import com.rakuten.tech.mobile.testapp.launchActivity
 import com.rakuten.tech.mobile.testapp.ui.display.MiniAppDisplayActivity
 import com.rakuten.tech.mobile.testapp.ui.display.preload.PreloadMiniAppWindow
@@ -104,17 +104,23 @@ class MiniAppInputActivity : MenuBaseActivity(), PreloadMiniAppWindow.PreloadMin
     private fun initiatePreloadScreen(miniAppId: String) {
         val viewModel: MiniAppInputViewModel = ViewModelProvider.NewInstanceFactory().create(MiniAppInputViewModel::class.java)
                 .apply {
-                    miniAppVersionId.observe(this@MiniAppInputActivity, Observer {
+                    miniAppVersionId.observe(this@MiniAppInputActivity) {
                         preloadMiniAppWindow.initiate(
                             null,
                             miniAppId,
                             it,
                             this@MiniAppInputActivity
                         )
-                    })
-                    versionIdErrorData.observe(this@MiniAppInputActivity, Observer {
+                    }
+                    versionIdErrorData.observe(this@MiniAppInputActivity) {
                         Toast.makeText(this@MiniAppInputActivity, it, Toast.LENGTH_LONG).show()
-                    })
+                    }
+                    containTooManyRequestsError.observe(this@MiniAppInputActivity) {
+                        showErrorDialog(
+                            this@MiniAppInputActivity,
+                            getString(R.string.error_desc_miniapp_too_many_request)
+                        )
+                    }
                 }
         viewModel.getMiniAppVersionId(miniAppId)
     }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/input/MiniAppInputViewModel.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/input/MiniAppInputViewModel.kt
@@ -6,24 +6,32 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.rakuten.tech.mobile.miniapp.MiniApp
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
+import com.rakuten.tech.mobile.miniapp.MiniAppTooManyRequestsError
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class MiniAppInputViewModel constructor(private val miniApp: MiniApp) : ViewModel() {
     private val _miniAppVersionId = MutableLiveData<String>()
     private val _versionIdErrorData = MutableLiveData<String>()
+    private val _containTooManyRequestsError = MutableLiveData<Boolean>()
 
     val miniAppVersionId: LiveData<String>
         get() = _miniAppVersionId
     val versionIdErrorData: LiveData<String>
         get() = _versionIdErrorData
+    val containTooManyRequestsError: LiveData<Boolean>
+        get() = _containTooManyRequestsError
 
     fun getMiniAppVersionId(miniAppId: String) = viewModelScope.launch(Dispatchers.IO) {
         try {
             val miniAppInfo = miniApp.fetchInfo(miniAppId)
             _miniAppVersionId.postValue(miniAppInfo.version.versionId)
         } catch (error: MiniAppSdkException) {
-            _versionIdErrorData.postValue(error.message)
+            when (error) {
+                is MiniAppTooManyRequestsError ->
+                    _containTooManyRequestsError.postValue(true)
+                else -> _versionIdErrorData.postValue(error.message)
+            }
         }
     }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
@@ -11,16 +11,14 @@ import androidx.appcompat.widget.Toolbar
 import androidx.databinding.DataBindingUtil
 import com.rakuten.tech.mobile.miniapp.MiniApp
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
+import com.rakuten.tech.mobile.miniapp.MiniAppTooManyRequestsError
 import com.rakuten.tech.mobile.miniapp.testapp.BuildConfig
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.SettingsMenuActivityBinding
 import com.rakuten.tech.mobile.testapp.AppScreen.MINI_APP_INPUT_ACTIVITY
 import com.rakuten.tech.mobile.testapp.AppScreen.MINI_APP_LIST_ACTIVITY
 import com.rakuten.tech.mobile.testapp.BuildVariant
-import com.rakuten.tech.mobile.testapp.helper.isAvailable
-import com.rakuten.tech.mobile.testapp.helper.isInputEmpty
-import com.rakuten.tech.mobile.testapp.helper.isInvalidUuid
-import com.rakuten.tech.mobile.testapp.helper.showAlertDialog
+import com.rakuten.tech.mobile.testapp.helper.*
 import com.rakuten.tech.mobile.testapp.launchActivity
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import com.rakuten.tech.mobile.testapp.ui.deeplink.DynamicDeepLinkActivity
@@ -241,6 +239,11 @@ class SettingsMenuActivity : BaseActivity() {
                     requireSignatureVerificationHolder,
                     "URL parameter",
                     error.message.toString()
+                )
+            } catch (error: MiniAppTooManyRequestsError) {
+                showErrorDialog(
+                    this@SettingsMenuActivity,
+                    getString(R.string.error_desc_miniapp_too_many_request)
                 )
             }
         }

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -95,6 +95,7 @@
     <string name="error_title_miniapp_version_mismatch">" Version %1$s is not valid "</string>
     <string name="error_desc_miniapp_version_mismatch">Please check with the project \nadministrator. See our Help Center for \nmore details.</string>
     <string name="error_desc_promotional_text_missing">Promotional text is not available</string>
+    <string name="error_desc_miniapp_too_many_request">"Mini app is requested too many times.</string>
 
     <string name="help_center_text">Help Center</string>
     <string name="lb_close">Close</string>


### PR DESCRIPTION
# Description
This PR aims to have the following changes:
- Return a specific error to the Host App for 429 status code e.g.`MiniAppTooManyRequestsError`
- If the provided Mini App ID is currently downloaded on the device, then the mini app files should be deleted.
- In Demo App: Display error message.

## Links
- MINI-4952

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
