### PR TITLE
[MINI-6110] Fix Miniapp loading issue

### DIFF
--- a/in-app-purchase/src/main/java/com/rakuten/tech/mobile/miniapp/iap/InAppPurchaseProviderDefault.kt
+++ b/in-app-purchase/src/main/java/com/rakuten/tech/mobile/miniapp/iap/InAppPurchaseProviderDefault.kt
@@ -38,20 +38,16 @@ class InAppPurchaseProviderDefault(
     private val purchasesUpdatedListener =
         PurchasesUpdatedListener { billingResult, purchases ->
             when {
-                billingResult.responseCode == BillingClient.BillingResponseCode.OK && purchases != null -> {
+                billingResult.responseCode == BillingClient.BillingResponseCode.OK && purchases != null ->
                     for (purchase in purchases) {
                         handlePurchase(purchase)
                     }
-                }
-                billingResult.responseCode == BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED -> {
+                billingResult.responseCode == BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED ->
                     if (this::onError.isInitialized) onError(MiniAppInAppPurchaseErrorType.productPurchasedAlreadyError)
-                }
-                billingResult.responseCode == BillingClient.BillingResponseCode.ITEM_UNAVAILABLE -> {
+                billingResult.responseCode == BillingClient.BillingResponseCode.ITEM_UNAVAILABLE ->
                     if (this::onError.isInitialized) onError(MiniAppInAppPurchaseErrorType.productNotFoundError)
-                }
-                billingResult.responseCode == BillingClient.BillingResponseCode.USER_CANCELED -> {
+                billingResult.responseCode == BillingClient.BillingResponseCode.USER_CANCELED ->
                     if (this::onError.isInitialized) onError(MiniAppInAppPurchaseErrorType.userCancelledPurchaseError)
-                }
                 this::onError.isInitialized -> onError(MiniAppInAppPurchaseErrorType.purchaseFailedError)
             }
         }
@@ -151,8 +147,9 @@ class InAppPurchaseProviderDefault(
         return skuDetailsList
     }
 
+    @Suppress("FunctionMaxLength")
     private fun createProductListFromSKuDetailList(skuDetailsList: List<SkuDetails>): List<ProductInfo> {
-        var productInfoList = ArrayList<ProductInfo>()
+        val productInfoList = ArrayList<ProductInfo>()
         for (skuDetails in skuDetailsList) {
             val productPrice = ProductPrice(skuDetails.priceCurrencyCode, skuDetails.price)
             val productInfo = ProductInfo(
@@ -211,9 +208,7 @@ class InAppPurchaseProviderDefault(
         val params = ConsumeParams.newBuilder().setPurchaseToken(purchaseToken).build()
         billingClient.consumeAsync(params) { billingResult, _ ->
             when (billingResult.responseCode) {
-                BillingClient.BillingResponseCode.OK -> {
-                    onConsumeSuccess("Success", "Product consume successfully")
-                }
+                BillingClient.BillingResponseCode.OK -> onConsumeSuccess("Success", "Product consume successfully")
                 else -> onError(MiniAppInAppPurchaseErrorType.consumeFailedError)
             }
         }

--- a/in-app-purchase/src/main/java/com/rakuten/tech/mobile/miniapp/iap/InAppPurchaseProviderDefault.kt
+++ b/in-app-purchase/src/main/java/com/rakuten/tech/mobile/miniapp/iap/InAppPurchaseProviderDefault.kt
@@ -37,17 +37,23 @@ class InAppPurchaseProviderDefault(
 
     private val purchasesUpdatedListener =
         PurchasesUpdatedListener { billingResult, purchases ->
-            if (billingResult.responseCode == BillingClient.BillingResponseCode.OK && purchases != null) {
-                for (purchase in purchases) {
-                    handlePurchase(purchase)
+            when {
+                billingResult.responseCode == BillingClient.BillingResponseCode.OK && purchases != null -> {
+                    for (purchase in purchases) {
+                        handlePurchase(purchase)
+                    }
                 }
-            } else if (billingResult.responseCode == BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED) {
-                if (this::onError.isInitialized) onError(MiniAppInAppPurchaseErrorType.productPurchasedAlreadyError)
-            } else if (billingResult.responseCode == BillingClient.BillingResponseCode.ITEM_UNAVAILABLE) {
-                if (this::onError.isInitialized) onError(MiniAppInAppPurchaseErrorType.productNotFoundError)
-            } else if (billingResult.responseCode == BillingClient.BillingResponseCode.USER_CANCELED) {
-                if (this::onError.isInitialized) onError(MiniAppInAppPurchaseErrorType.userCancelledPurchaseError)
-            } else if (this::onError.isInitialized) onError(MiniAppInAppPurchaseErrorType.purchaseFailedError)
+                billingResult.responseCode == BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED -> {
+                    if (this::onError.isInitialized) onError(MiniAppInAppPurchaseErrorType.productPurchasedAlreadyError)
+                }
+                billingResult.responseCode == BillingClient.BillingResponseCode.ITEM_UNAVAILABLE -> {
+                    if (this::onError.isInitialized) onError(MiniAppInAppPurchaseErrorType.productNotFoundError)
+                }
+                billingResult.responseCode == BillingClient.BillingResponseCode.USER_CANCELED -> {
+                    if (this::onError.isInitialized) onError(MiniAppInAppPurchaseErrorType.userCancelledPurchaseError)
+                }
+                this::onError.isInitialized -> onError(MiniAppInAppPurchaseErrorType.purchaseFailedError)
+            }
         }
 
     private val billingClient: BillingClient by lazy {

--- a/in-app-purchase/src/main/java/com/rakuten/tech/mobile/miniapp/iap/MiniAppInAppPurchaseErrorType.kt
+++ b/in-app-purchase/src/main/java/com/rakuten/tech/mobile/miniapp/iap/MiniAppInAppPurchaseErrorType.kt
@@ -6,7 +6,7 @@ import androidx.annotation.Keep
  * A class to provide the custom errors specific for in app purchase.
  */
 @Keep
-class MiniAppInAppPurchaseErrorType(val type: String? = null, val message: String? = null) {
+data class MiniAppInAppPurchaseErrorType(val type: String? = null, val message: String? = null) {
 
     companion object {
         private const val PurchaseFailedError = "PurchaseFailedError"

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/MiniApp.kt
@@ -300,7 +300,8 @@ abstract class MiniApp internal constructor() {
                     miniAppSdkConfig.maxStorageSizeLimitInBytes.toLong()
                 ),
                 enableH5Ads = miniAppSdkConfig.enableH5Ads,
-                initMiniAppIAPVerifier = { MiniAppIAPVerifier(context) }
+                initMiniAppIAPVerifier = { MiniAppIAPVerifier(context) },
+                miniAppSdkConfig = defaultConfig
             )
         }
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/RealMiniApp.kt
@@ -239,7 +239,7 @@ internal class RealMiniApp(
             miniAppDownloader.updateApiClient(it)
             miniAppInfoFetcher.updateApiClient(it)
             if (this::miniAppMessageBridge.isInitialized)
-                miniAppMessageBridge.updateApiClient(it)
+                this.miniAppMessageBridge.updateApiClient(it)
         }
 
         miniAppDownloader.updateRequireSignatureVerification(newConfig.requireSignatureVerification)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -113,7 +113,13 @@ open class MiniAppMessageBridge {
             bridgeExecutor, customPermissionCache, downloadedManifestCache, miniAppId
         )
         chatBridge.setMiniAppComponents(bridgeExecutor, customPermissionCache, miniAppId)
-        iapBridgeDispatcher.setMiniAppComponents(bridgeExecutor, miniAppId, apiClient, miniAppIAPVerifier)
+        if (this::apiClient.isInitialized)
+            iapBridgeDispatcher.setMiniAppComponents(
+                bridgeExecutor,
+                miniAppId,
+                apiClient,
+                miniAppIAPVerifier
+            )
         miniAppViewInitialized = true
     }
 
@@ -525,8 +531,9 @@ open class MiniAppMessageBridge {
         bridgeExecutor.postError(callbackId, ErrorBridgeMessage.ERR_CLOSE_ALERT)
     }
 
-    internal fun setComponentsIAPDispatcher(apiClient: ApiClient) {
+    internal fun updateApiClient(apiClient: ApiClient) {
         this.apiClient = apiClient
+        iapBridgeDispatcher.updateApiClient(apiClient)
     }
 
     /** Allow Host app to receive the miniapp close event. */

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/iap/InAppPurchaseBridgeDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/iap/InAppPurchaseBridgeDispatcher.kt
@@ -356,6 +356,10 @@ internal class InAppPurchaseBridgeDispatcher {
         inAppPurchaseProvider.onEndConnection()
     }
 
+    internal fun updateApiClient(apiClient: ApiClient) {
+        this.apiClient = apiClient
+    }
+
     companion object {
         const val ERR_IN_APP_PURCHASE = "InApp Purchase Error:"
         const val ERR_PRODUCT_ID_INVALID = "Invalid Product Id."

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/view/MiniAppViewHandler.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/view/MiniAppViewHandler.kt
@@ -196,7 +196,7 @@ internal class MiniAppViewHandler(
             miniAppDownloader.getCachedMiniApp(miniAppId)
         }
         verifyManifest(miniAppInfo.id, miniAppInfo.version.versionId, fromCache)
-        config.miniAppMessageBridge.setComponentsIAPDispatcher(apiClient)
+        config.miniAppMessageBridge.updateApiClient(apiClient)
         return displayer.createMiniAppDisplay(
             basePath,
             miniAppInfo,
@@ -225,7 +225,7 @@ internal class MiniAppViewHandler(
             miniAppDownloader.getCachedMiniApp(miniAppInfo)
         }
         verifyManifest(miniAppInfo.id, miniAppInfo.version.versionId, fromCache)
-        config.miniAppMessageBridge.setComponentsIAPDispatcher(apiClient)
+        config.miniAppMessageBridge.updateApiClient(apiClient)
         return displayer.createMiniAppDisplay(
             basePath,
             miniAppInfo,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/RealMiniAppSpec.kt
@@ -69,7 +69,8 @@ open class BaseRealMiniAppSpec {
                 ratDispatcher = ratDispatcher,
                 secureStorageDispatcher = secureStorageDispatcher,
                 enableH5Ads = false,
-                initMiniAppIAPVerifier = { miniAppIAPVerifier }
+                initMiniAppIAPVerifier = { miniAppIAPVerifier },
+                miniAppSdkConfig = miniAppSdkConfig
             ))
 
         When calling apiClientRepository.getApiClientFor(miniAppSdkConfig) itReturns apiClient

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/AdBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/AdBridgeSpec.kt
@@ -44,7 +44,7 @@ class AdBridgeSpec : BridgeCommon() {
         val miniAppBridge = Mockito.spy(createDefaultMiniAppMessageBridge())
         When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,
@@ -114,7 +114,7 @@ class ScreenBridgeSpec : BridgeCommon() {
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
             miniAppBridge.allowScreenOrientation(false)
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,
@@ -142,7 +142,7 @@ class ScreenBridgeSpec : BridgeCommon() {
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
             val miniAppBridge = Mockito.spy(createDefaultMiniAppMessageBridge())
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity, webViewListener, mock(), mock(), TEST_MA_ID, mock(), mock(), mock()
             )
@@ -181,7 +181,7 @@ class ScreenBridgeSpec : BridgeCommon() {
     fun `miniAppShouldClose value should be assigned properly`() {
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
             val miniAppBridge = Mockito.spy(createDefaultMiniAppMessageBridge())
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity, webViewListener, mock(), mock(), TEST_MA_ID, mock(), mock(), mock()
             )

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/CustomPermissionBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/CustomPermissionBridgeSpec.kt
@@ -87,7 +87,7 @@ class CustomPermissionBridgeSpec : BridgeCommon() {
             customPermissionWindow =
                 spy(MiniAppCustomPermissionWindow(activity, customPermissionBridgeDispatcher))
             customPermissionBridgeDispatcher.permissionsAsManifest = customPermissionManifest
-            miniappMessageBridge.setComponentsIAPDispatcher(mock())
+            miniappMessageBridge.updateApiClient(mock())
             miniappMessageBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
@@ -54,7 +54,7 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
     fun setup() {
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,
@@ -82,7 +82,7 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
                 createErrorWebViewListener("${ErrorBridgeMessage.ERR_MESSAGING_UNIQUE_ID} null")
             val bridgeExecutor = Mockito.spy(miniAppBridge.createBridgeExecutor(webViewListener))
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,
@@ -111,7 +111,7 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
             val errMsg = "${ErrorBridgeMessage.ERR_MESSAGING_UNIQUE_ID} $testErrorMessage"
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
             mockIsValid = false
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,
@@ -142,7 +142,7 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
             val webViewListener = createErrorWebViewListener("${ErrorBridgeMessage.ERR_MAUID} null")
             val bridgeExecutor = Mockito.spy(miniAppBridge.createBridgeExecutor(webViewListener))
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,
@@ -165,7 +165,7 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
             val errMsg = "${ErrorBridgeMessage.ERR_MAUID} $testErrorMessage"
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
             mockIsValid = false
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,
@@ -189,7 +189,7 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
             val errMsg = "Denied"
             val webViewListener = createErrorWebViewListener("dummy message")
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,
@@ -215,7 +215,7 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
             val webViewListener =
                 createErrorWebViewListener("${ErrorBridgeMessage.ERR_REQ_DEVICE_PERMISSION} null")
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,
@@ -244,7 +244,7 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
             val webViewListener =
                 createErrorWebViewListener("${ErrorBridgeMessage.ERR_REQ_DEVICE_PERMISSION} null")
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,
@@ -307,7 +307,7 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
             val webViewListener =
                 createErrorWebViewListener("${ErrorBridgeMessage.ERR_REQ_DEVICE_PERMISSION} null")
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/ShareContentBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/ShareContentBridgeSpec.kt
@@ -27,7 +27,7 @@ class ShareContentBridgeSpec : BridgeCommon() {
     fun setupShareInfo() {
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,
@@ -56,7 +56,7 @@ class ShareContentBridgeSpec : BridgeCommon() {
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
             val miniAppBridge = Mockito.spy(createDefaultMiniAppMessageBridge())
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,
@@ -78,7 +78,7 @@ class ShareContentBridgeSpec : BridgeCommon() {
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
             val miniAppBridge = Mockito.spy(createDefaultMiniAppMessageBridge())
             // When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,
@@ -102,7 +102,7 @@ class ShareContentBridgeSpec : BridgeCommon() {
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
             val miniAppBridge = Mockito.spy(createDefaultMiniAppMessageBridge())
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,
@@ -134,7 +134,7 @@ class ShareContentBridgeSpec : BridgeCommon() {
             val webViewListener = createErrorWebViewListener(errMsg)
             val bridgeExecutor = Mockito.spy(miniAppBridge.createBridgeExecutor(webViewListener))
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,
@@ -153,7 +153,7 @@ class ShareContentBridgeSpec : BridgeCommon() {
 
     @Test
     fun `postValue should not be called when using default method without Activity`() {
-        miniAppBridge.setComponentsIAPDispatcher(mock())
+        miniAppBridge.updateApiClient(mock())
         miniAppBridge.init(
             activity = TestFilesDirActivity(),
             webViewListener = webViewListener,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/UniversalBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/UniversalBridgeSpec.kt
@@ -47,7 +47,7 @@ class UniversalBridgeSpec : BridgeCommon() {
     fun setUp() {
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,
@@ -135,7 +135,7 @@ class UniversalBridgeSpec : BridgeCommon() {
                 any(),
                 any()
             ) itThrows RuntimeException()
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,
@@ -165,7 +165,7 @@ class UniversalBridgeSpec : BridgeCommon() {
                 org.amshove.kluent.any(),
                 org.amshove.kluent.any()
             ) itThrows RuntimeException()
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,
@@ -240,7 +240,7 @@ class UniversalBridgeSpec : BridgeCommon() {
     fun `bridgeExecutor postValue should not be called if it is not initialized`() {
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
             val miniAppBridge = Mockito.spy(createDefaultMiniAppMessageBridge())
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/chat/ChatBridgeDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/chat/ChatBridgeDispatcherSpec.kt
@@ -44,7 +44,7 @@ open class BaseChatBridgeDispatcherSpec {
         miniAppBridge = Mockito.spy(createMessageBridge())
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostEnvironmentInfoBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostEnvironmentInfoBridgeSpec.kt
@@ -27,7 +27,7 @@ class HostEnvironmentInfoBridgeSpec : BridgeCommon() {
     fun setup() {
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,
@@ -59,7 +59,7 @@ class HostEnvironmentInfoBridgeSpec : BridgeCommon() {
             )
             val miniAppBridge = Mockito.spy(createDefaultMiniAppMessageBridge())
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                     activity = activity,
                     webViewListener = webViewListener,
@@ -84,7 +84,7 @@ class HostEnvironmentInfoBridgeSpec : BridgeCommon() {
             val webViewListener = createErrorWebViewListener(infoErrMessage)
             val bridgeExecutor = Mockito.spy(miniAppBridge.createBridgeExecutor(webViewListener))
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/securestoragedispatcher/MessageBridgeSecurestorageDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/securestoragedispatcher/MessageBridgeSecurestorageDispatcherSpec.kt
@@ -56,7 +56,7 @@ class MessageBridgeSecurestorageDispatcherSpec : BridgeCommon() {
             miniAppSecureStorageDispatcher.setMiniAppComponents(TEST_MA_ID)
 
             When calling miniappMessageBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniappMessageBridge.setComponentsIAPDispatcher(mock())
+            miniappMessageBridge.updateApiClient(mock())
             miniappMessageBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/userinfo/UserInfoBridgeSpec.kt
@@ -80,7 +80,7 @@ class UserInfoBridgeSpec {
         ActivityScenario.launch(TestActivity::class.java).onActivity { activity ->
             miniAppBridge = Mockito.spy(createMessageBridge())
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/view/MiniAppViewImplSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/view/MiniAppViewImplSpec.kt
@@ -46,7 +46,7 @@ class MiniAppViewImplSpec {
     fun setUp() {
         withRealActivity { activity ->
             When calling miniAppBridge.createBridgeExecutor(webViewListener) itReturns bridgeExecutor
-            miniAppBridge.setComponentsIAPDispatcher(mock())
+            miniAppBridge.updateApiClient(mock())
             miniAppBridge.init(
                 activity = activity,
                 webViewListener = webViewListener,

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactAddActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/ContactAddActivity.kt
@@ -189,18 +189,23 @@ class ContactAddActivity : BaseActivity() {
         val name = binding.edtContactName.text.toString()
         val email = binding.edtContactEmail.text.toString()
 
-        if (id.isEmpty()) {
-            isVerified = false
-            showContactInputWarning(getString(R.string.userdata_error_empty_contact_id))
-        } else if (name.isEmpty() && email.isNotEmpty()) {
-            isVerified = false
-            showContactInputWarning(getString(R.string.userdata_error_empty_contact_name))
-        } else if (email.isEmpty() && name.isNotEmpty()) {
-            isVerified = false
-            showContactInputWarning(getString(R.string.userdata_error_empty_contact_email))
-        } else if (name.isEmpty() && email.isEmpty()) {
-            isVerified = false
-            showContactInputWarning(getString(R.string.userdata_error_empty_contact_name_email))
+        when {
+            id.isEmpty() -> {
+                isVerified = false
+                showContactInputWarning(getString(R.string.userdata_error_empty_contact_id))
+            }
+            name.isEmpty() && email.isNotEmpty() -> {
+                isVerified = false
+                showContactInputWarning(getString(R.string.userdata_error_empty_contact_name))
+            }
+            email.isEmpty() && name.isNotEmpty() -> {
+                isVerified = false
+                showContactInputWarning(getString(R.string.userdata_error_empty_contact_email))
+            }
+            name.isEmpty() && email.isEmpty() -> {
+                isVerified = false
+                showContactInputWarning(getString(R.string.userdata_error_empty_contact_name_email))
+            }
         }
 
         if (email.isNotEmpty() && !email.isEmailValid()) {


### PR DESCRIPTION
# Description
MiniApp was not loading if it uses the old architecture. This PR includes that fix.

## Links
MINI-6110

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
