### PR TITLE
[MINI-5641] Negative value displayed for available size if storage limit is set in decimal value

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -251,6 +251,9 @@ open class MiniAppMessageBridge {
             ActionType.SECURE_STORAGE_CLEAR.action -> miniAppSecureStorageDispatcher.onClearAll(
                 callbackObj.id
             )
+            ActionType.SECURE_STORAGE_SIZE.action -> miniAppSecureStorageDispatcher.onSize(
+                callbackObj.id
+            )
             ActionType.SET_CLOSE_ALERT.action -> onMiniAppShouldClose(callbackObj.id, jsonStr)
         }
         if (this::ratDispatcher.isInitialized) ratDispatcher.sendAnalyticsSdkFeature(callbackObj.action)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppSecureStorageDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppSecureStorageDispatcher.kt
@@ -5,6 +5,7 @@ import androidx.annotation.VisibleForTesting
 import com.google.gson.Gson
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppSecureStorageError
 import com.rakuten.tech.mobile.miniapp.storage.MiniAppSecureStorage
+import com.rakuten.tech.mobile.miniapp.storage.MiniAppSecureStorageSize
 
 internal const val DB_NAME_PREFIX = "rmapp-"
 
@@ -27,6 +28,9 @@ internal class MiniAppSecureStorageDispatcher(
 
     @VisibleForTesting
     internal lateinit var onSuccessGetItem: (String) -> Unit
+
+    @VisibleForTesting
+    internal lateinit var onSuccessDBSize: (Long) -> Unit
 
     @VisibleForTesting
     internal lateinit var miniAppSecureStorage: MiniAppSecureStorage
@@ -138,6 +142,17 @@ internal class MiniAppSecureStorageDispatcher(
             bridgeExecutor.postError(callbackId, Gson().toJson(errorSecure))
         }
         miniAppSecureStorage.delete(onSuccess, onFailed)
+    }
+
+    @Suppress("MagicNumber")
+    fun onSize(callbackId: String) = whenReady {
+        onSuccessDBSize = { fileSize: Long ->
+            val maxSizeInBytes = maxStorageSizeLimitInBytes
+            val storageSize =
+                Gson().toJson(MiniAppSecureStorageSize(fileSize, maxSizeInBytes))
+            bridgeExecutor.postValue(callbackId, storageSize)
+        }
+        miniAppSecureStorage.getDatabaseUsedSize(onSuccessDBSize)
     }
 
     /**

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppSecureStorageSize.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppSecureStorageSize.kt
@@ -1,0 +1,9 @@
+package com.rakuten.tech.mobile.miniapp.storage
+
+/**
+ * A data class to return used and max DB size.
+ */
+internal data class MiniAppSecureStorageSize(
+    val used: Long,
+    val max: Long
+)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/database/MiniAppSecureDatabase.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/database/MiniAppSecureDatabase.kt
@@ -32,7 +32,9 @@ private const val GET_ALL_ITEMS_QUERY = "select * from $TABLE_NAME"
 
 @VisibleForTesting
 internal const val DROP_TABLE_QUERY = "DROP TABLE IF EXISTS $TABLE_NAME"
