### PR TITLE
[MINI-5737] Error on clear storage data once the MiniApp is closed and reopened.

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/database/MiniAppSecureDatabase.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/database/MiniAppSecureDatabase.kt
@@ -197,6 +197,8 @@ internal class MiniAppSecureDatabase(
         }
     }
 
+    override fun  isDatabaseReady(): Boolean = this::database.isInitialized
+
     override fun isDatabaseOpen(): Boolean = database.isOpen
 
     @SuppressWarnings("ExpressionBodySyntax")

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/database/MiniAppSecureDatabaseImpl.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/storage/database/MiniAppSecureDatabaseImpl.kt
@@ -122,6 +122,8 @@ internal abstract class MiniAppSecureDatabaseImpl(
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
     abstract fun onDatabaseReady(database: SupportSQLiteDatabase)
 
+    internal abstract fun isDatabaseReady(): Boolean
+
     internal abstract fun isDatabaseOpen(): Boolean
 
     internal abstract fun isDatabaseAvailable(dbName: String): Boolean

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/database/MiniAppSecureDatabaseSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/storage/database/MiniAppSecureDatabaseSpec.kt
@@ -301,6 +301,14 @@ class MiniAppSecureDatabaseSpec {
     }
 
     /**
+     * isDatabaseReady test cases
+     */
+    @Test
+    fun `verify the isDatabaseReady should be true if lateinit var database isInitialized`() {
+        assertTrue(massDB.isDatabaseReady())
+    }
+
+    /**
      * isDatabaseOpen test cases
      */
     @Test


### PR DESCRIPTION
# Description
It was a side effect of [MINI-5711](https://jira.rakuten-it.com/jira/browse/MINI-5711) and was a genuine issue. There are many cases to DB need to take care and since the DB load time was changed to insert time only from [MINI-5711](https://jira.rakuten-it.com/jira/browse/MINI-5711) so due to the previous flow DB was loaded and opened only once during MiniApp Launch time but now it's loaded and opened only during insert time, So because if that the DB was unavailable for the other functionalities. However I already found the issue and fixed it. Now the Db will be loaded and opened for other functionalities if the DB is available for a MiniApp in the device. Tested the fix with many various scenarios and it seems to be working fine now as expected.

## Links
[MINI-5711](https://jira.rakuten-it.com/jira/browse/MINI-5711)

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
