### PR TITLE
[MINI-5900] Deeplink support to save project keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 **Sample App**
 - **Feature:** Added implementation of `MiniAppMessageBridge.getHostAppThemeColors`.
 - **Feature:** Added qa settings to test primary and secondary color.
+- **Feature:** Added Deeplink Support to change settings keys by QR code.
 
 ### 5.2.1 (2023-05-23)
 **SDK**

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ allprojects {
         tag {
             prefix = 'v'
             versionSeparator = ''
-            versionIncrementer 'incrementPatch'
+            versionIncrementer 'incrementMinor'
         }
     }
 

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -89,6 +89,10 @@
                     android:host="@string/miniappdemo_host"
                     android:pathPrefix="@string/miniappdemo_pathprefix"
                     android:scheme="@string/miniappdemo_scheme" />
+                <data
+                    android:host="@string/miniappdemo_host"
+                    android:pathPrefix="@string/settings_pathprefix"
+                    android:scheme="@string/miniappdemo_scheme" />
             </intent-filter>
         </activity>
         <activity

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/deeplink/SchemeActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/deeplink/SchemeActivity.kt
@@ -20,6 +20,7 @@ import com.rakuten.tech.mobile.testapp.ui.settings.cache.MiniAppConfigData
 /**
  * This activity will be the gateway of all deeplink scheme.
  */
+const val INTENT_EXTRA_DEEPLINK = "isFromDeeplink"
 class SchemeActivity : BaseActivity(), PreloadMiniAppWindow.PreloadMiniAppLaunchListener {
 
     override val pageName: String = this::class.simpleName ?: ""
@@ -39,13 +40,17 @@ class SchemeActivity : BaseActivity(), PreloadMiniAppWindow.PreloadMiniAppLaunch
                 val tab = data.getQueryParameter("tab") ?: ""
                 val projectId = data.getQueryParameter("projectid") ?: ""
                 val subscriptionKey = data.getQueryParameter("subscription") ?: ""
+                val isProduction = data.getBooleanQueryParameter("isProduction", false)
+                val isPreviewMode = data.getBooleanQueryParameter("isPreviewMode", false)
+                val isVerificationRequired = data.getBooleanQueryParameter("isVerificationRequired", false)
+
                 // Save the keys to prefs
                 if(tab == "1") {
                     AppSettings.instance.setTempTab1ConfigData(
                         MiniAppConfigData(
-                            isProduction = AppSettings.instance.getCurrentTab1ConfigData().isProduction,
-                            isPreviewMode = AppSettings.instance.getCurrentTab1ConfigData().isPreviewMode,
-                            isVerificationRequired =AppSettings.instance.getCurrentTab1ConfigData().isVerificationRequired,
+                            isProduction = isProduction,
+                            isPreviewMode = isPreviewMode,
+                            isVerificationRequired = isVerificationRequired,
                             projectId = projectId,
                             subscriptionId = subscriptionKey
                         )
@@ -54,15 +59,19 @@ class SchemeActivity : BaseActivity(), PreloadMiniAppWindow.PreloadMiniAppLaunch
                 } else if (tab == "2") {
                     AppSettings.instance.setTempTab2ConfigData(
                         MiniAppConfigData(
-                            isProduction = AppSettings.instance.getCurrentTab2ConfigData().isProduction,
-                            isPreviewMode = AppSettings.instance.getCurrentTab2ConfigData().isPreviewMode,
-                            isVerificationRequired =AppSettings.instance.getCurrentTab2ConfigData().isVerificationRequired,
+                            isProduction = isProduction,
+                            isPreviewMode = isPreviewMode,
+                            isVerificationRequired = isVerificationRequired,
                             projectId = projectId,
                             subscriptionId = subscriptionKey
                         )
                     )
                 }
-                startActivity(Intent(this, DemoAppMainActivity::class.java))
+                startActivity(
+                    Intent(this,
+                        DemoAppMainActivity::class.java
+                    ).putExtra(INTENT_EXTRA_DEEPLINK, false)
+                )
                 finish()
             } else if (data.pathSegments.size > 1) {
                 miniAppInfo = null

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/DemoAppMainActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/miniapptabs/DemoAppMainActivity.kt
@@ -14,6 +14,7 @@ import com.rakuten.tech.mobile.miniapp.testapp.databinding.MiniAppMainLayoutBind
 import com.rakuten.tech.mobile.miniapp.view.MiniAppView
 import com.rakuten.tech.mobile.testapp.helper.clearAllCursorFocus
 import com.rakuten.tech.mobile.testapp.ui.base.BaseActivity
+import com.rakuten.tech.mobile.testapp.ui.deeplink.INTENT_EXTRA_DEEPLINK
 import com.rakuten.tech.mobile.testapp.ui.miniapptabs.extensions.setupWithNavController
 import com.rakuten.tech.mobile.testapp.ui.miniapptabs.fragments.FeaturesFragment
 import com.rakuten.tech.mobile.testapp.ui.miniapptabs.fragments.MiniAppDisplayFragment
@@ -36,6 +37,15 @@ class DemoAppMainActivity : BaseActivity() {
             setUpBottomNavigationBar()
         }
         launchMiniApps()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (intent.hasExtra(INTENT_EXTRA_DEEPLINK) &&
+            intent.getBooleanExtra(INTENT_EXTRA_DEEPLINK, false)
+        ) {
+            changeTabMenu(PAGE_SETTINGS)
+        }
     }
 
     override fun dispatchTouchEvent(event: MotionEvent): Boolean {

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -118,6 +118,7 @@
     <string name="miniappdemo_scheme">miniappdemo</string>
     <string name="miniappdemo_host">miniapp</string>
     <string name="miniappdemo_pathprefix">/preview/</string>
+    <string name="settings_pathprefix">/settings</string>
 
     <string name="deeplink_activity_error_empty">Empty deeplink, please try again.</string>
     <string name="deeplink_activity_input_hint">Input here</string>


### PR DESCRIPTION
# Description

- Enable passing the Project ID and subscription key using deep link
- For eg., 
```
miniappdemo://miniapp/settings?tab=1/2&projectid=abc&subscription=123&isProduction=true/false&isPreviewMode=true/false&isVerificationRequired=true/false
```
- If the Demo app is closed and it is opened using the above Deeplink, then it can open the default state of the settings page OR the last known state of the settings page with the value of the above deep-link parameters in the text field.

## Links
MINI-5900

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