-private const val GET_ITEM_QUERY_PREFIX = "select * from $TABLE_NAME where $FIRST_COLUMN_NAME="
+
+@VisibleForTesting
+internal const val GET_ITEM_QUERY_PREFIX = "select * from $TABLE_NAME where $FIRST_COLUMN_NAME="
 
 @VisibleForTesting
 internal const val CREATE_TABLE_QUERY = "create table if not exists $TABLE_NAME (" +

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/database/MiniAppSecureDatabase.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/database/MiniAppSecureDatabase.kt
@@ -215,7 +215,11 @@ internal class MiniAppSecureDatabase(
 
     override fun getDatabaseUsedSize(): Long {
         val dbFile = context.getDatabasePath(dbName)
-        return dbFile.length()
+        var fileSize = dbFile.length()
+        if (dbFile.length() > maxDBSizeLimitInBytes) {
+            fileSize = maxDBSizeLimitInBytes
+        }
+        return fileSize
     }
 
     @Suppress("ExpressionBodySyntax")
@@ -285,19 +289,13 @@ internal class MiniAppSecureDatabase(
                 val listOfItems = items.entries.stream().collect(Collectors.toList())
                 val chunked = listOfItems.chunked(DB_BATCH_SIZE)
                 chunked.forEach { outer ->
-                    if (isDatabaseFull()) {
-                        miniAppDatabaseStatus = MiniAppDatabaseStatus.FULL
-                        throw SQLiteFullException(DATABASE_SPACE_LIMIT_REACHED_ERROR)
-                    }
                     database.beginTransaction()
                     outer.forEach { inner ->
-                        if (miniAppDatabaseStatus == MiniAppDatabaseStatus.BUSY) {
-                            contentValues.put(FIRST_COLUMN_NAME, inner.key)
-                            contentValues.put(SECOND_COLUMN_NAME, inner.value)
-                            result = insert(contentValues)
-                            if (result > -1) {
-                                isInserted = true
-                            }
+                        contentValues.put(FIRST_COLUMN_NAME, inner.key)
+                        contentValues.put(SECOND_COLUMN_NAME, inner.value)
+                        result = insert(contentValues)
+                        if (result > -1) {
+                            isInserted = true
                         }
                     }
                     database.setTransactionSuccessful()

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/securestoragedispatcher/MessageBridgeSecurestorageDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/securestoragedispatcher/MessageBridgeSecurestorageDispatcherSpec.kt
@@ -3,9 +3,7 @@ package com.rakuten.tech.mobile.miniapp.js.securestoragedispatcher
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.gson.Gson
-import com.rakuten.tech.mobile.miniapp.TEST_CALLBACK_ID
-import com.rakuten.tech.mobile.miniapp.TEST_MA_ID
-import com.rakuten.tech.mobile.miniapp.TestActivity
+import com.rakuten.tech.mobile.miniapp.*
 import com.rakuten.tech.mobile.miniapp.js.*
 import com.rakuten.tech.mobile.miniapp.storage.MiniAppSecureStorage
 import org.amshove.kluent.*
@@ -49,7 +47,12 @@ class MessageBridgeSecurestorageDispatcherSpec : BridgeCommon() {
     fun setup() {
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
             miniAppSecureStorageDispatcher =
-                spy(MiniAppSecureStorageDispatcher(activity, testMaxStorageSizeInKB))
+                spy(
+                    MiniAppSecureStorageDispatcher(
+                        activity,
+                        TEST_MAX_STORAGE_SIZE_IN_BYTES.toLong()
+                    )
+                )
             miniAppSecureStorageDispatcher.bridgeExecutor = bridgeExecutor
             miniAppSecureStorageDispatcher.setMiniAppComponents(TEST_MA_ID)
 
@@ -104,9 +107,21 @@ class MessageBridgeSecurestorageDispatcherSpec : BridgeCommon() {
     @Test
     fun `securestorageDispatcher should call onClearAll when secureStorageCallbackObj is valid`() {
         val secureStorageDispatcher = getMockSecureStorageDispatcher()
-        val callbackJson = getCallbackObjToJsonStr(getCallbackObject(ActionType.SECURE_STORAGE_CLEAR))
+        val callbackJson =
+            getCallbackObjToJsonStr(getCallbackObject(ActionType.SECURE_STORAGE_CLEAR))
         miniappMessageBridge.postMessage(callbackJson)
         verify(secureStorageDispatcher).onClearAll(
+            secureStorageCallbackObj.id
+        )
+    }
+
+    @Test
+    fun `securestorageDispatcher should call onSize when secureStorageCallbackObj is valid`() {
+        val secureStorageDispatcher = getMockSecureStorageDispatcher()
+        val callbackJson =
+            getCallbackObjToJsonStr(getCallbackObject(ActionType.SECURE_STORAGE_SIZE))
+        miniappMessageBridge.postMessage(callbackJson)
+        verify(secureStorageDispatcher).onSize(
             secureStorageCallbackObj.id
         )
     }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/securestoragedispatcher/MiniAppSecureStorageDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/securestoragedispatcher/MiniAppSecureStorageDispatcherSpec.kt
@@ -2,7 +2,6 @@ package com.rakuten.tech.mobile.miniapp.js.securestoragedispatcher
 
 import android.content.Context
 import androidx.test.core.app.ActivityScenario
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.gson.Gson
 import com.rakuten.tech.mobile.miniapp.TEST_CALLBACK_ID
 import com.rakuten.tech.mobile.miniapp.TEST_MAX_STORAGE_SIZE_IN_BYTES
@@ -16,9 +15,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
-import org.amshove.kluent.When
-import org.amshove.kluent.calling
-import org.amshove.kluent.itReturns
 import org.amshove.kluent.shouldBe
 import org.junit.After
 import org.junit.Before
@@ -30,11 +26,10 @@ import org.mockito.kotlin.spy
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
-import java.io.File
 import kotlin.test.expect
 
 @ExperimentalCoroutinesApi
-//@RunWith(AndroidJUnit4::class)
+// @RunWith(AndroidJUnit4::class)
 @Suppress("LargeClass")
 @RunWith(RobolectricTestRunner::class)
 class MiniAppSecureStorageDispatcherSpec {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppSecureStorageSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppSecureStorageSpec.kt
@@ -13,6 +13,7 @@ import net.sqlcipher.database.SQLiteFullException
 import org.amshove.kluent.*
 import org.junit.Before
 import org.junit.Test
+import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -33,10 +34,11 @@ class MiniAppSecureStorageSpec {
     @Before
     fun setup() {
         MockitoAnnotations.openMocks(this)
-        mass = MiniAppSecureStorage(
-            context,
-            TEST_STORAGE_VERSION,
-            TEST_MAX_STORAGE_SIZE_IN_BYTES.toLong()
+        mass = Mockito.spy(MiniAppSecureStorage(
+                context,
+                TEST_STORAGE_VERSION,
+                TEST_MAX_STORAGE_SIZE_IN_BYTES.toLong()
+            )
         )
         mass.databaseName = TEST_MA_ID
         mass.miniAppSecureDatabase = mock()

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/database/MiniAppSecureDatabaseSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/database/MiniAppSecureDatabaseSpec.kt
@@ -61,7 +61,7 @@ class MiniAppSecureDatabaseSpec {
             )
         )
         massDB.miniAppDatabaseStatus = mock()
-        massDB.database = mock(SupportSQLiteDatabase::class)
+        massDB.database = Mockito.spy(SupportSQLiteDatabase::class.java)
 
         database = mock(SupportSQLiteDatabase::class)
         massDBImpl = mock(MiniAppSecureDatabaseImpl::class)

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -59,7 +59,7 @@ android {
             sslPublicKey            : property("CERTIFICATE_PUBLIC_KEY") ?: "",
             sslPublicKeyBackup      : property("CERTIFICATE_PUBLIC_KEY_BACKUP") ?: "",
             enableH5Ads             : property("ENABLE_H5_ADS") ?: true,
-            maxStorageSizeLimitInBytes : property("MAX_STORAGE_SIZE_LIMIT_IN_BYTES") ?: '52428800'
+            maxStorageSizeLimitInBytes : property("MAX_STORAGE_SIZE_LIMIT_IN_BYTES") ?: '5242880'
     ] + commonPlaceholders
     def stagingManifestPlaceholders = debugManifestPlaceholders.clone()
     stagingManifestPlaceholders.appName = defaultAppName + " STG"
@@ -76,7 +76,7 @@ android {
             sslPublicKey            : property("PROD_CERTIFICATE_PUBLIC_KEY") ?: "",
             sslPublicKeyBackup      : property("PROD_CERTIFICATE_PUBLIC_KEY_BACKUP") ?: "",
             enableH5Ads             : property("ENABLE_H5_ADS") ?: true,
-            maxStorageSizeLimitInBytes : property("MAX_STORAGE_SIZE_LIMIT_IN_BYTES") ?: 'abdcef',
+            maxStorageSizeLimitInBytes : property("MAX_STORAGE_SIZE_LIMIT_IN_BYTES") ?: '5242880',
     ] + commonPlaceholders
 
     def buildVersion = System.getenv("CIRCLE_BUILD_NUM") ?: new Date().format('yyMMddHHmm')


### PR DESCRIPTION
Cherry-Picking [fdc4f06](https://github.com/rakutentech/android-miniapp/pull/498/commits/fdc4f0628851f0e27c6d1c6a0aef9f00a61ed5d5) from candidate branch.

# Description
Describe the changes in this pull request.
Explain your rationale of technical decisions you made (unless discussed before).

## Links
Add links to github/jira issues, design documents and other relevant resources (e.g. previous discussions, platform/tool documentation etc.)

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
