### PR TITLE
[MINI 4738] Back button navigates to secondary webview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 4.3.0 (release date TBD)
 **SDK**
 - **Feature:** Added `languageCode` in cached manifest to support localization of manifest.
+- **Fix:** Added fix when navigate to back page with invalid url. 
 
 ### 4.2.0 (2022-06-24)
 **SDK**

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppScheme.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppScheme.kt
@@ -14,6 +14,8 @@ internal class MiniAppScheme private constructor(miniAppId: String) {
     var appUrl: String? = null
         private set
 
+    val parentUrlExtension = "/index.html"
+
     companion object {
         fun schemeWithAppId(miniAppId: String) = MiniAppScheme(miniAppId)
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebView.kt
@@ -219,7 +219,7 @@ internal open class MiniAppWebView(
         .build()
 
     internal open fun getLoadUrl(): String {
-        val parentUrl = "${miniAppScheme.miniAppCustomDomain}$SUB_DOMAIN_PATH/index.html"
+        val parentUrl = "${miniAppScheme.miniAppCustomDomain}$SUB_DOMAIN_PATH${miniAppScheme.parentUrlExtension}"
         return miniAppScheme.appendParametersToUrl(parentUrl, queryParams)
     }
 

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebViewClient.kt
@@ -14,7 +14,7 @@ import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 
 internal class MiniAppWebViewClient(
     private val context: Context,
-    @VisibleForTesting internal val loader: WebViewAssetLoader?,
+    internal val loader: WebViewAssetLoader?,
     private val miniAppNavigator: MiniAppNavigator,
     private val externalResultHandler: ExternalResultHandler,
     private val miniAppScheme: MiniAppScheme
@@ -24,6 +24,13 @@ internal class MiniAppWebViewClient(
         val response = loader?.shouldInterceptRequest(request.url)
         interceptMimeType(response, request)
         return response
+    }
+
+    override fun onPageFinished(view: WebView?, url: String?) {
+        if (url?.startsWith(miniAppScheme.miniAppCustomDomain) == true && url.contains(miniAppScheme.parentUrlExtension))
+            view?.clearHistory()
+
+        super.onPageFinished(view, url)
     }
 
     override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {


### PR DESCRIPTION
# Description
This PR aims to fix an issue when MiniApp WebView tries to navigate back with invalid url. In this case, when MiniApp returns from a secondary WebView to it's main WebView with additional parameters, SDK will clear the old history. 

## Links
- MINI-4738

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
