### PR TITLE
[MINI-5306] Discrepancy in limit set in QA settings and Maximum size displayed in Miniapp

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -270,7 +270,7 @@ abstract class MiniApp internal constructor() {
                 ratDispatcher = MessageBridgeRatDispatcher(miniAppAnalytics = miniAppAnalytics),
                 secureStorageDispatcher = MiniAppSecureStorageDispatcher(
                     context,
-                    miniAppSdkConfig.maxStorageSizeLimit
+                    miniAppSdkConfig.maxStorageSizeLimitInMB
                 ),
                 enableH5Ads = miniAppSdkConfig.enableH5Ads
             )

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -270,7 +270,7 @@ abstract class MiniApp internal constructor() {
                 ratDispatcher = MessageBridgeRatDispatcher(miniAppAnalytics = miniAppAnalytics),
                 secureStorageDispatcher = MiniAppSecureStorageDispatcher(
                     context,
-                    miniAppSdkConfig.storageMaxSizeKB
+                    miniAppSdkConfig.maxStorageSizeLimit
                 ),
                 enableH5Ads = miniAppSdkConfig.enableH5Ads
             )

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -16,7 +16,7 @@ import kotlinx.android.parcel.Parcelize
  * @property miniAppAnalyticsConfigList List of analytic config to send events on.
  * @property sslPinningPublicKeyList List of SSL pinning public keys.
  * @property enableH5Ads Whether the host app wants to enable ad placement beta.
