### PR TITLE
[MINI-4188] Create "candidate to master" pull request automatically after a release done

### DIFF
--- a/.github/workflows/candidate_to_master.yml
+++ b/.github/workflows/candidate_to_master.yml
@@ -1,0 +1,22 @@
+name: Create pull request from candidate to master
+on:
+  release:
+    types: [published]
+jobs:
+  candidateToMaster:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: master
+      - name: Reset candidate
+        run: |
+          git fetch origin candidate:candidate
+          git reset --hard candidate
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: Candidate
+          body: This is the candidate merge after a successful SDK release
+          labels: SDK
+          branch: candidate


### PR DESCRIPTION
# Description
This PR aims to add Github-Action's workflow using [create-pull-request](https://github.com/marketplace/actions/create-pull-request) for opening a new pull request from candidate to master branch automatically after a successful release of MiniApp Android SDK. 

## Use-case
After creating a release tag in [here](https://github.com/rakutentech/android-miniapp/tags) we can store the latest release in https://github.com/rakutentech/android-miniapp/releases. It will trigger the Github Action workflow to create the pull request from candidate to master branch. The job-workflows can be tracked from https://github.com/rakutentech/android-miniapp/actions.

Todo: There should be a guideline how to use the process.

## Links
- MINI-4188

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
