### PR TITLE
[MINI-5276] Added check before closing miniapp by back press

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -449,7 +449,7 @@ class MiniAppDisplayActivity : BaseActivity() {
 
     override fun onBackPressed() {
         if (!viewModel.canGoBackwards()) {
-            super.onBackPressed()
+            checkCloseAlert()
         }
     }
 


### PR DESCRIPTION
# Description
Close alert popup was missing when closing miniapp by back button press.

## Links
MINI-5276

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
