### PR TITLE
[MINI-5953] Add sendJson public interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### 5.2.0 (xxxx-xx-xx)
+**SDK**
+- **Feature:** Added `MiniAppDisplay.sendJsonToHostApp` interface to provide `Universal Bridge` for sending messages from a MiniApp to the HostApp.
+
 ### 5.1.0 (2023-02-06)
 **SDK**
 - **Feature:** Added `MiniAppMessageBridge.sendJsonToHostApp` interface to provide `Universal Bridge` for sending messages from a MiniApp to the HostApp.

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -254,6 +254,8 @@ There are several different types of exceptions which could be thrown by `MiniAp
 You can handle each exception type differently if you would like different behavior for different cases.
 For example you may wish to display a different error message when the server contains no published versions of a mini app.
 See the full list of exceptions in the [API docs](api/com.rakuten.tech.mobile.miniapp/-mini-app/create.html).
+* **Universal Bridge:** 
+Sending data from host app to miniapp. `MiniAppDisplay.sendJsonToHostApp` is required to be called when host app wants to send data to miniapp.
 
 ## Mini App Features
 **API Docs:** [MiniAppMessageBridge](api/com.rakuten.tech.mobile.miniapp.js/-mini-app-message-bridge)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniAppDisplay.kt
@@ -43,4 +43,11 @@ interface MiniAppDisplay : LifecycleObserver {
      * Navigates one level forward from current position, in the call hierarchy, if possible.
      */
     fun navigateForward(): Boolean
+
+    /**
+     * Send a generic message to MiniApp using
+     * [com.rakuten.tech.mobile.miniapp.js.NativeEventType.MINIAPP_RECEIVE_JSON_INFO].
+     * @param message the content that will send to the MiniApp
+     */
+    fun sendJsonToMiniApp(message: String)
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplay.kt
@@ -19,6 +19,7 @@ import com.rakuten.tech.mobile.miniapp.js.MessageBridgeRatDispatcher
 import com.rakuten.tech.mobile.miniapp.navigator.MiniAppNavigator
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.miniapp.js.MiniAppSecureStorageDispatcher
+import com.rakuten.tech.mobile.miniapp.js.NativeEventType
 import com.rakuten.tech.mobile.miniapp.permission.MiniAppCustomPermissionCache
 import com.rakuten.tech.mobile.miniapp.sdkExceptionForNoActivityContext
 import com.rakuten.tech.mobile.miniapp.storage.DownloadedManifestCache
@@ -127,6 +128,10 @@ internal class RealMiniAppDisplay(
             else -> false
         }
     } else false
+
+    override fun sendJsonToMiniApp(message: String) {
+        miniAppMessageBridge.dispatchNativeEvent(NativeEventType.MINIAPP_RECEIVE_JSON_INFO, message)
+    }
 
     @Suppress("LongMethod")
     private suspend fun provideMiniAppWebView(context: Context): MiniAppWebView =

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplaySpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/display/RealMiniAppDisplaySpec.kt
@@ -16,6 +16,7 @@ import com.rakuten.tech.mobile.miniapp.analytics.Actype
 import com.rakuten.tech.mobile.miniapp.analytics.Etype
 import com.rakuten.tech.mobile.miniapp.analytics.MiniAppAnalytics
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
+import com.rakuten.tech.mobile.miniapp.js.NativeEventType
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.*
@@ -180,5 +181,14 @@ class RealMiniAppDisplaySpec {
 
         displayer.navigateBackward() shouldBe true
         displayer.navigateForward() shouldBe true
+    }
+
+    @Test
+    fun `sendJsonToMiniApp should invoke dipatch event`() = runBlockingTest {
+        realDisplay.sendJsonToMiniApp(TEST_BODY_CONTENT)
+        verify(miniAppMessageBridge).dispatchNativeEvent(
+            NativeEventType.MINIAPP_RECEIVE_JSON_INFO,
+            TEST_BODY_CONTENT
+        )
     }
 }


### PR DESCRIPTION
# Description
Add sendJson public interface to send data to miniapp

## Links
MINI-5359

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
