### PR TITLE
[NO TICKET] Remove unused option from settings page

### DIFF
--- a/testapp/src/main/res/layout/settings_fragment.xml
+++ b/testapp/src/main/res/layout/settings_fragment.xml
@@ -234,21 +234,6 @@
                     android:background="@color/bg_section" />
 
                 <com.rakuten.tech.mobile.testapp.analytics.rat_wrapper.CustomButtonViewWithArrow
-                    android:id="@+id/buttonDeeplink"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    app:rightArrowEnable="true"
-                    app:titleLabel="@string/action_dynamic_deeplinks"
-                    app:actionType="open"
-                    app:pageName="Settings"
-                    app:siteSection="Top"/>
-
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="@dimen/horizontal_divider_height"
-                    android:background="@color/bg_section" />
-
-                <com.rakuten.tech.mobile.testapp.analytics.rat_wrapper.CustomButtonViewWithArrow
                     android:id="@+id/buttonQA"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"


### PR DESCRIPTION
# Description
This PR aims to remove unused "Dynamic Deeplinks" button from settings page as it's moved to "General" page.

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
