### PR TITLE
[MINI-5883] Disable double click on settings cog

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/AppHelper.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/AppHelper.kt
@@ -215,3 +215,14 @@ fun delayUIThread(durationInMillis: Long = 3500L, onFinished: () -> Unit) {
 fun Context.showToastMessage(text: String, duration: Int = Toast.LENGTH_LONG) {
     Toast.makeText(this, text, duration).show()
 }
+
+private var DELAY_MILLIS = 1000
+fun singleSafeClick(
+    previousClickTimeMillis: Long,
+    block: (previousClickTimeMillis: Long) -> Unit
+) {
+    val currentTimeMillis = System.currentTimeMillis()
+    if (currentTimeMillis < previousClickTimeMillis || currentTimeMillis >= previousClickTimeMillis + DELAY_MILLIS) {
+        block(currentTimeMillis)
+    }
+}

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/display/MiniAppDisplayActivity.kt
@@ -93,6 +93,7 @@ class MiniAppDisplayActivity : BaseActivity(), PreloadMiniAppWindow.PreloadMiniA
 
     private var appInfo: MiniAppInfo? = null
     private var appUrl: String? = null
+    private var previousClickTimeMillis = 0L
 
     companion object {
         private const val appIdTag = "app_id_tag"
@@ -169,7 +170,10 @@ class MiniAppDisplayActivity : BaseActivity(), PreloadMiniAppWindow.PreloadMiniA
                 true
             }
             R.id.settings_permission_mini_app -> {
-                launchCustomPermissionDialog()
+                singleSafeClick(previousClickTimeMillis) { tappedTime ->
+                    previousClickTimeMillis = tappedTime
+                    launchCustomPermissionDialog()
+                }
                 true
             }
             else -> super.onOptionsItemSelected(item)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/MiniAppDisplayFragment.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/fragments/MiniAppDisplayFragment.kt
@@ -69,6 +69,7 @@ class MiniAppDisplayFragment : BaseFragment(), PreloadMiniAppWindow.PreloadMiniA
     private lateinit var miniAppFileChooser: MiniAppFileChooserDefault
     private lateinit var miniAppFileDownloader: MiniAppFileDownloaderDefault
     private val preloadMiniAppWindow by lazy { PreloadMiniAppWindow(requireActivity(), this) }
+    private var previousClickTimeMillis = 0L
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -389,7 +390,10 @@ class MiniAppDisplayFragment : BaseFragment(), PreloadMiniAppWindow.PreloadMiniA
                 true
             }
             R.id.settings_permission_mini_app -> {
-                launchCustomPermissionDialog()
+                singleSafeClick(previousClickTimeMillis) { tappedTime ->
+                    previousClickTimeMillis = tappedTime
+                    launchCustomPermissionDialog()
+                }
                 true
             }
             else -> super.onOptionsItemSelected(item)


### PR DESCRIPTION
# Description
Error: Permission displayed twice because of faster clicks
Solution: Added delay after first click.

## Links
MINI-5883

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
