### PR TITLE
[MINI-5696] Missing events for open and close dialog

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/AppHelper.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/AppHelper.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.AlertDialog
 import android.app.Application
+import android.app.Dialog
 import android.content.Context
 import android.text.InputType
 import android.util.Patterns
@@ -17,6 +18,8 @@ import android.widget.ImageView
 import androidx.appcompat.widget.AppCompatEditText
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
+import com.rakuten.tech.mobile.miniapp.js.NativeEventType
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import java.text.ParseException
 import java.text.SimpleDateFormat
@@ -59,8 +62,7 @@ fun showAlertDialog(activity: Activity, title: String = "Alert", content: String
     editText.background = null
     val container = FrameLayout(activity)
     val params: FrameLayout.LayoutParams = FrameLayout.LayoutParams(
-        ViewGroup.LayoutParams.MATCH_PARENT,
-        ViewGroup.LayoutParams.WRAP_CONTENT
+        ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT
     )
     params.topMargin = activity.resources.getDimensionPixelSize(R.dimen.medium_16)
     params.bottomMargin = activity.resources.getDimensionPixelSize(R.dimen.medium_16)
@@ -80,29 +82,26 @@ fun showAlertDialog(activity: Activity, title: String = "Alert", content: String
 }
 
 fun showErrorDialog(
-    context: Context,
-    description: String
+    context: Context, description: String
 ) {
     val builder = AlertDialog.Builder(context)
-    builder.setMessage(description)
-        .setNegativeButton("Close") { _, _ -> }
+    builder.setMessage(description).setNegativeButton("Close") { _, _ -> }
     val alert = builder.create()
     alert.show()
 }
 
-fun ImageView.load(context: Context, res: String, placeholder: Int = R.drawable.ic_default) = Glide.with(context)
-    .load(res)
-    .placeholder(placeholder)
-    .into(this)
+fun ImageView.load(context: Context, res: String, placeholder: Int = R.drawable.ic_default) =
+    Glide.with(context).load(res).placeholder(placeholder).into(this)
 
 fun String.isEmailValid(): Boolean = Patterns.EMAIL_ADDRESS.matcher(this).matches()
 
 fun hideSoftKeyboard(view: View) {
-    val imm: InputMethodManager? = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
+    val imm: InputMethodManager? =
+        view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
     imm?.hideSoftInputFromWindow(view.windowToken, 0)
 }
 
-fun setResizableSoftInputMode(activity: Activity){
+fun setResizableSoftInputMode(activity: Activity) {
     activity.window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE + WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
 }
 
@@ -142,3 +141,19 @@ fun getAdapterDataObserver(observeUIState: () -> Unit): RecyclerView.AdapterData
             observeUIState()
         }
     }
