### PR TITLE
[MINI-5733] Error while entering data once the MiniApp is closed and reopened.

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppSecureStorage.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppSecureStorage.kt
@@ -107,10 +107,7 @@ internal class MiniAppSecureStorage(
     ) {
         scope.launch {
             try {
-                if (!miniAppSecureDatabase.isDatabaseAvailable(databaseName)) {
-                    createOrOpenAndUnlockDatabase()
-                }
-
+                createOrOpenAndUnlockDatabase()
                 if (miniAppSecureDatabase.isDatabaseBusy()) {
                     onFailed(MiniAppSecureStorageError.secureStorageBusyError)
                 } else if (miniAppSecureDatabase.isDatabaseFull()) {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/database/MiniAppSecureDatabase.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/database/MiniAppSecureDatabase.kt
@@ -107,7 +107,7 @@ internal class MiniAppSecureDatabase(
 
     @SuppressWarnings("ExpressionBodySyntax")
     internal fun isDatabaseBusy(): Boolean {
-        return miniAppDatabaseStatus == MiniAppDatabaseStatus.BUSY
+        return database.inTransaction()
     }
 
     @VisibleForTesting

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppSecureStorageSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/MiniAppSecureStorageSpec.kt
@@ -118,7 +118,7 @@ class MiniAppSecureStorageSpec {
     /**
      * Starting of insert item test cases
      */
-    @Test
+    @Ignore
     fun `createAndOpenDatabase should not be called from insert if database is available`() =
         runBlockingTest {
 
@@ -132,8 +132,6 @@ class MiniAppSecureStorageSpec {
     @Test
     fun `createAndOpenDatabase should be called from insert if database is available`() =
         runBlockingTest {
-
-            When calling mass.miniAppSecureDatabase.isDatabaseAvailable(mass.databaseName) itReturns false
 
             mass.insertItems(mock(), mock(), onFailed)
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/database/MiniAppSecureDatabaseSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/database/MiniAppSecureDatabaseSpec.kt
@@ -2245,14 +2245,20 @@ class MiniAppSecureDatabaseSpec {
     }
 
     @Test
+    fun `isDatabasebusy should call inTrnsaction`() {
+        massDB.isDatabaseBusy()
+        verify(massDB.database, times(1)).inTransaction()
+    }
+
+    @Test
     fun `isDatabasebusy should be false if miniAppDatabaseStatus is not BUSY`() {
-        When calling massDB.miniAppDatabaseStatus itReturns MiniAppDatabaseStatus.READY
+        When calling massDB.database.inTransaction() itReturns false
         massDB.isDatabaseBusy().shouldBeFalse()
     }
 
     @Test
     fun `isDatabasebusy should be true if miniAppDatabaseStatus is BUSY`() {
-        massDB.miniAppDatabaseStatus = MiniAppDatabaseStatus.BUSY
+        When calling massDB.database.inTransaction() itReturns true
         massDB.isDatabaseBusy().shouldBeTrue()
     }
 


### PR DESCRIPTION
# Description
**Resolution:**
It was really a side effect of [MINI-5711](https://jira.rakuten-it.com/jira/browse/MINI-5711) and was a genuine issue. There are many cases to DB need to take care and since the DB load time was changed to insert time only from [MINI-5711](https://jira.rakuten-it.com/jira/browse/MINI-5711) so due to the previous flow a DB Unavailable check was causing the issue. However I already found the issue and fixed it and tested with many various scenarios and it seems to be working fine now as expected.

## Links
[MINI-5711](https://jira.rakuten-it.com/jira/browse/MINI-5711) 

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
