### PR TITLE
[MINI-5755] Invalidate Cached MiniAppView when Fragment got destroyed

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/MiniAppDisplayFragment.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/MiniAppDisplayFragment.kt
@@ -126,12 +126,22 @@ class MiniAppDisplayFragment : BaseFragment(), PreloadMiniAppWindow.PreloadMiniA
         }
     }
 
+    private fun removeCachedMiniAppViewIfExists(activity: Activity) {
+        if (activity is DemoAppMainActivity) {
+            val keyPair = Pair(activity.getCurrentSelectedId(), appId)
+            if (miniAppIdAndViewMap.containsKey(keyPair)) {
+                miniAppIdAndViewMap.remove(keyPair)
+            }
+        }
+    }
+
     @Suppress("LongMethod", "ComplexMethod")
     private fun initializeMiniAppDisplay(activity: Activity) {
         toggleProgressLoading(true)
         setUpFileChooserAndDownloader(activity)
         setUpNavigator(activity)
         setupMiniAppMessageBridge(requireActivity(), miniAppFileDownloader)
+        removeCachedMiniAppViewIfExists(activity)
         val miniAppView = MiniAppView.init(createMiniAppInfoParam(activity, args.miniAppInfo))
         miniAppView.load { miniAppDisplay, miniAppSdkException ->
             activity.runOnUiThread {


### PR DESCRIPTION
# Description
The fragment got destroyed and got the new MiniAppView instance instead, thus it gets different from the cached one. If it is loaded with the cached MiniAppView, it gets a different context attached to the activity. 

## Links
MINI-5755

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
