### PR TITLE
[MINI-5726] Fix config data to show cached data

### DIFF
--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionAdapterSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/ui/MiniAppCustomPermissionAdapterSpec.kt
@@ -157,7 +157,6 @@ class MiniAppCustomPermissionAdapterSpec {
         assertEquals(permissionAdapter.permissionToggles.size, results.size)
         assertEquals(permissionAdapter.permissionDescriptions.size, descriptions.size)
 
-        // val permissionViewHolder = MiniAppCustomPermissionAdapter.PermissionViewHolder(getItemView())
         val permissionViewHolder: MiniAppCustomPermissionAdapter.PermissionViewHolder = mock()
         val permissionName: TextView = mock()
         val permissionDescription: TextView = mock()

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/SettingsFragment.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/SettingsFragment.kt
@@ -387,7 +387,7 @@ class SettingsFragment : BaseFragment() {
 
     override fun onStop() {
         settings.isTab1Checked = isTab1Checked
-        settings.clearTempData()
+        //settings.clearTempData()
         super.onStop()
     }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/SettingsFragment.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/SettingsFragment.kt
@@ -387,7 +387,6 @@ class SettingsFragment : BaseFragment() {
 
     override fun onStop() {
         settings.isTab1Checked = isTab1Checked
-        //settings.clearTempData()
         super.onStop()
     }
 }


### PR DESCRIPTION
# Description
Remove the cache removing function to show the cached data properly.

## Links
MINI-5726

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
