### PR TITLE
[MINI-5796] Appending '.' to file names on file download creates a zero byte file in Android 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Feature:** Added `MiniAppMessageBridge.sendJsonToHostApp` interface to provide `Universal Bridge` for sending messages from a MiniApp to the HostApp.
 - **Feature:** Added `NativeEventType.MINIAPP_RECEIVE_JSON_INFO` to provide `Universal Bridge` for receiving messages from the HostApp to MiniApps.
 - **Feature:** Added `sendJsonToMiniApp` in `MiniAppView` and `MiniAppViewImpl` for receiving messages from the HostApp to MiniApps.
+- **Fix:** Prevent file creation with zero byte while downloading a file using `MiniAppFileDownloader` in Android 10.
 
 **Sample App**
 - **Feature:** Settings is moved to it's own tab.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileDownloader.kt
@@ -167,6 +167,9 @@ class MiniAppFileDownloaderDefault(var activity: Activity, var requestCode: Int)
             ""
         val mimetype = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
 
+        // Intent.ACTION_CREATE_DOCUMENT creates files with 0 bytes
+        // while specifying mimetype in Android API 29 platform,
+        // It needs to set "*/*" to prevent this issue.
         return if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
             return "*/*"
         } else {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileDownloader.kt
@@ -171,7 +171,7 @@ class MiniAppFileDownloaderDefault(var activity: Activity, var requestCode: Int)
         // while specifying mimetype in Android API 29 platform,
         // It needs to set "*/*" to prevent this issue.
         return if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
-            return "*/*"
+            "*/*"
         } else {
             if (!mimetype.isNullOrBlank())
                 mimetype

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileDownloader.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileDownloader.kt
@@ -3,6 +3,7 @@ package com.rakuten.tech.mobile.miniapp.file
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.util.Base64
 import android.util.Log
 import android.webkit.MimeTypeMap
@@ -165,16 +166,21 @@ class MiniAppFileDownloaderDefault(var activity: Activity, var requestCode: Int)
         else
             ""
         val mimetype = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
-        return if (!mimetype.isNullOrBlank())
-            mimetype
-        else
-            "text/plain"
+
+        return if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
+            return "*/*"
+        } else {
+            if (!mimetype.isNullOrBlank())
+                mimetype
+            else
+                "text/plain"
+        }
     }
 
     @VisibleForTesting
     internal fun createRequest(url: String, headers: Map<String, String>): Request {
         val builder = Request.Builder()
-        headers?.forEach { header ->
+        headers.forEach { header ->
             builder.addHeader(header.key, header.value)
         }
         return builder.url(url).build()

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileDownloaderSpec.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.ContentResolver
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.webkit.MimeTypeMap
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -32,6 +33,7 @@ import org.mockito.Mockito.timeout
 import org.mockito.kotlin.*
 import org.mockito.kotlin.mock
 import org.robolectric.Shadows
+import org.robolectric.util.ReflectionHelpers
 import java.io.OutputStream
 import kotlin.test.assertEquals
 
@@ -92,6 +94,13 @@ class MiniAppFileDownloaderSpec {
     fun `getMimeType should return the default mimeType for incorrect extension`() {
         val miniAppFileDownloader = MiniAppFileDownloaderDefault(activity, 100)
         miniAppFileDownloader.getMimeType("") shouldBeEqualTo "text/plain"
+    }
+
+    @Test
+    fun `getMimeType should return the all mimeType for android api level 29`() {
+        val miniAppFileDownloader = MiniAppFileDownloaderDefault(activity, 100)
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", 29)
+        miniAppFileDownloader.getMimeType(TEST_FILENAME) shouldBeEqualTo "*/*"
     }
 
     @Test


### PR DESCRIPTION
# Description
This PR aims to add a fix to prevent creation of zero byte-ed file when downloading a file by appending `Dot(.)' to the file name in Android 10. Basically, it's showing an issue as following:

```
    java.lang.IllegalArgumentException: Invalid file path: /storage/emulated/0/Download/sample..csv
        at com.android.providers.downloads.DownloadProvider.checkDownloadedFilePath(DownloadProvider.java:1091)
        at com.android.providers.downloads.DownloadProvider.insert(DownloadProvider.java:719)
        at android.content.ContentProvider$Transport.insert(ContentProvider.java:309)
        at android.content.ContentResolver.insert(ContentResolver.java:1828)
        ......
        at com.android.providers.downloads.DownloadStorageProvider.createDocument(DownloadStorageProvider.java:210)
        at android.provider.DocumentsProvider.callUnchecked(DocumentsProvider.java:1121)
        .....
```

`Intent.ACTION_CREATE_DOCUMENT` works differently while taking the Mime-type in Android 10 os, it needs to set `type = "*/*"` to the `Intent` to prevent creation of file with zero bytes.

## Links
- MINI-5796

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
