### PR TITLE
[MINI-5361] Save button of QA settings is not functional

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
@@ -71,7 +71,7 @@ class QASettingsActivity : BaseActivity() {
                 finish()
                 return true
             }
-            R.id.settings_menu_save -> {
+            R.id.qa_menu_save -> {
                 update()
                 return true
             }


### PR DESCRIPTION
# Description
This PR aims to fix an UI issue in QA Settings page.

## Links
- MINI-5361

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
