### PR TITLE
[MINI-4952] Fix UI in Settings page for Too Many Requests Error

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/SettingsMenuActivity.kt
@@ -220,6 +220,16 @@ class SettingsMenuActivity : BaseActivity() {
                     }
                     navigateToPreviousScreen()
                 }
+            } catch (error: MiniAppTooManyRequestsError) {
+                onUpdateError(
+                    appIdHolder,
+                    subscriptionKeyHolder,
+                    urlParametersHolder,
+                    isPreviewModeHolder,
+                    requireSignatureVerificationHolder,
+                    "Error",
+                    getString(R.string.error_desc_miniapp_too_many_request)
+                )
             } catch (error: MiniAppSdkException) {
                 onUpdateError(
                     appIdHolder,
@@ -239,11 +249,6 @@ class SettingsMenuActivity : BaseActivity() {
                     requireSignatureVerificationHolder,
                     "URL parameter",
                     error.message.toString()
-                )
-            } catch (error: MiniAppTooManyRequestsError) {
-                showErrorDialog(
-                    this@SettingsMenuActivity,
-                    getString(R.string.error_desc_miniapp_too_many_request)
                 )
             }
         }


### PR DESCRIPTION
# Description
This PR aims to fix an UI issue in demo app's settings page when `MiniAppTooManyRequestsError` is being caught.

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
