### PR TITLE
[MINI-5362] Settings: Tap on Bluetoth icon crashes app 

### DIFF
--- a/testapp/src/main/res/menu/settings_qa_menu.xml
+++ b/testapp/src/main/res/menu/settings_qa_menu.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:tools="http://schemas.android.com/tools"
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
         android:id="@+id/qa_menu_bluetooth"
         android:icon="@drawable/ic_bluetooth_connect"
-        app:showAsAction="always"
-        tools:ignore="MenuTitle" />
+        android:title="@string/action_show_bluetooth"
+        app:showAsAction="always" />
 
     <item
         android:id="@+id/qa_menu_save"

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -76,6 +76,7 @@
     <string name="action_clear_all">Clear All</string>
     <string name="action_clear_miniapp">Clear MiniApp Storage</string>
     <string name="action_detect_bluetooth">Start detect</string>
+    <string name="action_show_bluetooth">Show bluetooth devices</string>
 
     <string name="hint_host_project_id">Host Project ID</string>
     <string name="hint_subscription_key">Subscription Key</string>


### PR DESCRIPTION
# Description
This PR aims to fix a crash when tap on bluetooth icon in QA settings screen.

## Links
- MINI-5362

# Checklist
- [x] I have read the [contributing guidelines](../.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](../.github/CONTRIBUTING.md#SDK-Development-Learning-Path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
