### PR TITLE
[MINI-5641] Negative value displayed for available size if storage limit is set in decimal value

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppSecureStorageSize.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppSecureStorageSize.kt
@@ -1,8 +1,11 @@
 package com.rakuten.tech.mobile.miniapp.storage
 
+import androidx.annotation.Keep
+
 /**
  * A data class to return used and max DB size.
  */
+@Keep
 internal data class MiniAppSecureStorageSize(
     val used: Long,
     val max: Long


### PR DESCRIPTION
# Description
Describe the changes in this pull request.
Explain your rationale of technical decisions you made (unless discussed before).

## Links
Add links to github/jira issues, design documents and other relevant resources (e.g. previous discussions, platform/tool documentation etc.)

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