- * @property storageMaxSizeKB Maximum size in KB for each Mini App is allowed to use for Secure Storage, Default is 5MB.
+ * @property maxStorageSizeLimit Maximum size in KB for each Mini App is allowed to use for Secure Storage, Default is 5MB.
  */
 @Parcelize
 data class MiniAppSdkConfig(
@@ -30,7 +30,7 @@ data class MiniAppSdkConfig(
     val miniAppAnalyticsConfigList: List<MiniAppAnalyticsConfig> = emptyList(),
     val sslPinningPublicKeyList: List<String> = emptyList(),
     val enableH5Ads: Boolean = false,
-    val storageMaxSizeKB: Int = 5000
+    val maxStorageSizeLimit: Int = 5 // Default max storage limit in MB
 ) : Parcelable {
     internal val key = "$baseUrl-$isPreviewMode-$rasProjectId-$subscriptionKey"
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -16,7 +16,7 @@ import kotlinx.android.parcel.Parcelize
  * @property miniAppAnalyticsConfigList List of analytic config to send events on.
  * @property sslPinningPublicKeyList List of SSL pinning public keys.
  * @property enableH5Ads Whether the host app wants to enable ad placement beta.
- * @property maxStorageSizeLimit Maximum Secure Storage size limit for each Mini App, Default is 5MB.
+ * @property maxStorageSizeLimitInMB Maximum Secure Storage size limit in MB for each Mini App, Default is 5MB.
  */
 @Parcelize
 data class MiniAppSdkConfig(
@@ -30,7 +30,7 @@ data class MiniAppSdkConfig(
     val miniAppAnalyticsConfigList: List<MiniAppAnalyticsConfig> = emptyList(),
     val sslPinningPublicKeyList: List<String> = emptyList(),
     val enableH5Ads: Boolean = false,
-    val maxStorageSizeLimit: Int = 5 // Default max storage limit in MB
+    val maxStorageSizeLimitInMB: Int = 5 // Default max storage limit in MB
 ) : Parcelable {
     internal val key = "$baseUrl-$isPreviewMode-$rasProjectId-$subscriptionKey"
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppSdkConfig.kt
@@ -16,7 +16,7 @@ import kotlinx.android.parcel.Parcelize
  * @property miniAppAnalyticsConfigList List of analytic config to send events on.
  * @property sslPinningPublicKeyList List of SSL pinning public keys.
  * @property enableH5Ads Whether the host app wants to enable ad placement beta.
- * @property maxStorageSizeLimit Maximum size in KB for each Mini App is allowed to use for Secure Storage, Default is 5MB.
+ * @property maxStorageSizeLimit Maximum Secure Storage size limit for each Mini App, Default is 5MB.
  */
 @Parcelize
 data class MiniAppSdkConfig(

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -69,10 +69,10 @@ class MiniappSdkInitializer : ContentProvider() {
         fun enableH5Ads(): Boolean
 
         /**
-         * Sets the maximum size in KB that each Mini App is allowed to use for Secure Storage.
+         * Maximum Secure Storage size limit in MB for each Mini App, Default is 5MB.
          **/
         @MetaData(key = "com.rakuten.tech.mobile.miniapp.MaxStorageSizeLimitInMB")
-        fun maxStorageSizeLimit(): Int
+        fun maxStorageSizeLimitInMB(): Int
     }
 
     override fun onCreate(): Boolean {
@@ -99,7 +99,7 @@ class MiniappSdkInitializer : ContentProvider() {
         isPreviewMode = manifestConfig.isPreviewMode(),
         requireSignatureVerification = manifestConfig.requireSignatureVerification(),
         enableH5Ads = manifestConfig.enableH5Ads(),
-        maxStorageSizeLimit = manifestConfig.maxStorageSizeLimit()
+        maxStorageSizeLimitInMB = manifestConfig.maxStorageSizeLimitInMB()
     )
 
     private fun executeMiniAppAnalytics(rasProjId: String) {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniappSdkInitializer.kt
@@ -71,8 +71,8 @@ class MiniappSdkInitializer : ContentProvider() {
         /**
          * Sets the maximum size in KB that each Mini App is allowed to use for Secure Storage.
          **/
-        @MetaData(key = "com.rakuten.tech.mobile.miniapp.StorageMaxSizeKB")
-        fun storageMaxSizeKB(): Int
+        @MetaData(key = "com.rakuten.tech.mobile.miniapp.MaxStorageSizeLimitInMB")
+        fun maxStorageSizeLimit(): Int
     }
 
     override fun onCreate(): Boolean {
@@ -99,7 +99,7 @@ class MiniappSdkInitializer : ContentProvider() {
         isPreviewMode = manifestConfig.isPreviewMode(),
         requireSignatureVerification = manifestConfig.requireSignatureVerification(),
         enableH5Ads = manifestConfig.enableH5Ads(),
-        storageMaxSizeKB = manifestConfig.storageMaxSizeKB()
+        maxStorageSizeLimit = manifestConfig.maxStorageSizeLimit()
     )
 
     private fun executeMiniAppAnalytics(rasProjId: String) {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -195,7 +195,7 @@ internal class RealMiniApp(
             miniAppAnalytics =
                 MiniAppAnalytics(newConfig.rasProjectId, newConfig.miniAppAnalyticsConfigList)
 
-        secureStorageDispatcher.updateMiniAppStorageMaxLimit(newConfig.maxStorageSizeLimit)
+        secureStorageDispatcher.updateMiniAppStorageMaxLimit(newConfig.maxStorageSizeLimitInMB)
     }
 
     @VisibleForTesting

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -195,7 +195,7 @@ internal class RealMiniApp(
             miniAppAnalytics =
                 MiniAppAnalytics(newConfig.rasProjectId, newConfig.miniAppAnalyticsConfigList)
 
-        secureStorageDispatcher.updateMiniAppStorageMaxLimit(newConfig.storageMaxSizeKB)
+        secureStorageDispatcher.updateMiniAppStorageMaxLimit(newConfig.maxStorageSizeLimit)
     }
 
     @VisibleForTesting

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppSecureStorageDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppSecureStorageDispatcher.kt
@@ -6,12 +6,13 @@ import com.google.gson.Gson
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppSecureStorageError
 import com.rakuten.tech.mobile.miniapp.storage.MiniAppSecureStorage
 
+internal const val CONVERT_TO_KB = 1024
 internal const val DB_NAME_PREFIX = "rmapp-"
 
 @Suppress("TooManyFunctions", "LargeClass")
 internal class MiniAppSecureStorageDispatcher(
     internal var context: Context,
-    private var storageMaxSizeKB: Int
+    private var maxStorageSizeLimit: Int
 ) {
     private val databaseVersion = 1
     private lateinit var miniAppId: String
@@ -42,12 +43,12 @@ internal class MiniAppSecureStorageDispatcher(
         this.miniAppSecureStorage = MiniAppSecureStorage(
             context,
             databaseVersion,
-            storageMaxSizeKB
+            maxStorageSizeLimit
         )
     }
 
-    fun updateMiniAppStorageMaxLimit(maxStorage: Int) {
-        storageMaxSizeKB = maxStorage
+    fun updateMiniAppStorageMaxLimit(maxStorageInMB: Int) {
+        maxStorageSizeLimit = (maxStorageInMB * CONVERT_TO_KB)
     }
 
     @Suppress("ComplexCondition")
@@ -162,7 +163,7 @@ internal class MiniAppSecureStorageDispatcher(
     @Deprecated("No Longer Needed")
     fun onSize(callbackId: String) = whenReady {
         onSuccessDBSize = { fileSize: Long ->
-            val maxSizeInBytes = storageMaxSizeKB * 1024
+            val maxSizeInBytes = maxStorageSizeLimit * 1024
             val storageSize =
                 Gson().toJson(MiniAppSecureStorageSize(fileSize, maxSizeInBytes.toLong()))
             bridgeExecutor.postValue(callbackId, storageSize)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -173,7 +173,7 @@ class AppSettings private constructor(context: Context) {
                     BuildConfig.ADDITIONAL_ANALYTICS_AID
                 )
             ),
-            storageMaxSizeKB = maxStorageSizeLimit
+            maxStorageSizeLimit = maxStorageSizeLimit
         )
 
     companion object {
@@ -311,7 +311,7 @@ private class Settings(context: Context) {
         get() = prefs.contains(DYNAMIC_DEEPLINKS)
 
     var maxStorageSizeLimit: Int
-        get() = prefs.getInt(MAX_STORAGE_SIZE_LIMIT, 5000)
+        get() = prefs.getInt(MAX_STORAGE_SIZE_LIMIT, 5) // Default max storage is 5MB
         set(maxStorageSizeLimit) = prefs.edit().putInt(MAX_STORAGE_SIZE_LIMIT, maxStorageSizeLimit).apply()
 
     companion object {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -153,9 +153,9 @@ class AppSettings private constructor(context: Context) {
     val isDynamicDeeplinksSaved: Boolean
         get() = cache.isDynamicDeeplinksSaved
 
-    var maxStorageSizeLimit: Int
-        get() = cache.maxStorageSizeLimit
-        set(maxStorageSizeLimit) { cache.maxStorageSizeLimit = maxStorageSizeLimit }
+    var maxStorageSizeLimitInMB: Int
+        get() = cache.maxStorageSizeLimitInMB
+        set(maxStorageSizeLimit) { cache.maxStorageSizeLimitInMB = maxStorageSizeLimit }
 
     val miniAppSettings: MiniAppSdkConfig
         get() = MiniAppSdkConfig(
@@ -173,7 +173,7 @@ class AppSettings private constructor(context: Context) {
                     BuildConfig.ADDITIONAL_ANALYTICS_AID
                 )
             ),
-            maxStorageSizeLimit = maxStorageSizeLimit
+            maxStorageSizeLimitInMB = maxStorageSizeLimitInMB
         )
 
     companion object {
@@ -310,7 +310,7 @@ private class Settings(context: Context) {
     val isDynamicDeeplinksSaved: Boolean
         get() = prefs.contains(DYNAMIC_DEEPLINKS)
 
-    var maxStorageSizeLimit: Int
+    var maxStorageSizeLimitInMB: Int
         get() = prefs.getInt(MAX_STORAGE_SIZE_LIMIT, 5) // Default max storage is 5MB
         set(maxStorageSizeLimit) = prefs.edit().putInt(MAX_STORAGE_SIZE_LIMIT, maxStorageSizeLimit).apply()
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
@@ -185,6 +185,7 @@ class QASettingsActivity : BaseActivity() {
                             "Successfully cleared all secured storage!",
                             Toast.LENGTH_LONG
                         ).show()
+                        invalidateMaxStorageField()
                     }
                 }
                 dialog.dismiss()

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
@@ -8,7 +8,6 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.CompoundButton
-import android.widget.TextView
 import android.widget.Toast
 import androidx.core.text.isDigitsOnly
 import androidx.databinding.DataBindingUtil
@@ -103,7 +102,7 @@ class QASettingsActivity : BaseActivity() {
         // mauid
         binding.edtMauidError.setText(settings.mauIdError)
 
-        val maxStorage = settings.maxStorageSizeLimit
+        val maxStorage = settings.maxStorageSizeLimitInMB
         binding.edtMaxStorageLimit.setText("Current limit is $maxStorage MB")
 
         invalidateMaxStorageField()
@@ -258,8 +257,8 @@ class QASettingsActivity : BaseActivity() {
 
         val upgradedSize = binding.edtMaxStorageLimit.text
         if (!upgradedSize.isNullOrEmpty() && upgradedSize.isDigitsOnly()) {
-            val maxStorageSizeLimit = binding.edtMaxStorageLimit.text.toString().toInt()
-            settings.maxStorageSizeLimit = maxStorageSizeLimit
+            val maxStorageSizeLimitInMB = binding.edtMaxStorageLimit.text.toString().toInt()
+            settings.maxStorageSizeLimitInMB = maxStorageSizeLimitInMB
         }
 
         // post tasks

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
@@ -10,6 +10,7 @@ import android.view.MenuItem
 import android.widget.CompoundButton
 import android.widget.TextView
 import android.widget.Toast
+import androidx.core.text.isDigitsOnly
 import androidx.databinding.DataBindingUtil
 import com.rakuten.tech.mobile.miniapp.MiniApp
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppAccessTokenError
@@ -102,7 +103,7 @@ class QASettingsActivity : BaseActivity() {
         // mauid
         binding.edtMauidError.setText(settings.mauIdError)
 
-        val maxStorage = settings.maxStorageSizeLimit / 1000
+        val maxStorage = settings.maxStorageSizeLimit
         binding.edtMaxStorageLimit.setText("Current limit is $maxStorage MB")
 
         invalidateMaxStorageField()
@@ -254,12 +255,10 @@ class QASettingsActivity : BaseActivity() {
             settings.mauIdError = binding.edtMauidError.text.toString()
         }
 
-        if (!binding.edtMaxStorageLimit.text.isNullOrEmpty()) {
+        val upgradedSize = binding.edtMaxStorageLimit.text
+        if (!upgradedSize.isNullOrEmpty() && upgradedSize.isDigitsOnly()) {
             val maxStorageSizeLimit = binding.edtMaxStorageLimit.text.toString().toInt()
-            settings.maxStorageSizeLimit = (maxStorageSizeLimit * 1000)
-        } else {
-            // Default max storage size limit
-            settings.maxStorageSizeLimit = (5 * 1000)
+            settings.maxStorageSizeLimit = maxStorageSizeLimit
         }
 
         // post tasks


### PR DESCRIPTION
[MINI-5306](https://jira.rakuten-it.com/jira/browse/MINI-5306)

For Solution now multiplying with 1024 instead of 1000 to convert from MB to KB also changed the position of conversion now changing in one place only rather many places. It'll be a solution for Link Integration too.

…d the position of conversion now hanging in one rather many places. It'll affect for Link Integration too

# Description
Describe the changes in this pull request.
Explain your rationale of technical decisions you made (unless discussed before).

## Links
Add links to github/jira issues, design documents and other relevant resources (e.g. previous discussions, platform/tool documentation etc.)

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
