### PR TITLE
feat(MINI-5635): add unit test coverage in FileChooser and WebView

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,7 @@ ignore:
   - "miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionWindow.kt"
   - "miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/analytics/MiniAppAnalytics.kt"
   - "miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/WebViewDialog.kt"
+  - "miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/view/MiniAppConfig.kt"
 coverage:
   status:
     patch: off

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooser.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooser.kt
@@ -33,10 +33,15 @@ interface MiniAppFileChooser {
      * @param fileChooserParams the parameters can be used to customize the options of file chooser.
      * @param context the Activity context can be used to start the intent to choose file.
      **/
+
+    @Suppress("LongParameterList")
     fun onShowFileChooser(
         filePathCallback: ValueCallback<Array<Uri>>?,
         fileChooserParams: WebChromeClient.FileChooserParams?,
-        context: Context
+        context: Context,
+        isOpenMultipleMode: Boolean = fileChooserParams?.mode == WebChromeClient.FileChooserParams.MODE_OPEN_MULTIPLE,
+        isCaptureEnabled: Boolean = fileChooserParams?.isCaptureEnabled ?: false,
+        fileChooserParamsAcceptTypes: Array<String>? = fileChooserParams?.acceptTypes
     ): Boolean
 }
 
@@ -89,7 +94,8 @@ class MiniAppFileChooserDefault(
         }
     }
 
-    private fun launchCameraIntent() = whenReady {
+    @VisibleForTesting
+    internal fun launchCameraIntent() = whenReady {
         val permissionCallback: (Boolean) -> Unit = { isGranted: Boolean ->
             if (isGranted) {
                 context?.let { dispatchTakePictureIntent(it) }
@@ -114,24 +120,27 @@ class MiniAppFileChooserDefault(
         )
     }
 
-    @Suppress("TooGenericExceptionCaught", "SwallowedException", "LongMethod", "NestedBlockDepth")
+    @Suppress("TooGenericExceptionCaught", "SwallowedException", "LongMethod", "NestedBlockDepth", "LongParameterList")
     override fun onShowFileChooser(
         filePathCallback: ValueCallback<Array<Uri>>?,
         fileChooserParams: WebChromeClient.FileChooserParams?,
-        context: Context
+        context: Context,
+        isOpenMultipleMode: Boolean,
+        isCaptureEnabled: Boolean,
+        fileChooserParamsAcceptTypes: Array<String>?
     ): Boolean {
         try {
             callback = filePathCallback
             this.context = context
             val intent = fileChooserParams?.createIntent()
-            if (fileChooserParams?.mode == WebChromeClient.FileChooserParams.MODE_OPEN_MULTIPLE) {
+            if (isOpenMultipleMode) {
                 intent?.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
             }
-            if (fileChooserParams?.isCaptureEnabled == true) {
+            if (isCaptureEnabled) {
                 launchCameraIntent()
             } else {
                 // Uses Intent.EXTRA_MIME_TYPES to pass multiple mime types.
-                fileChooserParams?.acceptTypes?.let { acceptTypes ->
+                fileChooserParamsAcceptTypes?.let { acceptTypes ->
                     if (acceptTypes.isNotEmpty() && !(acceptTypes.size == 1 && acceptTypes[0].equals(""))) {
                         // Accept all first.
                         intent?.type = "*/*"
@@ -151,8 +160,9 @@ class MiniAppFileChooserDefault(
         return true
     }
 
+    @VisibleForTesting
     @Suppress("SwallowedException")
-    private fun dispatchTakePictureIntent(context: Context) {
+    internal fun dispatchTakePictureIntent(context: Context) {
         Intent(MediaStore.ACTION_IMAGE_CAPTURE).also { takePictureIntent ->
             // Create the File where the photo should go
             val photoFile: File? = try {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/MiniAppWebviewSpec.kt
@@ -191,6 +191,28 @@ class MiniAppWebViewSpec : BaseWebViewSpec() {
     }
 
     @Test
+    fun `should invoke MiniAppH5AdsProvider when isH5AdsEnabled is true`() {
+        miniAppWebView = MiniAppWebView(
+            context,
+            basePath = basePath,
+            miniAppInfo = TEST_MA,
+            miniAppMessageBridge = miniAppMessageBridge,
+            miniAppNavigator = miniAppNavigator,
+            miniAppFileChooser = miniAppFileChooser,
+            hostAppUserAgentInfo = "",
+            miniAppWebChromeClient = webChromeClient,
+            miniAppCustomPermissionCache = mock(),
+            downloadedManifestCache = mock(),
+            queryParams = TEST_URL_PARAMS,
+            ratDispatcher = mock(),
+            secureStorageDispatcher = mock(),
+            enableH5Ads = true
+        )
+
+        verify(whenHasH5AdsWebViewClient { })
+    }
+
+    @Test
     fun `when destroyView called then the MiniAppWebView should be disposed`() {
         val displayer = Mockito.spy(miniAppWebView)
         displayer.destroyView()

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooserDefaultSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileChooserDefaultSpec.kt
@@ -83,6 +83,35 @@ class MiniAppFileChooserDefaultSpec {
     }
 
     @Test
+    fun `onShowFileChooser should launch camera permission when isCaptureEnabled is true`() {
+        val actual =
+            miniAppFileChooser.onShowFileChooser(mock(), fileChooserParams, context, false, true)
+        verify(miniAppFileChooser).launchCameraIntent()
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `onShowFileChooser should add EXTRA_MIME_TYPES when acceptTypes is not empty`() {
+        val fileChooserParamsAcceptTypes = arrayOf("image/png", "image/jpg")
+        val actual = miniAppFileChooser.onShowFileChooser(
+            mock(),
+            fileChooserParams,
+            context,
+            fileChooserParamsAcceptTypes = fileChooserParamsAcceptTypes
+        )
+        verify(context as Activity).startActivityForResult(intent, requestCode)
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `onShowFileChooser Intent should add EXTRA_ALLOW_MULTIPLE extra if isOpenMultipleMode is true`() {
+        val actual =
+            miniAppFileChooser.onShowFileChooser(callback, fileChooserParams, context, true)
+        verify(fileChooserParams?.createIntent())?.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+        assertTrue(actual)
+    }
+
+    @Test
     fun `onReceivedFiles should invoke value when intent data in intent after onShowFileChooser`() {
         val intent: Intent = mock()
         val uri: Uri = mock()


### PR DESCRIPTION
# Description
Also Ignoring MiniAppConfig.kt

## Links
https://jira.rakuten-it.com/jira/browse/MINI-5635

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
