### PR TITLE
[MINI-5815] Support multiple emails in contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Feature:** Added `NativeEventType.MINIAPP_RECEIVE_JSON_INFO` to provide `Universal Bridge` for receiving messages from the HostApp to MiniApps.
 - **Feature:** Added `sendJsonToMiniApp` in `MiniAppView` and `MiniAppViewImpl` for receiving messages from the HostApp to MiniApps.
 - **Fix:** Prevent file creation with zero byte with appending a single dot(.) at the end of file's name while downloading a file using `MiniAppFileDownloader` in Android 10.
+- **Update:** Added `allEmailList` field to support multiple emails for contacts.
 
 **Sample App**
 - **Feature:** Settings is moved to it's own tab.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - **Feature:** Added `NativeEventType.MINIAPP_RECEIVE_JSON_INFO` to provide `Universal Bridge` for receiving messages from the HostApp to MiniApps.
 - **Feature:** Added `sendJsonToMiniApp` in `MiniAppView` and `MiniAppViewImpl` for receiving messages from the HostApp to MiniApps.
 - **Fix:** Prevent file creation with zero byte with appending a single dot(.) at the end of file's name while downloading a file using `MiniAppFileDownloader` in Android 10.
-- **Update:** Added `allEmailList` field to support multiple emails for contacts.
+- **Update:** Added `allEmailList` field in `Contact` to support multiple emails of a specific contact.
 
 **Sample App**
 - **Feature:** Settings is moved to it's own tab.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/Contact.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/Contact.kt
@@ -8,5 +8,5 @@ data class Contact(
     val id: String,
     var name: String?,
     var email: String?,
-    var allEmailList: List<String> = emptyList()
+    var allEmailList: List<String>?
 )

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/Contact.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/userinfo/Contact.kt
@@ -7,5 +7,6 @@ import androidx.annotation.Keep
 data class Contact(
     val id: String,
     var name: String?,
-    var email: String?
+    var email: String?,
+    var allEmailList: List<String> = emptyList()
 )

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
@@ -1,10 +1,9 @@
 package com.rakuten.tech.mobile.miniapp
 
 import com.rakuten.tech.mobile.miniapp.analytics.MiniAppAnalyticsConfig
+import com.rakuten.tech.mobile.miniapp.js.userinfo.Contact
 import com.rakuten.tech.mobile.miniapp.permission.AccessTokenScope
 import java.io.File
-
-import com.rakuten.tech.mobile.miniapp.js.userinfo.Contact
 
 internal const val TEST_BODY_CONTENT = "lorem ipsum"
 internal const val TEST_ERROR_MSG = "error_message"
@@ -54,7 +53,8 @@ internal const val INVALID_FILE_URL_PATH = "https://78d85043-d04f-486a-8212-bf26
 
 internal const val TEST_USER_NAME = "test_user_name"
 internal const val TEST_PROFILE_PHOTO = "data:image/png;base64,encodedValue"
-internal val TEST_CONTACT = Contact("test_contact_id", "test_contact_name", "test_contact_email")
+internal val TEST_EMAIL_LIST = listOf("test@sample.com", "test@example.com")
+internal val TEST_CONTACT = Contact("test_contact_id", "test_contact_name", "test_contact_email", TEST_EMAIL_LIST)
 internal const val TEST_PROMOTIONAL_URL = "http://testImageurl.co"
 internal const val TEST_PROMOTIONAL_TEXT = "test_promotional_text"
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactHelper.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactHelper.kt
@@ -1,3 +1,4 @@
+
 package com.rakuten.tech.mobile.testapp.ui.userdata
 
 import com.rakuten.tech.mobile.miniapp.js.userinfo.Contact
@@ -27,6 +28,17 @@ object ContactHelper {
         "Nicolas",
         "Freeman"
     )
+    private val fakeEmails = listOf(
+        "andrews@sample.com",
+        "casey@sample.com",
+        "gross@sample.com",
+        "lane@sample.com",
+        "thomas@sample.com",
+        "patrick@sample.com",
+        "strickland@sample.com",
+        "nicolas@sample.com",
+        "freeman@sample.com"
+    )
 
 
     @Suppress("UnusedPrivateMember", "MagicNumber")
@@ -42,6 +54,6 @@ object ContactHelper {
         val lastName = fakeLastNames[(SecureRandom().nextDouble() * fakeLastNames.size).toInt()]
         val email =
             firstName.lowercase(Locale.ROOT) + "." + lastName.lowercase(Locale.ROOT) + "@example.com"
-        return Contact(UUID.randomUUID().toString().trimEnd(), "$firstName $lastName", email)
+        return Contact(UUID.randomUUID().toString().trimEnd(), "$firstName $lastName", email, fakeEmails)
     }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactListActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactListActivity.kt
@@ -113,7 +113,8 @@ class ContactListActivity : BaseActivity(), ContactListener {
                 val email: String = edtContactEmail.text.toString().trim()
 
                 if (isVerifiedContact(id, name, email)) {
-                    val contact = Contact(id = id, name = name, email = email)
+                    // TODO: Need to update the all emailList from empty to valid.
+                    val contact = Contact(id = id, name = name, email = email, allEmailList = emptyList())
                     if (isUpdate) position?.let { adapter.updateContact(it, contact) }
                     else adapter.addContact(adapter.itemCount, contact)
 


### PR DESCRIPTION
# Description
Added `allEmailList` field to support multiple emails for contacts.
![Screen Shot 2022-12-21 at 1 55 48 PM](https://user-images.githubusercontent.com/84305007/208824795-54eba282-bfef-4656-b2f9-1b6e2ff0e84b.png)

## Links
MINI-5815

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
