### PR TITLE
[MINI-5882] Fix back operation on top page

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/DemoAppMainActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/DemoAppMainActivity.kt
@@ -15,7 +15,10 @@ import com.rakuten.tech.mobile.miniapp.view.MiniAppView
 import com.rakuten.tech.mobile.testapp.helper.clearAllCursorFocus
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
 import com.rakuten.tech.mobile.testapp.ui.miniapptabs.extensions.setupWithNavController
+import com.rakuten.tech.mobile.testapp.ui.miniapptabs.fragments.FeaturesFragment
 import com.rakuten.tech.mobile.testapp.ui.miniapptabs.fragments.MiniAppDisplayFragment
+import com.rakuten.tech.mobile.testapp.ui.miniapptabs.fragments.MiniAppListFragment
+import com.rakuten.tech.mobile.testapp.ui.miniapptabs.fragments.SettingsFragment
 import com.rakuten.tech.mobile.testapp.ui.settings.AppSettings
 import kotlinx.android.synthetic.main.mini_app_main_layout.*
 
@@ -152,9 +155,15 @@ class DemoAppMainActivity : BaseActivity() {
 
     override fun onBackPressed() {
         getCurrentVisibleFragment()?.let { fragment ->
-            if (fragment is MiniAppDisplayFragment) {
-                fragment.onBackPressed()
-            } else super.onBackPressed()
+            when (fragment) {
+                is MiniAppDisplayFragment -> {
+                    fragment.onBackPressed()
+                }
+                is MiniAppListFragment, is FeaturesFragment, is SettingsFragment -> {
+                    finish()
+                }
+                else -> super.onBackPressed()
+            }
         }
     }
 


### PR DESCRIPTION
Added condition on back button press when at top page. Application will be close if user is at the top page and press device's back button.

## Links
MINI-5882

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
