### PR TITLE
[MINI-5531] Miniapp version fix

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/view/MiniAppViewHandler.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/view/MiniAppViewHandler.kt
@@ -3,7 +3,14 @@ package com.rakuten.tech.mobile.miniapp.view
 import android.content.Context
 import android.util.Log
 import com.rakuten.tech.mobile.miniapp.MiniAppDownloader
+import com.rakuten.tech.mobile.miniapp.MiniAppNetException
+import com.rakuten.tech.mobile.miniapp.RequiredPermissionsNotGrantedException
+import com.rakuten.tech.mobile.miniapp.MiniAppNotFoundException
+import com.rakuten.tech.mobile.miniapp.MiniAppManifest
+import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
 import com.rakuten.tech.mobile.miniapp.MiniAppInfoFetcher
+import com.rakuten.tech.mobile.miniapp.MiniAppSdkConfig
+import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.analytics.MiniAppAnalytics
 import com.rakuten.tech.mobile.miniapp.api.ApiClient
 import com.rakuten.tech.mobile.miniapp.api.ApiClientRepository
@@ -20,12 +27,6 @@ import com.rakuten.tech.mobile.miniapp.storage.MiniAppStatus
 import com.rakuten.tech.mobile.miniapp.storage.MiniAppStorage
 import com.rakuten.tech.mobile.miniapp.storage.verifier.CachedMiniAppVerifier
 import com.rakuten.tech.mobile.miniapp.storage.verifier.MiniAppManifestVerifier
-import com.rakuten.tech.mobile.miniapp.MiniAppSdkConfig
-import com.rakuten.tech.mobile.miniapp.MiniAppNetException
-import com.rakuten.tech.mobile.miniapp.RequiredPermissionsNotGrantedException
-import com.rakuten.tech.mobile.miniapp.MiniAppNotFoundException
-import com.rakuten.tech.mobile.miniapp.MiniAppManifest
-import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
 
 @Suppress("LargeClass")
 internal class MiniAppViewHandler(
@@ -180,6 +181,35 @@ internal class MiniAppViewHandler(
         } else {
             miniAppDownloader.getCachedMiniApp(miniAppId)
         }
+        verifyManifest(miniAppInfo.id, miniAppInfo.version.versionId, fromCache)
+        return displayer.createMiniAppDisplay(
+            basePath,
+            miniAppInfo,
+            config.miniAppMessageBridge,
+            config.miniAppNavigator,
+            config.miniAppFileChooser,
+            miniAppCustomPermissionCache,
+            downloadedManifestCache,
+            config.queryParams,
+            miniAppAnalytics,
+            ratDispatcher,
+            secureStorageDispatcher,
+            enableH5Ads
+        )
+    }
+
+    suspend fun createMiniAppView(
+        miniAppInfo: MiniAppInfo,
+        config: MiniAppConfig,
+        fromCache: Boolean = false
+    ): MiniAppDisplay {
+        val (basePath, miniAppInfo) = if (!fromCache) {
+            miniAppDownloader.getMiniApp(miniAppInfo)
+        } else {
+            miniAppDownloader.getCachedMiniApp(miniAppInfo)
+        }
+        Log.e("id", miniAppInfo.id)
+        Log.e("version", miniAppInfo.version.versionId)
         verifyManifest(miniAppInfo.id, miniAppInfo.version.versionId, fromCache)
         return displayer.createMiniAppDisplay(
             basePath,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/view/MiniAppViewHandler.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/view/MiniAppViewHandler.kt
@@ -208,8 +208,6 @@ internal class MiniAppViewHandler(
         } else {
             miniAppDownloader.getCachedMiniApp(miniAppInfo)
         }
-        Log.e("id", miniAppInfo.id)
-        Log.e("version", miniAppInfo.version.versionId)
         verifyManifest(miniAppInfo.id, miniAppInfo.version.versionId, fromCache)
         return displayer.createMiniAppDisplay(
             basePath,

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/view/MiniAppViewImpl.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/view/MiniAppViewImpl.kt
@@ -27,18 +27,18 @@ internal class MiniAppViewImpl(
                 )
             }
             is MiniAppParameters.InfoParams -> scope.launch {
-                if (queryParams != "") (miniAppParameters as MiniAppParameters.DefaultParams).config.queryParams =
+                if (queryParams != "") (miniAppParameters as MiniAppParameters.InfoParams).config.queryParams =
                     queryParams
                 onComplete(
                     miniAppViewHandler.createMiniAppView(
-                        (miniAppParameters as MiniAppParameters.InfoParams).miniAppInfo.id,
+                        (miniAppParameters as MiniAppParameters.InfoParams).miniAppInfo,
                         (miniAppParameters as MiniAppParameters.InfoParams).config,
                         (miniAppParameters as MiniAppParameters.InfoParams).fromCache
                     )
                 )
             }
             is MiniAppParameters.UrlParams -> scope.launch {
-                if (queryParams != "") (miniAppParameters as MiniAppParameters.DefaultParams).config.queryParams =
+                if (queryParams != "") (miniAppParameters as MiniAppParameters.UrlParams).config.queryParams =
                     queryParams
                 onComplete(
                     miniAppViewHandler.createMiniAppViewWithUrl(

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/MiniAppDisplayFragment.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/MiniAppDisplayFragment.kt
@@ -120,7 +120,7 @@ class MiniAppDisplayFragment : BaseFragment() {
         setUpFileChooserAndDownloader(activity)
         setUpNavigator(activity)
         setupMiniAppMessageBridge(requireActivity(), miniAppFileDownloader)
-        val miniAppView = MiniAppView.init(createMiniAppDefaultParam(activity, args.miniAppInfo))
+        val miniAppView = MiniAppView.init(createMiniAppInfoParam(activity, args.miniAppInfo))
         try {
             miniAppView.load { miniAppDisplay ->
                 this.miniAppDisplay = miniAppDisplay
@@ -469,8 +469,8 @@ class MiniAppDisplayFragment : BaseFragment() {
         miniAppMessageBridge.dispatchNativeEvent(NativeEventType.MINIAPP_ON_RESUME, "MiniApp Resumed")
     }
 
-    private fun createMiniAppDefaultParam(activity: Activity, miniAppInfo: MiniAppInfo): MiniAppParameters {
-        return MiniAppParameters.DefaultParams(
+    private fun createMiniAppInfoParam(activity: Activity, miniAppInfo: MiniAppInfo): MiniAppParameters {
+        return MiniAppParameters.InfoParams(
             context = activity,
             config = MiniAppConfig(
                 miniAppSdkConfig = AppSettings.instance.miniAppSettings,
@@ -479,9 +479,9 @@ class MiniAppDisplayFragment : BaseFragment() {
                 miniAppFileChooser = miniAppFileChooser,
                 queryParams = AppSettings.instance.urlParameters
             ),
-            miniAppId = miniAppInfo.id,
-            miniAppVersion = miniAppInfo.version.versionId,
+            miniAppInfo =  miniAppInfo,
             fromCache = false
         )
     }
+
 }


### PR DESCRIPTION
# Description
Previously miniapp was opening by only `miniapp id` , added another function to open open miniapp by `MiniAppInfo`.

## Links
MINI-5531

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
