### PR TITLE
[MINI-5796] quick fix: adopt variable name from MiniAppFileDownloaderSpec

### DIFF
--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileDownloaderSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/file/MiniAppFileDownloaderSpec.kt
@@ -90,7 +90,7 @@ class MiniAppFileDownloaderSpec {
     fun `getMimeType should return the all mimeType for android api level 29`() {
         val miniAppFileDownloader = MiniAppFileDownloaderDefault(activity, 100)
         ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", 29)
-        miniAppFileDownloader.getMimeType(TEST_FILENAME) shouldBeEqualTo "*/*"
+        miniAppFileDownloader.getMimeType(testFileName) shouldBeEqualTo "*/*"
     }
 
     @Test


### PR DESCRIPTION
# Description
This PR aims to fix an issue in MiniAppFileDownloaderSpec in master branch.

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
