### PR TITLE
[MINI-5657] Load miniapp from cache.

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/view/MiniAppParameters.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/view/MiniAppParameters.kt
@@ -20,7 +20,7 @@ sealed class MiniAppParameters {
         val config: MiniAppConfig,
         val miniAppId: String,
         val miniAppVersion: String,
-        val fromCache: Boolean = false
+        var fromCache: Boolean = false
     ) : MiniAppParameters()
 
     /**
@@ -35,7 +35,7 @@ sealed class MiniAppParameters {
         val context: Context,
         val config: MiniAppConfig,
         val miniAppInfo: MiniAppInfo,
-        val fromCache: Boolean = false
+        var fromCache: Boolean = false
     ) : MiniAppParameters()
 
     /**

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/view/MiniAppView.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/view/MiniAppView.kt
@@ -2,9 +2,9 @@ package com.rakuten.tech.mobile.miniapp.view
 
 import android.content.Context
 import androidx.annotation.VisibleForTesting
-import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 import com.rakuten.tech.mobile.miniapp.MiniAppDisplay
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkConfig
+import com.rakuten.tech.mobile.miniapp.MiniAppSdkException
 
 /**
  * This class can be used in the HostApp to create the miniapp views independently.
@@ -55,7 +55,12 @@ abstract class MiniAppView internal constructor() {
      * load a mini app view.
      * The mini app is downloaded, saved and provides a view when successful.
      * @param queryParams the parameters will be appended with the miniapp url scheme.
+     * @param fromCache the parameters will be appended with cached miniapp.
      * @param onComplete parameters needed to callback when the miniapp is successfully loaded.
      */
-    abstract fun load(queryParams: String = "", onComplete: (MiniAppDisplay?, MiniAppSdkException?) -> Unit)
+    abstract fun load(
+        queryParams: String = "",
+        fromCache: Boolean = false,
+        onComplete: (MiniAppDisplay?, MiniAppSdkException?) -> Unit
+    )
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/view/MiniAppViewImpl.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/view/MiniAppViewImpl.kt
@@ -16,12 +16,14 @@ internal class MiniAppViewImpl(
 
     override fun load(
         queryParams: String,
+        fromCache: Boolean,
         onComplete: (MiniAppDisplay?, MiniAppSdkException?) -> Unit
     ) {
         scope.launch {
             try {
                 when (miniAppParameters) {
                     is MiniAppParameters.DefaultParams -> {
+                        (miniAppParameters as MiniAppParameters.DefaultParams).fromCache = fromCache
                         if (queryParams != "") (miniAppParameters as MiniAppParameters.DefaultParams).config.queryParams =
                             queryParams
                         onComplete(
@@ -33,6 +35,7 @@ internal class MiniAppViewImpl(
                         )
                     }
                     is MiniAppParameters.InfoParams -> {
+                        (miniAppParameters as MiniAppParameters.InfoParams).fromCache = fromCache
                         if (queryParams != "") (miniAppParameters as MiniAppParameters.InfoParams).config.queryParams =
                             queryParams
                         onComplete(

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/view/MiniAppViewImpl.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/view/MiniAppViewImpl.kt
@@ -14,6 +14,7 @@ internal class MiniAppViewImpl(
     private val miniAppViewHandler: MiniAppViewHandler by lazy { initMiniAppViewHandler() }
     internal var scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 
+    @Suppress("LongMethod")
     override fun load(
         queryParams: String,
         fromCache: Boolean,

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/MiniAppDisplayFragment.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/MiniAppDisplayFragment.kt
@@ -138,12 +138,14 @@ class MiniAppDisplayFragment : BaseFragment() {
                                 showErrorDialog(activity, getString(R.string.error_desc_miniapp_too_many_request))
                             else -> {
                                 // try to load miniapp from cache.
+                                toggleProgressLoading(true)
                                 miniAppView.load(fromCache = true) { miniAppDisplay, miniAppSdkException ->
                                     activity.runOnUiThread {
                                         miniAppDisplay?.let {
                                             this.miniAppDisplay = miniAppDisplay
                                             addMiniAppChildView(activity, miniAppDisplay)
                                         } ?: kotlin.run {
+                                            toggleProgressLoading(false)
                                             miniAppSdkException?.let { e ->
                                                 when (e) {
                                                     is MiniAppNotFoundException ->

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/MiniAppDisplayFragment.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/MiniAppDisplayFragment.kt
@@ -137,7 +137,23 @@ class MiniAppDisplayFragment : BaseFragment() {
                             is MiniAppTooManyRequestsError ->
                                 showErrorDialog(activity, getString(R.string.error_desc_miniapp_too_many_request))
                             else -> {
-                                Toast.makeText(activity, it.message, Toast.LENGTH_LONG).show()
+                                // try to load miniapp from cache.
+                                miniAppView.load(fromCache = true) { miniAppDisplay, miniAppSdkException ->
+                                    activity.runOnUiThread {
+                                        miniAppDisplay?.let {
+                                            this.miniAppDisplay = miniAppDisplay
+                                            addMiniAppChildView(activity, miniAppDisplay)
+                                        } ?: kotlin.run {
+                                            miniAppSdkException?.let { e ->
+                                                when (e) {
+                                                    is MiniAppNotFoundException ->
+                                                        Toast.makeText(activity, "No Mini App found for the provided Project ID.", Toast.LENGTH_LONG).show()
+                                                    else -> Toast.makeText(activity, it.message, Toast.LENGTH_LONG).show()
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
# Description
MiniApp can be loaded from cache when preview mode is off.

## Links
MINI-5657

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
