### PR TITLE
[MINI-6077] interface primary seconday color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## CHANGELOG
 
+### 5.x.x (xxxx-xx-xx)
+**SDK**
+- **Feature:** Added `MiniAppMessageBridge.getHostAppThemeColors` in MiniAppMessageBridge for retrieving primary and secondary theme color.
+
+**Sample App**
+- **Feature:** Added implementation of `MiniAppMessageBridge.getHostAppThemeColors`.
+- **Feature:** Added qa settings to test primary and secondary color.
+
 ### 5.2.0 (2023-04-06)
 **SDK**
 - **Feature:** Added `in-app-purchase` module to support android billing sdk.

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -368,10 +368,10 @@ val miniAppMessageBridge = object: MiniAppMessageBridge() {
     }
 
     override fun getHostAppThemeColors(
-        onSuccess: (themeColor: HostThemeColor) -> Unit,
+        onSuccess: (themeColor: HostAppThemeColors) -> Unit,
         onError: (message: String) -> Unit
     ) {
-        onSuccess(HostThemeColor(primaryColor = "", secondaryColor = ""))
+        onSuccess(HostAppThemeColors(primaryColor = "", secondaryColor = ""))
     }
         
 }

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -273,6 +273,7 @@ There are some methods have a default implementation but the host app can overri
 | shareContent                 | ✅       |
 | getHostEnvironmentInfo       | ✅       |
 | sendJsonToHostApp            | 🚫       |
+| getHostAppThemeColors        | 🚫       |
 
 The `UserInfoBridgeDispatcher`:
 
@@ -364,6 +365,13 @@ val miniAppMessageBridge = object: MiniAppMessageBridge() {
         } else {
             onError(jsonStr)
         }
+    }
+
+    override fun getHostAppThemeColors(
+        onSuccess: (themeColor: HostThemeColor) -> Unit,
+        onError: (message: String) -> Unit
+    ) {
+        onSuccess(HostThemeColor(primaryColor = "", secondaryColor = ""))
     }
         
 }
@@ -541,7 +549,11 @@ The default functionality will provide information using `HostEnvironmentInfo` o
 **API Docs:** [MiniAppMessageBridge.sendJsonToHostApp](api/com.rakuten.tech.mobile.miniapp.js/-mini-app-message-bridge/send-json-to-host-app.html)
 
 The MiniApp is able to send the Universal Bridge in `json` string format. 
-    
+
+### Get Host App Theme Colors
+**API Docs:** [MiniAppMessageBridge.getHostAppThemeColors](api/com.rakuten.tech.mobile.miniapp.js/-mini-app-message-bridge/get-host-app-theme-colors.html)
+
+Your App should provide a primary and secondary color to the mini app which is the theme colors of the host app . The mini app can use those colors and change it's appearence.
 
 ### User Info
 **API Docs:** [MiniAppMessageBridge.setUserInfoBridgeDispatcher](api/com.rakuten.tech.mobile.miniapp.js/-mini-app-message-bridge/set-user-info-bridge-dispatcher.html)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/analytics/Type.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/analytics/Type.kt
