### PR TITLE
[MINI-5828] Multiple optional emails demo app

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactAddActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactAddActivity.kt
@@ -25,6 +25,7 @@ import kotlin.properties.Delegates
 private const val START_OPTIONAL_EMAIL_EDIT_TEXT_CHILD_INDEX = 3
 private const val MAX_OPTIONAL_EMAIL_ADDRESS = 4
 
+@Suppress("TooManyFunctions", "ReturnCount", "MagicNumber")
 class ContactAddActivity : BaseActivity() {
     override val pageName: String = this::class.simpleName ?: ""
     override val siteSection: String = this::class.simpleName ?: ""

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactAddActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactAddActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.Gravity
 import android.view.Menu
 import android.view.MenuItem
+import android.widget.EditText
 import android.widget.Toast
 import androidx.databinding.DataBindingUtil
 import com.google.android.material.textfield.TextInputLayout
@@ -83,18 +84,19 @@ class ContactAddActivity : BaseActivity() {
         renderScreen()
 
         binding.btnAddOptionalEmailField.setOnClickListener {
-            addOptionalEmailView()
-            currentOptionalEmailAddressCount += 1
+            getOptionalEmailEditText()
         }
     }
 
-    private fun addOptionalEmailView() {
+    private fun getOptionalEmailEditText(): EditText {
         val inflatedView = layoutInflater.inflate(
             R.layout.item_optional_email_address,
             null,
             false
         ) as TextInputLayout
         binding.layoutFields.addView(inflatedView)
+        currentOptionalEmailAddressCount += 1
+        return inflatedView.editText!!
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -123,7 +125,9 @@ class ContactAddActivity : BaseActivity() {
         for (i in START_OPTIONAL_EMAIL_EDIT_TEXT_CHILD_INDEX until childCount) {
             with(binding.layoutFields.getChildAt(i)) {
                 val text = (this as TextInputLayout).editText?.text.toString()
-                return isOptionalEmailTextValid(text)
+                if (!isOptionalEmailTextValid(text)) {
+                    return false
+                }
             }
         }
         return true
@@ -164,6 +168,15 @@ class ContactAddActivity : BaseActivity() {
             binding.edtContactId.setText(id)
             binding.edtContactName.setText(name)
             binding.edtContactEmail.setText(email)
+            allEmailList?.let { emailList ->
+                if (emailList.isNotEmpty()) {
+                    emailList.forEachIndexed { index, email ->
+                        if (index > 4) return
+                        val editText = getOptionalEmailEditText()
+                        editText.setText(email)
+                    }
+                }
+            }
         }
     }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactAddActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactAddActivity.kt
@@ -173,7 +173,7 @@ class ContactAddActivity : BaseActivity() {
             allEmailList?.let { emailList ->
                 if (emailList.isNotEmpty()) {
                     emailList.forEachIndexed { index, email ->
-                        if (index > 4) return
+                        if (index > MAX_OPTIONAL_EMAIL_ADDRESS) return
                         val editText = getOptionalEmailEditText()
                         editText.setText(email)
                     }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactAddActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactAddActivity.kt
@@ -8,6 +8,7 @@ import android.view.Menu
 import android.view.MenuItem
 import android.widget.Toast
 import androidx.databinding.DataBindingUtil
+import com.google.android.material.textfield.TextInputLayout
 import com.google.gson.Gson
 import com.rakuten.tech.mobile.miniapp.js.userinfo.Contact
 import com.rakuten.tech.mobile.miniapp.testapp.R
@@ -18,6 +19,11 @@ import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
 import java.security.SecureRandom
 import java.util.*
+import kotlin.properties.Delegates
+
+
+private const val START_OPTIONAL_EMAIL_EDIT_TEXT_CHILD_INDEX = 3
+private const val MAX_OPTIONAL_EMAIL_ADDRESS = 4
 
 class ContactAddActivity : BaseActivity() {
     override val pageName: String = this::class.simpleName ?: ""
@@ -52,6 +58,11 @@ class ContactAddActivity : BaseActivity() {
     private var contact: Contact? = null
     private var isUpdate = false
     private var position = 0
+    private val optionalEmailList = arrayListOf<String>()
+
+    private var currentOptionalEmailAddressCount by Delegates.observable(0) { _, old, new ->
+        binding.btnAddOptionalEmailField.isEnabled = new < MAX_OPTIONAL_EMAIL_ADDRESS
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -70,6 +81,20 @@ class ContactAddActivity : BaseActivity() {
         }
         renderScreen()
 
+        binding.btnAddOptionalEmailField.setOnClickListener {
+            addOptionalEmailView()
+            currentOptionalEmailAddressCount += 1
+        }
+    }
+
+
+    private fun addOptionalEmailView() {
+        val inflatedView = layoutInflater.inflate(
+            R.layout.item_optional_email_address,
+            null,
+            false
+        ) as TextInputLayout
+        binding.layoutFields.addView(inflatedView)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -92,16 +117,39 @@ class ContactAddActivity : BaseActivity() {
         }
     }
 
+    private fun isOptionalEmailValid(): Boolean {
+        val childCount = binding.layoutFields.childCount
+
+        for (i in START_OPTIONAL_EMAIL_EDIT_TEXT_CHILD_INDEX until childCount) {
+            with(binding.layoutFields.getChildAt(i)) {
+                val text = (this as TextInputLayout).editText?.text.toString()
+                text.let {
+                    return isOptionalEmailTextValid(it)
+                }
+            }
+        }
+        return true
+    }
+
+    private fun isOptionalEmailTextValid(email: String): Boolean {
+        if (email.isBlank() || !email.isEmailValid()) {
+            showContactInputWarning(getString(R.string.userdata_error_invalid_contact_email))
+            return false
+        }
+        optionalEmailList.add(email)
+        return true
+    }
+
     private fun onSaveAction() {
-        if (!isVerifiedContact()) {
+        if (!isVerifiedContact() || !isOptionalEmailValid()) {
             return
         }
-        // TODO: Need to update the all emailList from empty to valid.
+
         contact = Contact(
             id = binding.edtContactId.text.toString(),
             email = binding.edtContactEmail.text.toString(),
             name = binding.edtContactName.text.toString(),
-            allEmailList = emptyList()
+            allEmailList = optionalEmailList
         )
         val returnIntent = Intent().apply {
             putExtra(contactTag, Gson().toJson(contact))
@@ -157,12 +205,18 @@ class ContactAddActivity : BaseActivity() {
     }
 
     private fun createRandomContact(): Contact {
-        val firstName = ContactHelper.fakeFirstNames[(SecureRandom().nextDouble() * ContactHelper.fakeFirstNames.size).toInt()]
-        val lastName = ContactHelper.fakeLastNames[(SecureRandom().nextDouble() * ContactHelper.fakeLastNames.size).toInt()]
+        val firstName =
+            ContactHelper.fakeFirstNames[(SecureRandom().nextDouble() * ContactHelper.fakeFirstNames.size).toInt()]
+        val lastName =
+            ContactHelper.fakeLastNames[(SecureRandom().nextDouble() * ContactHelper.fakeLastNames.size).toInt()]
         val email =
-            firstName.toLowerCase(Locale.ROOT) + "." + lastName.toLowerCase(Locale.ROOT) + "@example.com"
-        // TODO: Need to update the all emailList from empty to valid.
-        return Contact(UUID.randomUUID().toString().trimEnd(), "$firstName $lastName", email, emptyList())
+            firstName.lowercase(Locale.ROOT) + "." + lastName.lowercase(Locale.ROOT) + "@example.com"
+        return Contact(
+            UUID.randomUUID().toString().trimEnd(),
+            "$firstName $lastName",
+            email,
+            emptyList()
+        )
     }
 
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactAddActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactAddActivity.kt
@@ -61,7 +61,7 @@ class ContactAddActivity : BaseActivity() {
     private var position = 0
     private val optionalEmailList = arrayListOf<String>()
 
-    private var currentOptionalEmailAddressCount by Delegates.observable(0) { _, old, new ->
+    private var currentOptionalEmailAddressCount by Delegates.observable(0) { _, _, new ->
         binding.btnAddOptionalEmailField.isEnabled = new < MAX_OPTIONAL_EMAIL_ADDRESS
     }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactAddActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactAddActivity.kt
@@ -123,9 +123,7 @@ class ContactAddActivity : BaseActivity() {
         for (i in START_OPTIONAL_EMAIL_EDIT_TEXT_CHILD_INDEX until childCount) {
             with(binding.layoutFields.getChildAt(i)) {
                 val text = (this as TextInputLayout).editText?.text.toString()
-                text.let {
-                    return isOptionalEmailTextValid(it)
-                }
+                return isOptionalEmailTextValid(text)
             }
         }
         return true

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactAddActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactAddActivity.kt
@@ -134,11 +134,13 @@ class ContactAddActivity : BaseActivity() {
     }
 
     private fun isOptionalEmailTextValid(email: String): Boolean {
-        if (email.isBlank() || !email.isEmailValid()) {
-            showContactInputWarning(getString(R.string.userdata_error_invalid_contact_email))
-            return false
+        if (email.isNotBlank()) {
+            if (!email.isEmailValid()) {
+                showContactInputWarning(getString(R.string.userdata_error_invalid_contact_email))
+                return false
+            }
+            optionalEmailList.add(email)
         }
-        optionalEmailList.add(email)
         return true
     }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactAddActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactAddActivity.kt
@@ -88,7 +88,6 @@ class ContactAddActivity : BaseActivity() {
         }
     }
 
-
     private fun addOptionalEmailView() {
         val inflatedView = layoutInflater.inflate(
             R.layout.item_optional_email_address,

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactListAdapter.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactListAdapter.kt
@@ -9,7 +9,8 @@ import com.rakuten.tech.mobile.miniapp.js.userinfo.Contact
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.ItemListContactBinding
 
-class ContactListAdapter(private val contactListener: ContactListener) : RecyclerView.Adapter<ContactListAdapter.ViewHolder?>(),
+class ContactListAdapter(private val contactListener: ContactListener) :
+    RecyclerView.Adapter<ContactListAdapter.ViewHolder?>(),
     ContactAdapterPresenter {
     private var contactEntries = ArrayList<Contact>()
 
@@ -24,9 +25,14 @@ class ContactListAdapter(private val contactListener: ContactListener) : Recycle
         bindNonVisibleView("Id: ", contact.id, holder.contactId)
         bindNonVisibleView("Name: ", contact.name, holder.contactName)
         bindNonVisibleView("Email: ", contact.email, holder.contactEmail)
+        bindNonVisibleView(
+            "Optional Email(s): ",
+            contact.allEmailList?.joinToString(),
+            holder.contactOptionalEmail
+        )
 
         holder.contactRemoveButton.setOnClickListener { removeContactAt(position) }
-        holder.rootView.setOnClickListener{
+        holder.rootView.setOnClickListener {
             contactListener.onContactItemClick(position)
         }
     }
@@ -34,7 +40,8 @@ class ContactListAdapter(private val contactListener: ContactListener) : Recycle
     private fun bindNonVisibleView(prefix: String, text: String?, holderView: TextView) {
         if (text != null) {
             holderView.visibility = View.VISIBLE
-            holderView.text = holderView.context.getString(R.string.prefix_placeholder, prefix, text)
+            holderView.text =
+                holderView.context.getString(R.string.prefix_placeholder, prefix, text)
         } else
             holderView.visibility = View.GONE
     }
@@ -64,10 +71,12 @@ class ContactListAdapter(private val contactListener: ContactListener) : Recycle
 
     override fun provideContactEntries() = contactEntries
 
-    inner class ViewHolder(itemView: ItemListContactBinding) : RecyclerView.ViewHolder(itemView.root) {
+    inner class ViewHolder(itemView: ItemListContactBinding) :
+        RecyclerView.ViewHolder(itemView.root) {
         val contactId = itemView.tvId
         val contactName = itemView.tvName
         val contactEmail = itemView.tvEmail
+        val contactOptionalEmail = itemView.tvOptionalEmail
         val contactRemoveButton = itemView.buttonRemoveContact
         val rootView = itemView.root
     }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactListAdapter.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactListAdapter.kt
@@ -25,11 +25,19 @@ class ContactListAdapter(private val contactListener: ContactListener) :
         bindNonVisibleView("Id: ", contact.id, holder.contactId)
         bindNonVisibleView("Name: ", contact.name, holder.contactName)
         bindNonVisibleView("Email: ", contact.email, holder.contactEmail)
-        bindNonVisibleView(
-            "Optional Email(s): ",
-            contact.allEmailList?.joinToString(),
-            holder.contactOptionalEmail
-        )
+
+        with(contact.allEmailList) {
+            if(isNullOrEmpty()) {
+                holder.contactOptionalEmail.visibility = View.GONE
+            } else {
+                bindNonVisibleView(
+                    "Optional Email(s): ",
+                    joinToString(),
+                    holder.contactOptionalEmail
+                )
+            }
+        }
+
 
         holder.contactRemoveButton.setOnClickListener { removeContactAt(position) }
         holder.rootView.setOnClickListener {

--- a/testapp/src/main/res/layout/activity_contact_add.xml
+++ b/testapp/src/main/res/layout/activity_contact_add.xml
@@ -4,68 +4,98 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_root"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:paddingTop="@dimen/small_12"
+        android:layout_height="wrap_content"
         android:paddingHorizontal="@dimen/small_12"
+        android:paddingTop="@dimen/small_12"
         tools:context="com.rakuten.tech.mobile.testapp.ui.userdata.ContactAddActivity">
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/tilContactId"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:endIconMode="clear_text"
+            android:layout_height="match_parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
-            <androidx.appcompat.widget.AppCompatEditText
-                android:id="@+id/edtContactId"
+
+            <LinearLayout
+                android:id="@+id/layout_fields"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/small_4"
-                android:hint="@string/userdata_contact_id"
-                android:imeOptions="actionNext"
-                android:inputType="text" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/tilContactName"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:endIconMode="clear_text"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tilContactId">
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilContactId"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:endIconMode="clear_text">
 
-            <androidx.appcompat.widget.AppCompatEditText
-                android:id="@+id/edtContactName"
+                    <androidx.appcompat.widget.AppCompatEditText
+                        android:id="@+id/edtContactId"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/small_4"
+                        android:hint="@string/userdata_contact_id"
+                        android:imeOptions="actionNext"
+                        android:inputType="text" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilContactName"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:endIconMode="clear_text">
+
+                    <androidx.appcompat.widget.AppCompatEditText
+                        android:id="@+id/edtContactName"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/small_4"
+                        android:hint="@string/userdata_contact_name"
+                        android:imeOptions="actionNext"
+                        android:inputType="text" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilContactEmail"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:endIconMode="clear_text">
+
+                    <androidx.appcompat.widget.AppCompatEditText
+                        android:id="@+id/edtContactEmail"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/small_4"
+                        android:hint="@string/userdata_contact_email"
+                        android:imeOptions="actionDone"
+                        android:inputType="textEmailAddress" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+            </LinearLayout>
+
+            <com.rakuten.tech.mobile.testapp.analytics.rat_wrapper.RATButton
+                android:id="@+id/btnAddOptionalEmailField"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/small_4"
-                android:hint="@string/userdata_contact_name"
-                android:imeOptions="actionNext"
-                android:inputType="text" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:layout_height="@dimen/large_44"
+                android:layout_margin="@dimen/medium_16"
+                android:background="@drawable/bg_red_curve"
+                android:gravity="center"
+                android:padding="@dimen/small_4"
+                android:text="@string/add_new_email"
+                android:textColor="@android:color/white"
+                android:textSize="@dimen/text_large_16"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/layout_fields"
+                app:pageName="Add Contact"
+                app:siteSection="Contacts" />
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/tilContactEmail"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:endIconMode="clear_text"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tilContactName">
-
-            <androidx.appcompat.widget.AppCompatEditText
-                android:id="@+id/edtContactEmail"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/small_4"
-                android:hint="@string/userdata_contact_email"
-                android:imeOptions="actionDone"
-                android:inputType="textEmailAddress" />
-        </com.google.android.material.textfield.TextInputLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/testapp/src/main/res/layout/item_list_contact.xml
+++ b/testapp/src/main/res/layout/item_list_contact.xml
@@ -57,6 +57,15 @@
           android:textSize="@dimen/text_small_12"
           tools:text="Contacts email" />
 
+      <androidx.appcompat.widget.AppCompatTextView
+          android:id="@+id/tvOptionalEmail"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:ellipsize="end"
+          android:textColor="@android:color/black"
+          android:textSize="@dimen/text_small_12"
+          tools:text="Optional emails" />
+
     </LinearLayout>
 
     <ImageView

--- a/testapp/src/main/res/layout/item_optional_email_address.xml
+++ b/testapp/src/main/res/layout/item_optional_email_address.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.textfield.TextInputLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:endIconMode="clear_text">
+
+    <androidx.appcompat.widget.AppCompatEditText
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/small_4"
+        android:hint="@string/userdata_email_address_optional"
+        android:imeOptions="actionDone"
+        android:inputType="textEmailAddress" />
+
+</com.google.android.material.textfield.TextInputLayout>
+

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="userdata_contact_id">Contact id</string>
     <string name="userdata_contact_name">Contact name</string>
     <string name="userdata_contact_email">Contact email</string>
+    <string name="userdata_email_address_optional">Email Address (Optional)</string>
 
     <string name="miniapp_preload_tutorial">Would you like to download this miniapp?</string>
     <string name="miniapp_preload_perm_status_required">(Required)</string>
@@ -131,5 +132,6 @@
     <string name="please_input_the_message">Please input the message</string>
     <string name="error_send_json_to_mini_app_message_cannot_be_empty">Unable to send the message: The message cannot be empty</string>
     <string name="lb_general">General</string>
+    <string name="add_new_email">Add new email</string>
 
 </resources>


### PR DESCRIPTION
# Description
Support multiple emails, including mandatory email, that would be 5 max.

Adding fields with Email Address(optional) placeholder text.
Validate the email address added in these text fields if it's not blank
If it's blank, the email address (optional) list wouldn't count.


## Links
[MINI-5828](https://jira.rakuten-it.com/jira/browse/MINI-5828)

## Video
https://rak.box.com/s/1lcz3fc53hb6zrl4kvt7f1zh8anmbwct

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
