### PR TITLE
[MINI-5751] Use the cached miniapview even after fragment destroyed

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/MiniAppDisplayFragment.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/MiniAppDisplayFragment.kt
@@ -126,13 +126,26 @@ class MiniAppDisplayFragment : BaseFragment(), PreloadMiniAppWindow.PreloadMiniA
         }
     }
 
+    private fun getMiniAppView(activity: Activity): MiniAppView {
+        return if (activity is DemoAppMainActivity) {
+            miniAppIdAndViewMap[Pair(activity.getCurrentSelectedId(), appId)] ?: initNewMiniAppView(
+                activity
+            )
+        } else {
+            initNewMiniAppView(activity)
+        }
+    }
+
+    private fun initNewMiniAppView(activity: Activity) =
+        MiniAppView.init(createMiniAppInfoParam(activity, args.miniAppInfo))
+
     @Suppress("LongMethod", "ComplexMethod")
     private fun initializeMiniAppDisplay(activity: Activity) {
         toggleProgressLoading(true)
         setUpFileChooserAndDownloader(activity)
         setUpNavigator(activity)
         setupMiniAppMessageBridge(requireActivity(), miniAppFileDownloader)
-        val miniAppView = MiniAppView.init(createMiniAppInfoParam(activity, args.miniAppInfo))
+        val miniAppView = getMiniAppView(activity)
         miniAppView.load { miniAppDisplay, miniAppSdkException ->
             activity.runOnUiThread {
                 miniAppDisplay?.let {


### PR DESCRIPTION
# Description
Fragment got destroyed thus creating the MiniAppView instance again where the current MiniAppView associated with appId has been cached.

## Links
MINI-5751

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
