### PR TITLE
[MINI-4131] Proper error message should be displayed when Contact Name and email are empty

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -186,7 +186,6 @@ class MiniAppDisplayActivity : BaseActivity() {
 
                 //action: display webview
                 addLifeCycleObserver(lifecycle)
-                (binding.root.parent as ViewGroup).removeAllViews()
                 setContentView(it)
             }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactListActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactListActivity.kt
@@ -133,19 +133,20 @@ class ContactListActivity : BaseActivity(), ContactListener {
         if (id.isEmpty()) {
             isVerified = false
             showContactInputWarning(getString(R.string.userdata_error_empty_contact_id))
-        }
-
-        if (name.isEmpty()) {
+        } else if (name.isEmpty() && email.isNotEmpty()) {
             isVerified = false
             showContactInputWarning(getString(R.string.userdata_error_empty_contact_name))
+        } else if (email.isEmpty() && name.isNotEmpty()) {
+            isVerified = false
+            showContactInputWarning(getString(R.string.userdata_error_empty_contact_email))
+        } else if (name.isEmpty() && email.isEmpty()) {
+            isVerified = false
+            showContactInputWarning(getString(R.string.userdata_error_empty_contact_name_email))
         }
 
         if (email.isNotEmpty() && !email.isEmailValid()) {
             isVerified = false
             showContactInputWarning(getString(R.string.userdata_error_invalid_contact_email))
-        } else if (email.isEmpty()) {
-            isVerified = false
-            showContactInputWarning(getString(R.string.userdata_error_empty_email_name))
         }
 
         return isVerified

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -42,7 +42,8 @@
     <string name="userdata_hint_edit_name">Enter your name here</string>
     <string name="userdata_error_empty_contact_id">Empty contact id, please try again.</string>
     <string name="userdata_error_empty_contact_name">Empty contact name, please try again.</string>
-    <string name="userdata_error_empty_email_name">Empty contact email, please try again.</string>
+    <string name="userdata_error_empty_contact_email">Empty contact email, please try again.</string>
+    <string name="userdata_error_empty_contact_name_email">Empty contact name and email, please try again.</string>
     <string name="userdata_error_invalid_contact_email">Invalid contact email, please input the correct format.</string>
     <string name="userdata_warning_empty_contact_list">No contact available!</string>
     <string name="userdata_warning_not_saved_contact">No contact has been saved yet</string>


### PR DESCRIPTION
# Description
This PR aims to add proper error message when empty name and email in contact list page in Demo app.

## Links
- MINI-4131

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
