### PR TITLE
[MINI-5859] Remove sorting from saving custom permission

### DIFF
--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
@@ -115,14 +115,6 @@ internal class MiniAppCustomPermissionCache constructor(
         prefs.edit().putString(miniAppCustomPermission.miniAppId, jsonToStore).apply()
     }
 
-    // Sort the `pairValues` by ordinal of [MiniAppCustomPermissionType].
-    // [NOT_USED]
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun sortedByDefault(miniAppCustomPermission: MiniAppCustomPermission): MiniAppCustomPermission {
-        val sortedPairValues = miniAppCustomPermission.pairValues.sortedBy { it.first.ordinal }
-        return MiniAppCustomPermission(miniAppCustomPermission.miniAppId, sortedPairValues)
-    }
-
     /**
      * Prepare all the permissions supplied from HostApp including the permissions which was already
      * cached. It removes the old cached results if HostApp supplies the new results.

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCache.kt
@@ -111,11 +111,12 @@ internal class MiniAppCustomPermissionCache constructor(
 
     @VisibleForTesting
     fun applyStoringPermissions(miniAppCustomPermission: MiniAppCustomPermission) {
-        val jsonToStore: String = Gson().toJson(sortedByDefault(miniAppCustomPermission))
+        val jsonToStore: String = Gson().toJson(miniAppCustomPermission)
         prefs.edit().putString(miniAppCustomPermission.miniAppId, jsonToStore).apply()
     }
 
     // Sort the `pairValues` by ordinal of [MiniAppCustomPermissionType].
+    // [NOT_USED]
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun sortedByDefault(miniAppCustomPermission: MiniAppCustomPermission): MiniAppCustomPermission {
         val sortedPairValues = miniAppCustomPermission.pairValues.sortedBy { it.first.ordinal }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
@@ -97,10 +97,10 @@ class MiniAppCustomPermissionCacheSpec {
     }
 
     @Test
-    fun `applyStoringPermissions will invoke sortedByDefault to save value`() {
+    fun `applyStoringPermissions will not invoke sortedByDefault to save value`() {
         miniAppCustomPermissionCache.applyStoringPermissions(miniAppCustomPermission)
         assertTrue(prefs.all.contains(miniAppCustomPermission.miniAppId))
-        verify(miniAppCustomPermissionCache).sortedByDefault(miniAppCustomPermission)
+        verify(miniAppCustomPermissionCache, never()).sortedByDefault(miniAppCustomPermission)
     }
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
@@ -14,9 +14,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.mockito.kotlin.never
 import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 @Suppress("LongMethod", "LargeClass")
 @RunWith(AndroidJUnit4::class)
@@ -95,33 +93,6 @@ class MiniAppCustomPermissionCacheSpec {
 
         verify(miniAppCustomPermissionCache).prepareAllPermissionsToStore(TEST_MA_ID, deniedPermissions)
         verify(miniAppCustomPermissionCache).applyStoringPermissions(miniAppCustomPermission)
-    }
-
-    @Test
-    fun `applyStoringPermissions will not invoke sortedByDefault to save value`() {
-        miniAppCustomPermissionCache.applyStoringPermissions(miniAppCustomPermission)
-        assertTrue(prefs.all.contains(miniAppCustomPermission.miniAppId))
-        verify(miniAppCustomPermissionCache, never()).sortedByDefault(miniAppCustomPermission)
-    }
-
-    @Test
-    fun `orderByDefaultList should return correct ordering by MiniAppCustomPermissionType`() {
-        val unorderedPermission = MiniAppCustomPermission(
-            TEST_MA_ID,
-            listOf(
-                Pair(MiniAppCustomPermissionType.USER_NAME, MiniAppCustomPermissionResult.DENIED),
-                Pair(MiniAppCustomPermissionType.CONTACT_LIST, MiniAppCustomPermissionResult.DENIED),
-                Pair(MiniAppCustomPermissionType.LOCATION, MiniAppCustomPermissionResult.DENIED),
-                Pair(MiniAppCustomPermissionType.PROFILE_PHOTO, MiniAppCustomPermissionResult.DENIED)
-            )
-        )
-
-        val actual = miniAppCustomPermissionCache.sortedByDefault(unorderedPermission)
-
-        actual.pairValues[0].first shouldBeEqualTo MiniAppCustomPermissionType.USER_NAME
-        actual.pairValues[1].first shouldBeEqualTo MiniAppCustomPermissionType.PROFILE_PHOTO
-        actual.pairValues[2].first shouldBeEqualTo MiniAppCustomPermissionType.CONTACT_LIST
-        actual.pairValues[3].first shouldBeEqualTo MiniAppCustomPermissionType.LOCATION
     }
 
     /**

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/permission/MiniAppCustomPermissionCacheSpec.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.mockito.kotlin.never
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppPermissionAdapter.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/preload/PreloadMiniAppPermissionAdapter.kt
@@ -69,8 +69,10 @@ class PreloadMiniAppPermissionAdapter :
         this.manifestPermissions = manifestPermissions
         if (shouldShowDialog) {
             val customPermissionResultList = miniApp.getCustomPermissions(miniAppId).pairValues
-            this.manifestPermissions.forEachIndexed { position, (_, _) ->
-                manifestPermissionPairs.add(position, customPermissionResultList[position])
+            manifestPermissions.forEach { manifestPermission ->
+                customPermissionResultList.find { (permissionType) ->
+                    manifestPermission.type == permissionType
+                }?.let { manifestPermissionPairs.add(Pair(manifestPermission.type, it.second)) }
             }
         } else {
             this.manifestPermissions.forEachIndexed { position, (type, _) ->


### PR DESCRIPTION
# Description
 Custom permission SHOULD NOT be sorted .

## Links
MINI-5859

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