+
+
+fun Dialog.registerOnShowAndOnDismissEvent(onShow: () -> Unit, onDismiss: () -> Unit) {
+    setOnShowListener { onShow() }
+    setOnDismissListener { onDismiss() }
+}
+
+fun MiniAppMessageBridge.dispatchOnPauseEvent() {
+    dispatchNativeEvent(NativeEventType.MINIAPP_ON_PAUSE, "MiniApp Paused")
+}
+
+fun MiniAppMessageBridge.dispatchOnResumeEvent() {
+    dispatchNativeEvent(
+        NativeEventType.MINIAPP_ON_RESUME, "MiniApp Resumed"
+    )
+}

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/deeplink/SchemeActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/deeplink/SchemeActivity.kt
@@ -58,9 +58,11 @@ class SchemeActivity : BaseActivity(), PreloadMiniAppWindow.PreloadMiniAppLaunch
                             miniAppInfo?.let { miniAppInfo ->
                                 miniApp?.let { miniApp ->
                                     preloadMiniAppWindow.initiate(
-                                        miniAppInfo,
-                                        miniAppInfo.id,
-                                        miniAppInfo.version.versionId,
+                                        appInfo = miniAppInfo,
+                                        miniAppIdAndVersionIdPair = Pair(
+                                            miniAppInfo.id,
+                                            miniAppInfo.version.versionId
+                                        ),
                                         this@SchemeActivity,
                                         miniApp = miniApp
                                     )
@@ -93,7 +95,7 @@ class SchemeActivity : BaseActivity(), PreloadMiniAppWindow.PreloadMiniAppLaunch
         finish()
     }
 
-    private fun showErrorDialog(type: QRCodeErrorType, miniAppVersion: String = "") {
+    private fun showErrorDialog(type: QRCodeErrorType) {
         AppCoroutines.main {
             QRErrorWindow.getInstance(this).showMiniAppQRCodeError(errorType = type) {
                 finish()

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/deeplink/SchemeActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/deeplink/SchemeActivity.kt
@@ -121,12 +121,10 @@ class SchemeActivity : BaseActivity(), PreloadMiniAppWindow.PreloadMiniAppLaunch
     }
 
     private fun getSSlKeyList(): List<String> {
-        return if (!AppSettings.instance.isProdVersionEnabled) listOf(
-            getString(R.string.sslPublicKey),
-            getString(R.string.sslPublicKeyBackup)
+        return if (AppSettings.instance.miniAppSettings1.baseUrl != getString(R.string.prodBaseUrl)) listOf(
+            getString(R.string.sslPublicKey), getString(R.string.sslPublicKeyBackup)
         ) else listOf(
-            getString(R.string.sslPublicKeyProd),
-            getString(R.string.sslPublicKeyProdBackup)
+            getString(R.string.sslPublicKeyProd), getString(R.string.sslPublicKeyProdBackup)
         )
     }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -185,8 +185,10 @@ class MiniAppDisplayActivity : BaseActivity(), PreloadMiniAppWindow.PreloadMiniA
         appInfo?.let {
             preloadMiniAppWindow.initiate(
                 appInfo = appInfo,
-                it.id,
-                it.version.versionId,
+                miniAppIdAndVersionIdPair = Pair(
+                    it.id,
+                    it.version.versionId
+                ),
                 this,
                 shouldShowDialog = true,
                 onShow = miniAppMessageBridge::dispatchOnPauseEvent,

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -42,10 +42,7 @@ import com.rakuten.tech.mobile.miniapp.permission.AccessTokenScope
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppDevicePermissionType
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.MiniAppDisplayActivityBinding
-import com.rakuten.tech.mobile.testapp.helper.AppPermission
-import com.rakuten.tech.mobile.testapp.helper.setResizableSoftInputMode
-import com.rakuten.tech.mobile.testapp.helper.showAlertDialog
-import com.rakuten.tech.mobile.testapp.helper.showErrorDialog
+import com.rakuten.tech.mobile.testapp.helper.*
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import com.rakuten.tech.mobile.testapp.ui.chat.ChatWindow
 import com.rakuten.tech.mobile.testapp.ui.display.preload.PreloadMiniAppWindow
@@ -168,7 +165,11 @@ class MiniAppDisplayActivity : BaseActivity(), PreloadMiniAppWindow.PreloadMiniA
             }
             R.id.share_mini_app -> {
                 appInfo?.let {
-                    MiniAppShareWindow.getInstance(this).show(miniAppInfo = it)
+                    MiniAppShareWindow.getInstance(
+                        this,
+                        onShow = miniAppMessageBridge::dispatchOnPauseEvent,
+                        onDismiss = miniAppMessageBridge::dispatchOnResumeEvent,
+                    ).show(miniAppInfo = it)
                 }
                 true
             }
@@ -187,7 +188,9 @@ class MiniAppDisplayActivity : BaseActivity(), PreloadMiniAppWindow.PreloadMiniA
                 it.id,
                 it.version.versionId,
                 this,
-                shouldShowDialog = true
+                shouldShowDialog = true,
+                onShow = miniAppMessageBridge::dispatchOnPauseEvent,
+                onDismiss = miniAppMessageBridge::dispatchOnResumeEvent
             )
         }
 
@@ -505,15 +508,12 @@ class MiniAppDisplayActivity : BaseActivity(), PreloadMiniAppWindow.PreloadMiniA
 
     override fun onPause() {
         super.onPause()
-        miniAppMessageBridge.dispatchNativeEvent(NativeEventType.MINIAPP_ON_PAUSE, "MiniApp Paused")
+        miniAppMessageBridge.dispatchOnPauseEvent()
     }
 
     override fun onResume() {
         super.onResume()
-        miniAppMessageBridge.dispatchNativeEvent(
-            NativeEventType.MINIAPP_ON_RESUME,
-            "MiniApp Resumed"
-        )
+        miniAppMessageBridge.dispatchOnResumeEvent()
     }
 
     override fun onPreloadMiniAppResponse(isAccepted: Boolean) {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppShareWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppShareWindow.kt
@@ -10,6 +10,7 @@ import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.WindowShareMiniappBinding
 import com.rakuten.tech.mobile.testapp.helper.load
+import com.rakuten.tech.mobile.testapp.helper.registerOnShowAndOnDismissEvent
 
 class MiniAppShareWindow {
     companion object {
@@ -19,13 +20,21 @@ class MiniAppShareWindow {
         private lateinit var context: Context
 
         @Synchronized
-        fun getInstance(context: Context): MiniAppShareWindow {
-            dialog = initDialog(context)
+        fun getInstance(
+            context: Context,
+            onShow: () -> Unit,
+            onDismiss: () -> Unit
+        ): MiniAppShareWindow {
+            dialog = initDialog(context, onShow, onDismiss)
             this.context = context
             return instance ?: MiniAppShareWindow().also { instance = it }
         }
 
-        private fun initDialog(context: Context): AlertDialog {
+        private fun initDialog(
+            context: Context,
+            onShow: () -> Unit,
+            onDismiss: () -> Unit
+        ): AlertDialog {
             // set ui components
             val layoutInflater = LayoutInflater.from(context)
             binding = DataBindingUtil.inflate(
@@ -33,6 +42,7 @@ class MiniAppShareWindow {
             )
             val alertDialog = AlertDialog.Builder(context, R.style.AppThemeSettings).create()
             alertDialog?.setView(binding.root)
+            alertDialog?.registerOnShowAndOnDismissEvent(onShow = onShow, onDismiss = onDismiss)
             return alertDialog
         }
     }
@@ -45,8 +55,13 @@ class MiniAppShareWindow {
 
     private fun renderScreen(miniAppInfo: MiniAppInfo) {
         if (dialog.isShowing) dismissDialog()
-        binding.imgPromotional.load(context, miniAppInfo.promotionalImageUrl ?: "", android.R.color.darker_gray)
-        binding.tvPromotionalText.text = miniAppInfo.promotionalText ?: context.getText(R.string.error_desc_promotional_text_missing)
+        binding.imgPromotional.load(
+            context,
+            miniAppInfo.promotionalImageUrl ?: "",
+            android.R.color.darker_gray
+        )
+        binding.tvPromotionalText.text = miniAppInfo.promotionalText
+            ?: context.getText(R.string.error_desc_promotional_text_missing)
         binding.btnClose.setOnClickListener(listener)
         dialog.setCancelable(false)
         if (!(context as Activity).isFinishing) {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
@@ -20,6 +20,7 @@ import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.WindowPreloadMiniappBinding
 import com.rakuten.tech.mobile.testapp.helper.isAvailable
 import com.rakuten.tech.mobile.testapp.helper.load
+import com.rakuten.tech.mobile.testapp.helper.registerOnShowAndOnDismissEvent
 import com.rakuten.tech.mobile.testapp.helper.showErrorDialog
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
 
@@ -45,6 +46,8 @@ class PreloadMiniAppWindow(
         lifecycleOwner: LifecycleOwner,
         miniApp: MiniApp = MiniApp.instance(AppSettings.instance.newMiniAppSdkConfig),
         shouldShowDialog: Boolean = false,
+        onShow: () -> Unit = {},
+        onDismiss: () -> Unit = {}
     ) {
         this.lifecycleOwner = lifecycleOwner
         this.miniApp = miniApp
@@ -58,7 +61,11 @@ class PreloadMiniAppWindow(
             this.versionId = versionId
         }
 
-        if (miniAppId.isNotEmpty() && versionId.isNotEmpty()) initDefaultWindow(shouldShowDialog)
+        if (miniAppId.isNotEmpty() && versionId.isNotEmpty()) initDefaultWindow(
+            shouldShowDialog = shouldShowDialog,
+            onShow = onShow,
+            onDismiss = onDismiss
+        )
     }
 
     private fun launchScreen() {
@@ -66,20 +73,25 @@ class PreloadMiniAppWindow(
     }
 
     @SuppressLint("SetTextI18n")
-    private fun initDefaultWindow(shouldShowDialog: Boolean) {
+    private fun initDefaultWindow(
+        shouldShowDialog: Boolean,
+        onShow: () -> Unit,
+        onDismiss: () -> Unit
+    ) {
         // set ui components
         val layoutInflater = LayoutInflater.from(context)
         binding = DataBindingUtil.inflate(
             layoutInflater, R.layout.window_preload_miniapp, null, false
         )
 
-        if(shouldShowDialog){
+        if (shouldShowDialog) {
             binding.preloadTutorial.visibility = View.INVISIBLE
         }
 
         preloadMiniAppAlertDialog =
             AlertDialog.Builder(context, R.style.AppTheme_DefaultWindow).create()
         preloadMiniAppAlertDialog.setView(binding.root)
+        preloadMiniAppAlertDialog.registerOnShowAndOnDismissEvent(onShow = onShow, onDismiss = onDismiss)
 
         // set data to ui
         if (miniAppInfo != null) {

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppWindow.kt
@@ -41,8 +41,7 @@ class PreloadMiniAppWindow(
     @Suppress("LongParameterList")
     fun initiate(
         appInfo: MiniAppInfo?,
-        miniAppId: String,
-        versionId: String,
+        miniAppIdAndVersionIdPair: Pair<String, String>,
         lifecycleOwner: LifecycleOwner,
         miniApp: MiniApp = MiniApp.instance(AppSettings.instance.newMiniAppSdkConfig),
         shouldShowDialog: Boolean = false,
@@ -57,8 +56,8 @@ class PreloadMiniAppWindow(
             this.miniAppId = miniAppInfo!!.id
             this.versionId = miniAppInfo!!.version.versionId
         } else {
-            this.miniAppId = miniAppId
-            this.versionId = versionId
+            this.miniAppId = miniAppIdAndVersionIdPair.first
+            this.versionId = miniAppIdAndVersionIdPair.second
         }
 
         if (miniAppId.isNotEmpty() && versionId.isNotEmpty()) initDefaultWindow(

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/MiniAppDisplayFragment.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/MiniAppDisplayFragment.kt
@@ -40,9 +40,7 @@ import com.rakuten.tech.mobile.miniapp.testapp.databinding.FragmentMiniAppDispla
 import com.rakuten.tech.mobile.miniapp.view.MiniAppConfig
 import com.rakuten.tech.mobile.miniapp.view.MiniAppParameters
 import com.rakuten.tech.mobile.miniapp.view.MiniAppView
-import com.rakuten.tech.mobile.testapp.helper.AppPermission
-import com.rakuten.tech.mobile.testapp.helper.showAlertDialog
-import com.rakuten.tech.mobile.testapp.helper.showErrorDialog
+import com.rakuten.tech.mobile.testapp.helper.*
 import com.rakuten.tech.mobile.testapp.ui.base.BaseFragment
 import com.rakuten.tech.mobile.testapp.ui.chat.ChatWindow
 import com.rakuten.tech.mobile.testapp.ui.display.MiniAppShareWindow
@@ -55,7 +53,7 @@ import kotlinx.coroutines.launch
 
 
 @Suppress("TooManyFunctions", "MagicNumber", "VariableNaming")
-class MiniAppDisplayFragment : BaseFragment(),  PreloadMiniAppWindow.PreloadMiniAppLaunchListener {
+class MiniAppDisplayFragment : BaseFragment(), PreloadMiniAppWindow.PreloadMiniAppLaunchListener {
 
     override val pageName: String = this::class.simpleName ?: ""
     override val siteSection: String = this::class.simpleName ?: ""
@@ -460,7 +458,11 @@ class MiniAppDisplayFragment : BaseFragment(),  PreloadMiniAppWindow.PreloadMini
             }
             R.id.share_mini_app -> {
                 appInfo?.let {
-                    MiniAppShareWindow.getInstance(requireActivity()).show(miniAppInfo = it)
+                    MiniAppShareWindow.getInstance(
+                        context = requireActivity(),
+                        onShow = miniAppMessageBridge::dispatchOnPauseEvent,
+                        onDismiss = miniAppMessageBridge::dispatchOnResumeEvent
+                    ).show(miniAppInfo = it)
                 }
                 true
             }
@@ -511,15 +513,12 @@ class MiniAppDisplayFragment : BaseFragment(),  PreloadMiniAppWindow.PreloadMini
 
     override fun onPause() {
         super.onPause()
-        miniAppMessageBridge.dispatchNativeEvent(NativeEventType.MINIAPP_ON_PAUSE, "MiniApp Paused")
+        miniAppMessageBridge.dispatchOnPauseEvent()
     }
 
     override fun onResume() {
         super.onResume()
-        miniAppMessageBridge.dispatchNativeEvent(
-            NativeEventType.MINIAPP_ON_RESUME,
-            "MiniApp Resumed"
-        )
+        miniAppMessageBridge.dispatchOnResumeEvent()
     }
 
     private fun createMiniAppInfoParam(
@@ -547,7 +546,9 @@ class MiniAppDisplayFragment : BaseFragment(),  PreloadMiniAppWindow.PreloadMini
                 it.id,
                 it.version.versionId,
                 this,
-                shouldShowDialog = true
+                shouldShowDialog = true,
+                onShow = miniAppMessageBridge::dispatchOnPauseEvent,
+                onDismiss = miniAppMessageBridge::dispatchOnResumeEvent
             )
         }
     }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/MiniAppDisplayFragment.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/MiniAppDisplayFragment.kt
@@ -543,8 +543,10 @@ class MiniAppDisplayFragment : BaseFragment(), PreloadMiniAppWindow.PreloadMiniA
         appInfo?.let {
             preloadMiniAppWindow.initiate(
                 appInfo = appInfo,
-                it.id,
-                it.version.versionId,
+                miniAppIdAndVersionIdPair = Pair(
+                    it.id,
+                    it.version.versionId
+                ),
                 this,
                 shouldShowDialog = true,
                 onShow = miniAppMessageBridge::dispatchOnPauseEvent,

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/MiniAppListFragment.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/MiniAppListFragment.kt
@@ -83,7 +83,8 @@ class MiniAppListFragment : BaseFragment(), MiniAppListener, OnSearchListener,
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        val factory = MiniAppListViewModelFactory(MiniApp.instance(AppSettings.instance.newMiniAppSdkConfig))
+        val factory =
+            MiniAppListViewModelFactory(MiniApp.instance(AppSettings.instance.newMiniAppSdkConfig))
 
         viewModel = ViewModelProvider(this, factory).get(MiniAppListViewModel::class.java)
 
@@ -124,9 +125,11 @@ class MiniAppListFragment : BaseFragment(), MiniAppListener, OnSearchListener,
             selectedMiniAppInfo = miniAppInfo
             activity?.let {
                 preloadMiniAppWindow.initiate(
-                    miniAppInfo,
-                    miniAppInfo.id,
-                    miniAppInfo.version.versionId,
+                    appInfo = miniAppInfo,
+                    miniAppIdAndVersionIdPair = Pair(
+                        miniAppInfo.id,
+                        miniAppInfo.version.versionId
+                    ),
                     this
                 )
             }


### PR DESCRIPTION
# Description
Add onPause and onResume event on permission dialog and share dialog

## Links
[MINI-5696](https://jira.rakuten-it.com/jira/browse/MINI-5696)

## Video
https://rak.box.com/s/1pmxnhjlnc8heqi6mrm26ttmeuutoh82

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