@@ -41,5 +41,6 @@ internal enum class Actype(val value: String) {
     CONSUME_PURCHASE("mini_app_consume_product_with"),
     JSON_INFO("mini_app_send_json_to_host_app"),
     CLOSE_MINIAPP("mini_app_close"),
+    GET_HOST_APP_THEME_COLORS("mini_app_get_host_app_theme_colors"),
     DEFAULT("")
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MessageBridgeRatDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MessageBridgeRatDispatcher.kt
@@ -48,6 +48,7 @@ internal class MessageBridgeRatDispatcher(private val miniAppAnalytics: MiniAppA
             ActionType.CONSUME_PURCHASE.action -> Actype.CONSUME_PURCHASE
             ActionType.JSON_INFO.action -> Actype.JSON_INFO
             ActionType.CLOSE_MINIAPP.action -> Actype.CLOSE_MINIAPP
+            ActionType.GET_HOST_APP_THEME_COLORS.action -> Actype.GET_HOST_APP_THEME_COLORS
             else -> Actype.DEFAULT
         }
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -24,7 +24,7 @@ import com.rakuten.tech.mobile.miniapp.js.chat.ChatBridge
 import com.rakuten.tech.mobile.miniapp.js.chat.ChatBridgeDispatcher
 import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostEnvironmentInfo
 import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostEnvironmentInfoError
-import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostThemeColor
+import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostAppThemeColors
 import com.rakuten.tech.mobile.miniapp.js.hostenvironment.isValidLocale
 import com.rakuten.tech.mobile.miniapp.js.iap.InAppPurchaseBridgeDispatcher
 import com.rakuten.tech.mobile.miniapp.js.userinfo.UserInfoBridge
@@ -157,7 +157,7 @@ open class MiniAppMessageBridge {
 
     /** Interface that should be implemented to return theme colors that uniquely identifies a host. **/
     open fun getHostAppThemeColors(
-        onSuccess: (themeColor: HostThemeColor) -> Unit,
+        onSuccess: (themeColor: HostAppThemeColors) -> Unit,
         onError: (message: String) -> Unit
     ) {
         throw MiniAppSdkException(ErrorBridgeMessage.NO_IMPL)
@@ -392,7 +392,7 @@ open class MiniAppMessageBridge {
     }
 
     private fun onGetHostAppThemeColors(callbackObj: CallbackObj) = try {
-        val successCallback = { themeColor: HostThemeColor ->
+        val successCallback = { themeColor: HostAppThemeColors ->
             bridgeExecutor.postValue(callbackObj.id, Gson().toJson(themeColor))
         }
         val errorCallback = { message: String ->

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/Type.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/Type.kt
@@ -30,7 +30,8 @@ internal enum class ActionType(val action: String) {
     PURCHASE_ITEM("purchaseProductWith"),
     CONSUME_PURCHASE("consumeProductWith"),
     JSON_INFO("sendJsonToHostapp"),
-    CLOSE_MINIAPP("closeMiniApp")
+    CLOSE_MINIAPP("closeMiniApp"),
+    GET_HOST_APP_THEME_COLORS("getHostAppThemeColors")
 }
 
 internal enum class DialogType {

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostAppThemeColors.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostAppThemeColors.kt
@@ -8,7 +8,7 @@ import androidx.annotation.Keep
  * @property secondaryColor The secondary color of the host app.
  */
 @Keep
-data class HostThemeColor(
+data class HostAppThemeColors(
     var primaryColor: String?,
     val secondaryColor: String?
 )

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostThemeColor.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/hostenvironment/HostThemeColor.kt
@@ -1,0 +1,14 @@
+package com.rakuten.tech.mobile.miniapp.js.hostenvironment
+
+import androidx.annotation.Keep
+
+/**
+ * Represents the color theme of the host app.
+ * @property primaryColor The primary color of the host app.
+ * @property secondaryColor The secondary color of the host app.
+ */
+@Keep
+data class HostThemeColor(
+    var primaryColor: String?,
+    val secondaryColor: String?
+)

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
@@ -1,6 +1,7 @@
 package com.rakuten.tech.mobile.miniapp
 
 import com.rakuten.tech.mobile.miniapp.analytics.MiniAppAnalyticsConfig
+import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostThemeColor
 import com.rakuten.tech.mobile.miniapp.js.userinfo.Contact
 import com.rakuten.tech.mobile.miniapp.permission.AccessTokenScope
 import java.io.File
@@ -40,6 +41,7 @@ internal const val TEST_HA_SUBSCRIPTION_KEY = "test_subscription_key"
 
 internal const val TEST_CALLBACK_ID = "test_callback_id"
 internal const val TEST_CALLBACK_VALUE = "test_callback_value"
+internal val TEST_CALLBACK_THEME = HostThemeColor("", "")
 
 internal const val TEST_AD_UNIT_ID = "ca-app-pub-xxxxxxxxxxxxxxxx/xxxxxxxxxx"
 internal val TEST_LIST_PUBLIC_KEY_SSL = emptyList<String>()

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/TestData.kt
@@ -1,7 +1,7 @@
 package com.rakuten.tech.mobile.miniapp
 
 import com.rakuten.tech.mobile.miniapp.analytics.MiniAppAnalyticsConfig
-import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostThemeColor
+import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostAppThemeColors
 import com.rakuten.tech.mobile.miniapp.js.userinfo.Contact
 import com.rakuten.tech.mobile.miniapp.permission.AccessTokenScope
 import java.io.File
@@ -41,7 +41,7 @@ internal const val TEST_HA_SUBSCRIPTION_KEY = "test_subscription_key"
 
 internal const val TEST_CALLBACK_ID = "test_callback_id"
 internal const val TEST_CALLBACK_VALUE = "test_callback_value"
-internal val TEST_CALLBACK_THEME = HostThemeColor("", "")
+internal val TEST_CALLBACK_THEME = HostAppThemeColors("", "")
 
 internal const val TEST_AD_UNIT_ID = "ca-app-pub-xxxxxxxxxxxxxxxx/xxxxxxxxxx"
 internal val TEST_LIST_PUBLIC_KEY_SSL = emptyList<String>()

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/BridgeCommon.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/BridgeCommon.kt
@@ -7,6 +7,7 @@ import com.rakuten.tech.mobile.miniapp.display.WebViewListener
 import com.rakuten.tech.mobile.miniapp.js.ErrorBridgeMessage.ERR_GET_ENVIRONMENT_INFO
 import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostEnvironmentInfo
 import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostEnvironmentInfoError
+import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostThemeColor
 import com.rakuten.tech.mobile.miniapp.permission.*
 import org.junit.Assert
 import org.mockito.Mockito
@@ -70,6 +71,17 @@ open class BridgeCommon {
         ) {
             if (mockIsValid) {
                 onSuccess(TEST_CALLBACK_VALUE)
+            } else {
+                onError(testErrorMessage)
+            }
+        }
+
+        override fun getHostAppThemeColors(
+            onSuccess: (themeColor: HostThemeColor) -> Unit,
+            onError: (message: String) -> Unit
+        ) {
+            if (mockIsValid) {
+                onSuccess(TEST_CALLBACK_THEME)
             } else {
                 onError(testErrorMessage)
             }

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/BridgeCommon.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/BridgeCommon.kt
@@ -7,7 +7,7 @@ import com.rakuten.tech.mobile.miniapp.display.WebViewListener
 import com.rakuten.tech.mobile.miniapp.js.ErrorBridgeMessage.ERR_GET_ENVIRONMENT_INFO
 import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostEnvironmentInfo
 import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostEnvironmentInfoError
-import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostThemeColor
+import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostAppThemeColors
 import com.rakuten.tech.mobile.miniapp.permission.*
 import org.junit.Assert
 import org.mockito.Mockito
@@ -77,7 +77,7 @@ open class BridgeCommon {
         }
 
         override fun getHostAppThemeColors(
-            onSuccess: (themeColor: HostThemeColor) -> Unit,
+            onSuccess: (themeColor: HostAppThemeColors) -> Unit,
             onError: (message: String) -> Unit
         ) {
             if (mockIsValid) {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MessageBridgeRatDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MessageBridgeRatDispatcherSpec.kt
@@ -45,6 +45,7 @@ class MessageBridgeRatDispatcherSpec {
         ActionType.SECURE_STORAGE_SIZE.action to Actype.SECURE_STORAGE_SIZE,
         ActionType.JSON_INFO.action to Actype.JSON_INFO,
         ActionType.CLOSE_MINIAPP.action to Actype.CLOSE_MINIAPP,
+        ActionType.GET_HOST_APP_THEME_COLORS.action to Actype.GET_HOST_APP_THEME_COLORS,
         )
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
@@ -37,7 +37,13 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
     private val mauIdCallbackObj = CallbackObj(
         action = ActionType.GET_MAUID.action, param = null, id = TEST_CALLBACK_ID
     )
+
+    private val themeCallbackObj = CallbackObj(
+        action = ActionType.GET_HOST_APP_THEME_COLORS.action, param = null, id = TEST_CALLBACK_ID
+    )
+
     private val mauIdJsonStr = Gson().toJson(mauIdCallbackObj)
+    private val themeJsonStr = Gson().toJson(themeCallbackObj)
 
     private val permissionCallbackObj = CallbackObj(
         action = ActionType.REQUEST_PERMISSION.action,
@@ -180,6 +186,15 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
             verify(bridgeExecutor).postError(TEST_CALLBACK_ID, errMsg)
         }
     }
+
+    /** region: device theme color*/
+    @Test
+    fun `should be able to return themeColor to miniapp`() {
+        miniAppBridge.postMessage(themeJsonStr)
+
+        verify(bridgeExecutor).postValue(TEST_CALLBACK_ID, Gson().toJson(TEST_CALLBACK_THEME))
+    }
+    /** end region*/
 
     /** region: device permission */
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/UnimplementedMessageBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/UnimplementedMessageBridgeSpec.kt
@@ -33,4 +33,9 @@ class UnimplementedMessageBridgeSpec : BridgeCommon() {
         val mockFunction: (Any) -> Unit = {}
         unimplementedMessageBridge.sendJsonToHostApp("", mockFunction, mockFunction)
     }
+
+    @Test(expected = MiniAppSdkException::class)
+    fun `getHostAppThemeColors should throw MiniAppSdkException when it is not implemented`() {
+        unimplementedMessageBridge.getHostAppThemeColors(mock(), mock())
+    }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/MessageBridgeHelper.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/MessageBridgeHelper.kt
@@ -7,6 +7,7 @@ import com.rakuten.tech.mobile.miniapp.errors.MiniAppPointsError
 import com.rakuten.tech.mobile.miniapp.js.MessageToContact
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.miniapp.js.chat.ChatBridgeDispatcher
+import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostThemeColor
 import com.rakuten.tech.mobile.miniapp.js.userinfo.Contact
 import com.rakuten.tech.mobile.miniapp.js.userinfo.Points
 import com.rakuten.tech.mobile.miniapp.js.userinfo.TokenData
@@ -81,6 +82,13 @@ fun getMessageBridge(
                 activity.showToastMessage(message)
             }
         }
+    }
+
+    override fun getHostAppThemeColors(
+        onSuccess: (themeColor: HostThemeColor) -> Unit,
+        onError: (message: String) -> Unit
+    ) {
+        onSuccess(AppSettings.instance.colorTheme)
     }
 }
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/MessageBridgeHelper.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/MessageBridgeHelper.kt
@@ -7,7 +7,7 @@ import com.rakuten.tech.mobile.miniapp.errors.MiniAppPointsError
 import com.rakuten.tech.mobile.miniapp.js.MessageToContact
 import com.rakuten.tech.mobile.miniapp.js.MiniAppMessageBridge
 import com.rakuten.tech.mobile.miniapp.js.chat.ChatBridgeDispatcher
-import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostThemeColor
+import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostAppThemeColors
 import com.rakuten.tech.mobile.miniapp.js.userinfo.Contact
 import com.rakuten.tech.mobile.miniapp.js.userinfo.Points
 import com.rakuten.tech.mobile.miniapp.js.userinfo.TokenData
@@ -85,7 +85,7 @@ fun getMessageBridge(
     }
 
     override fun getHostAppThemeColors(
-        onSuccess: (themeColor: HostThemeColor) -> Unit,
+        onSuccess: (themeColor: HostAppThemeColors) -> Unit,
         onError: (message: String) -> Unit
     ) {
         onSuccess(AppSettings.instance.colorTheme)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -6,7 +6,7 @@ import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkConfig
 import com.rakuten.tech.mobile.miniapp.analytics.MiniAppAnalyticsConfig
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppAccessTokenError
-import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostThemeColor
+import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostAppThemeColors
 import com.rakuten.tech.mobile.miniapp.js.userinfo.Contact
 import com.rakuten.tech.mobile.miniapp.js.userinfo.Points
 import com.rakuten.tech.mobile.miniapp.js.userinfo.TokenData
@@ -84,8 +84,8 @@ class AppSettings private constructor(context: Context) {
             cache.tokenData = tokenData
         }
 
-    var colorTheme: HostThemeColor
-        get() = cache.colorTheme ?: HostThemeColor("", "")
+    var colorTheme: HostAppThemeColors
+        get() = cache.colorTheme ?: HostAppThemeColors("", "")
         set(colorTheme) {
             cache.colorTheme = colorTheme
         }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/AppSettings.kt
@@ -6,6 +6,7 @@ import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.MiniAppSdkConfig
 import com.rakuten.tech.mobile.miniapp.analytics.MiniAppAnalyticsConfig
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppAccessTokenError
+import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostThemeColor
 import com.rakuten.tech.mobile.miniapp.js.userinfo.Contact
 import com.rakuten.tech.mobile.miniapp.js.userinfo.Points
 import com.rakuten.tech.mobile.miniapp.js.userinfo.TokenData
@@ -81,6 +82,12 @@ class AppSettings private constructor(context: Context) {
         get() = cache.tokenData ?: TokenData("test_token", Date().time)
         set(tokenData) {
             cache.tokenData = tokenData
+        }
+
+    var colorTheme: HostThemeColor
+        get() = cache.colorTheme ?: HostThemeColor("", "")
+        set(colorTheme) {
+            cache.colorTheme = colorTheme
         }
 
     var contacts: ArrayList<Contact>

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/cache/Cache.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/cache/Cache.kt
@@ -6,6 +6,7 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppAccessTokenError
+import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostThemeColor
 import com.rakuten.tech.mobile.miniapp.js.userinfo.Contact
 import com.rakuten.tech.mobile.miniapp.js.userinfo.Points
 import com.rakuten.tech.mobile.miniapp.js.userinfo.TokenData
@@ -74,6 +75,11 @@ internal class Cache(
     var tokenData: TokenData?
         get() = gson.fromJson(prefs.getString(TOKEN_DATA, null), TokenData::class.java)
         set(tokenData) = prefs.edit().putString(TOKEN_DATA, gson.toJson(tokenData))
+            .apply()
+
+    var colorTheme: HostThemeColor?
+        get() = gson.fromJson(prefs.getString(COLOR_THEME, null), HostThemeColor::class.java)
+        set(colorTheme) = prefs.edit().putString(COLOR_THEME, gson.toJson(colorTheme))
             .apply()
 
     var contacts: ArrayList<Contact>?
@@ -150,6 +156,7 @@ internal class Cache(
         private const val MAX_STORAGE_SIZE_LIMIT = "max_storage_size_limit"
         private const val IS_TEMP_CLEARED = "is_temp_cleared"
         private const val IS_TAB_1_CHECKED = "is_tab_1_checked"
+        private const val COLOR_THEME = "color_theme"
     }
 
     @Suppress("TooManyFunctions")

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/cache/Cache.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/settings/cache/Cache.kt
@@ -6,7 +6,7 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.rakuten.tech.mobile.miniapp.MiniAppInfo
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppAccessTokenError
-import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostThemeColor
+import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostAppThemeColors
 import com.rakuten.tech.mobile.miniapp.js.userinfo.Contact
 import com.rakuten.tech.mobile.miniapp.js.userinfo.Points
 import com.rakuten.tech.mobile.miniapp.js.userinfo.TokenData
@@ -77,8 +77,8 @@ internal class Cache(
         set(tokenData) = prefs.edit().putString(TOKEN_DATA, gson.toJson(tokenData))
             .apply()
 
-    var colorTheme: HostThemeColor?
-        get() = gson.fromJson(prefs.getString(COLOR_THEME, null), HostThemeColor::class.java)
+    var colorTheme: HostAppThemeColors?
+        get() = gson.fromJson(prefs.getString(COLOR_THEME, null), HostAppThemeColors::class.java)
         set(colorTheme) = prefs.edit().putString(COLOR_THEME, gson.toJson(colorTheme))
             .apply()
 

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
@@ -15,6 +15,7 @@ import androidx.core.text.isDigitsOnly
 import androidx.databinding.DataBindingUtil
 import com.rakuten.tech.mobile.miniapp.MiniApp
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppAccessTokenError
+import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostThemeColor
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.QaSettingsActivityBinding
 import com.rakuten.tech.mobile.testapp.helper.MiniAppBluetoothDelegate
@@ -120,6 +121,11 @@ class QASettingsActivity : BaseActivity() {
 
         val maxStorage = settings.maxStorageSizeLimitInBytes
         binding.edtMaxStorageLimit.setText("Current limit is $maxStorage Bytes")
+
+        // theme color
+        binding.edtPrimaryColor.setText(settings.colorTheme.primaryColor)
+        binding.edtSecondaryColor.setText(settings.colorTheme.secondaryColor)
+
 
         invalidateMaxStorageField()
     }
@@ -307,6 +313,17 @@ class QASettingsActivity : BaseActivity() {
         if (!upgradedSize.isNullOrEmpty() && upgradedSize.isDigitsOnly()) {
             settings.maxStorageSizeLimitInBytes = binding.edtMaxStorageLimit.text.toString()
         }
+
+        //Save color theme
+        var primaryColor = ""
+        var secondaryColor = ""
+        if (!binding.edtPrimaryColor.text.isNullOrEmpty()) {
+            primaryColor = binding.edtPrimaryColor.text.toString()
+        }
+        if (!binding.edtSecondaryColor.text.isNullOrEmpty()) {
+            secondaryColor = binding.edtSecondaryColor.text.toString()
+        }
+        settings.colorTheme = HostThemeColor(primaryColor, secondaryColor)
 
         // post tasks
         hideSoftKeyboard(binding.root)

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QASettingsActivity.kt
@@ -15,7 +15,7 @@ import androidx.core.text.isDigitsOnly
 import androidx.databinding.DataBindingUtil
 import com.rakuten.tech.mobile.miniapp.MiniApp
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppAccessTokenError
-import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostThemeColor
+import com.rakuten.tech.mobile.miniapp.js.hostenvironment.HostAppThemeColors
 import com.rakuten.tech.mobile.miniapp.testapp.R
 import com.rakuten.tech.mobile.miniapp.testapp.databinding.QaSettingsActivityBinding
 import com.rakuten.tech.mobile.testapp.helper.MiniAppBluetoothDelegate
@@ -323,7 +323,7 @@ class QASettingsActivity : BaseActivity() {
         if (!binding.edtSecondaryColor.text.isNullOrEmpty()) {
             secondaryColor = binding.edtSecondaryColor.text.toString()
         }
-        settings.colorTheme = HostThemeColor(primaryColor, secondaryColor)
+        settings.colorTheme = HostAppThemeColors(primaryColor, secondaryColor)
 
         // post tasks
         hideSoftKeyboard(binding.root)

--- a/testapp/src/main/res/layout/qa_settings_activity.xml
+++ b/testapp/src/main/res/layout/qa_settings_activity.xml
@@ -32,14 +32,14 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:padding="@dimen/medium_16"
-                android:textOff="@string/lb_auth_failure_error"
-                android:textOn="@string/lb_auth_failure_error"
                 android:text="@string/lb_auth_failure_error"
                 android:textColor="@android:color/black"
+                android:textOff="@string/lb_auth_failure_error"
+                android:textOn="@string/lb_auth_failure_error"
                 android:textSize="@dimen/text_large_16"
                 app:actionType="change_status"
                 app:pageName="QA"
-                app:siteSection="Settings"/>
+                app:siteSection="Settings" />
 
             <View
                 android:layout_width="match_parent"
@@ -56,7 +56,7 @@
                 android:textSize="@dimen/text_large_16"
                 app:actionType="change_status"
                 app:pageName="QA"
-                app:siteSection="Settings"/>
+                app:siteSection="Settings" />
 
             <View
                 android:layout_width="match_parent"
@@ -98,7 +98,7 @@
                 android:textSize="@dimen/text_large_16"
                 app:actionType="change_status"
                 app:pageName="QA"
-                app:siteSection="Settings"/>
+                app:siteSection="Settings" />
 
             <View
                 android:layout_width="match_parent"
@@ -197,12 +197,12 @@
                 android:layout_height="@dimen/large_44"
                 android:layout_margin="@dimen/medium_16"
                 android:background="@drawable/bg_red_curve"
+                android:enabled="false"
                 android:gravity="center"
                 android:padding="@dimen/small_4"
                 android:text="@string/action_clear_miniapp"
                 android:textColor="@android:color/white"
                 android:textSize="@dimen/text_large_16"
-                android:enabled="false"
                 app:actionType="change_status"
                 app:pageName="QA"
                 app:siteSection="Settings" />
@@ -287,6 +287,38 @@
                 app:actionType="change_status"
                 app:pageName="QA"
                 app:siteSection="Settings" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="@dimen/small_4"
+                app:endIconMode="clear_text">
+
+                <androidx.appcompat.widget.AppCompatEditText
+                    android:id="@+id/edtPrimaryColor"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/small_4"
+                    android:hint="@string/hint_set_primary_color"
+                    android:imeOptions="actionDone"
+                    android:inputType="textMultiLine" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="@dimen/small_4"
+                app:endIconMode="clear_text">
+
+                <androidx.appcompat.widget.AppCompatEditText
+                    android:id="@+id/edtSecondaryColor"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/small_4"
+                    android:hint="@string/hint_set_secondary_color"
+                    android:imeOptions="actionDone"
+                    android:inputType="textMultiLine" />
+            </com.google.android.material.textfield.TextInputLayout>
 
         </LinearLayout>
     </ScrollView>

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -133,5 +133,7 @@
     <string name="error_send_json_to_mini_app_message_cannot_be_empty">Unable to send the message: The message cannot be empty</string>
     <string name="lb_general">General</string>
     <string name="add_new_email">Add new email</string>
+    <string name="hint_set_primary_color">Primary Color</string>
+    <string name="hint_set_secondary_color">Secondary Color</string>
 
 </resources>


### PR DESCRIPTION
# Description
Changes

- Added `MiniAppMessageBridge.getHostAppThemeColors` in MiniAppMessageBridge for retrieving primary and secondary theme color.
- Added qa settings to test primary and secondary color.


## Links
MINI-6077

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
