### PR TITLE
[NO TICKET] Add cross icon to clear input fields in Demo app

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/SettingsFragment.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/SettingsFragment.kt
@@ -185,14 +185,13 @@ class SettingsFragment : BaseFragment() {
     private fun validateInputIDs() {
         val isInputValid = isInputIDValid()
 
-        if (isInputEmpty(binding.editProjectId) || !isInputValid) binding.inputProjectId.error =
-            getString(R.string.error_invalid_input)
+        if (isInputEmpty(binding.editProjectId) || !isInputValid)
+            binding.inputProjectId.error = getString(R.string.error_invalid_input)
         else binding.inputProjectId.error = null
 
-        if (isInputEmpty(binding.editSubscriptionKey)) binding.inputSubscriptionKey.error =
-            getString(R.string.error_invalid_input)
+        if (isInputEmpty(binding.editSubscriptionKey))
+            binding.inputSubscriptionKey.error = getString(R.string.error_invalid_input)
         else binding.inputSubscriptionKey.error = null
-
 
         saveViewEnabled =
             binding.inputProjectId.error == null && binding.inputSubscriptionKey.error == null

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/AccessTokenActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/AccessTokenActivity.kt
@@ -10,6 +10,7 @@ import androidx.databinding.DataBindingUtil
 import com.rakuten.tech.mobile.miniapp.js.userinfo.TokenData
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.AccessTokenSettingsActivityBinding
+import com.rakuten.tech.mobile.testapp.helper.hideSoftKeyboard
 import com.rakuten.tech.mobile.testapp.helper.parseDateToString
 import com.rakuten.tech.mobile.testapp.helper.parseStringToDate
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
@@ -53,6 +54,7 @@ class AccessTokenActivity : BaseActivity() {
         super.onOptionsItemSelected(item)
         return when (item.itemId) {
             android.R.id.home -> {
+                hideSoftKeyboard(binding.root)
                 finish()
                 return true
             }
@@ -85,6 +87,7 @@ class AccessTokenActivity : BaseActivity() {
 
     private fun update() {
         settings.tokenData = TokenData(accessToken, expiredDate)
+        hideSoftKeyboard(binding.root)
         finish()
     }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactListActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactListActivity.kt
@@ -111,7 +111,7 @@ class ContactListActivity : BaseActivity(), ContactListener {
                 setDialogTitle("Contact Input")
             }
 
-            setPositiveListener(View.OnClickListener {
+            setPositiveListener {
                 val id: String = edtContactId.text.toString().trim()
                 val name: String = edtContactName.text.toString().trim()
                 val email: String = edtContactEmail.text.toString().trim()
@@ -123,7 +123,7 @@ class ContactListActivity : BaseActivity(), ContactListener {
 
                     this.dialog?.cancel()
                 }
-            })
+            }
         }.show()
     }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ProfileSettingsActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ProfileSettingsActivity.kt
@@ -52,6 +52,7 @@ class ProfileSettingsActivity : BaseActivity() {
         super.onOptionsItemSelected(item)
         return when (item.itemId) {
             android.R.id.home -> {
+                hideSoftKeyboard(binding.root)
                 finish()
                 return true
             }

--- a/testapp/src/main/res/layout/access_token_settings_activity.xml
+++ b/testapp/src/main/res/layout/access_token_settings_activity.xml
@@ -16,7 +16,8 @@
 
     <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:endIconMode="clear_text">
 
       <EditText
           android:id="@+id/edtToken"
@@ -31,7 +32,8 @@
 
     <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:endIconMode="clear_text">
 
       <EditText
           android:id="@+id/edtDateExpired"

--- a/testapp/src/main/res/layout/mini_app_input_activity.xml
+++ b/testapp/src/main/res/layout/mini_app_input_activity.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -21,13 +22,17 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-                android:layout_marginBottom="@dimen/medium_16">
+                android:layout_marginBottom="@dimen/medium_16"
+                app:endIconMode="clear_text"
+                app:errorTextAppearance="@style/SettingsError.TextAppearance">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/edtAppId"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:inputType="text" />
+                    android:inputType="text"
+                    android:paddingEnd="@dimen/large_40"
+                    tools:ignore="RtlSymmetry" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <com.rakuten.tech.mobile.testapp.analytics.rat_wrapper.RATButton

--- a/testapp/src/main/res/layout/points_activity.xml
+++ b/testapp/src/main/res/layout/points_activity.xml
@@ -13,7 +13,8 @@
             android:padding="@dimen/small_8"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toTopOf="parent"
+            app:endIconMode="clear_text">
 
             <androidx.appcompat.widget.AppCompatEditText
                 android:id="@+id/edtPointStandard"
@@ -32,7 +33,8 @@
             android:layout_height="wrap_content"
             android:padding="@dimen/small_8"
             app:layout_constraintStart_toStartOf="@id/layoutPointStandard"
-            app:layout_constraintTop_toBottomOf="@+id/layoutPointStandard">
+            app:layout_constraintTop_toBottomOf="@+id/layoutPointStandard"
+            app:endIconMode="clear_text">
 
             <androidx.appcompat.widget.AppCompatEditText
                 android:id="@+id/edtPointTimeLimited"
@@ -50,7 +52,8 @@
             android:layout_height="wrap_content"
             android:padding="@dimen/small_8"
             app:layout_constraintStart_toStartOf="@id/layoutPointTimeLimited"
-            app:layout_constraintTop_toBottomOf="@+id/layoutPointTimeLimited">
+            app:layout_constraintTop_toBottomOf="@+id/layoutPointTimeLimited"
+            app:endIconMode="clear_text">
 
             <androidx.appcompat.widget.AppCompatEditText
                 android:id="@+id/edtPointRakutenCash"

--- a/testapp/src/main/res/layout/profile_settings_activity.xml
+++ b/testapp/src/main/res/layout/profile_settings_activity.xml
@@ -41,7 +41,8 @@
 
       <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:endIconMode="clear_text">
 
         <androidx.appcompat.widget.AppCompatEditText
           android:id="@+id/editProfileName"

--- a/testapp/src/main/res/layout/qa_settings_activity.xml
+++ b/testapp/src/main/res/layout/qa_settings_activity.xml
@@ -66,7 +66,8 @@
             <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:padding="@dimen/small_8">
+                android:padding="@dimen/small_8"
+                app:endIconMode="clear_text">
 
                 <androidx.appcompat.widget.AppCompatEditText
                     android:id="@+id/edtCustomErrorMessage"
@@ -107,7 +108,8 @@
             <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:padding="@dimen/small_4">
+                android:padding="@dimen/small_4"
+                app:endIconMode="clear_text">
 
                 <androidx.appcompat.widget.AppCompatEditText
                     android:id="@+id/edtUniqueIdError"
@@ -122,7 +124,8 @@
             <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:padding="@dimen/small_4">
+                android:padding="@dimen/small_4"
+                app:endIconMode="clear_text">
 
                 <androidx.appcompat.widget.AppCompatEditText
                     android:id="@+id/edtMessagingUniqueIdError"
@@ -136,7 +139,8 @@
             <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:padding="@dimen/small_4">
+                android:padding="@dimen/small_4"
+                app:endIconMode="clear_text">
 
                 <androidx.appcompat.widget.AppCompatEditText
                     android:id="@+id/edtMauidError"
@@ -160,7 +164,8 @@
             <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:padding="@dimen/small_4">
+                android:padding="@dimen/small_4"
+                app:endIconMode="clear_text">
 
                 <androidx.appcompat.widget.AppCompatEditText
                     android:id="@+id/edtMaxStorageLimit"
@@ -174,7 +179,8 @@
             <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:padding="@dimen/small_4">
+                android:padding="@dimen/small_4"
+                app:endIconMode="clear_text">
 
                 <androidx.appcompat.widget.AppCompatEditText
                     android:id="@+id/clearStorageForMiniAppId"

--- a/testapp/src/main/res/layout/settings_fragment.xml
+++ b/testapp/src/main/res/layout/settings_fragment.xml
@@ -256,7 +256,9 @@
                 <com.google.android.material.textfield.TextInputLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_margin="@dimen/small_8">
+                    android:layout_margin="@dimen/small_8"
+                    app:endIconMode="clear_text"
+                    app:errorTextAppearance="@style/SettingsError.TextAppearance">
 
                     <androidx.appcompat.widget.AppCompatEditText
                         android:id="@+id/editParametersUrl"

--- a/testapp/src/main/res/values/dimens.xml
+++ b/testapp/src/main/res/values/dimens.xml
@@ -16,6 +16,7 @@
     <dimen name="medium_16">16dp</dimen>
     <dimen name="large_24">24dp</dimen>
     <dimen name="large_32">32dp</dimen>
+    <dimen name="large_40">40dp</dimen>
     <dimen name="large_44">44dp</dimen>
     <dimen name="large_48">48dp</dimen>
     <dimen name="large_52">52dp</dimen>


### PR DESCRIPTION
# Description
Usually, in Demo app we can clear input fields easily in several places by cross icon, but still there are some remaining fields to implement this UX. This PR aims to add the cross icon to clear input fields in those remaining input fields.

# Screenshots
![Screen Shot 2022-11-16 at 14 49 16](https://user-images.githubusercontent.com/66930373/202095774-add9b2a5-f4cd-4635-b61c-2461935515c6.png)
![Screen Shot 2022-11-16 at 14 49 33](https://user-images.githubusercontent.com/66930373/202095777-7d273a9a-a9ad-48f1-a16a-1b19b9852943.png)
![Screen Shot 2022-11-16 at 14 51 21](https://user-images.githubusercontent.com/66930373/202095779-c3d4662a-3ae9-4897-afe1-35b51f7be44b.png)

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
