### PR TITLE
[MINI- 6131] Implement dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 ### 5.x.x (xxxx-xx-xx)
 **SDK**
 - **Feature:** Added `MiniAppMessageBridge.getHostAppThemeColors` in MiniAppMessageBridge for retrieving primary and secondary theme color.
+- **Feature:** Added `MiniAppMessageBridge.getIsDarkMode` in MiniAppMessageBridge for retrieving dark mode status.
 
 **Sample App**
 - **Feature:** Added implementation of `MiniAppMessageBridge.getHostAppThemeColors`.
 - **Feature:** Added qa settings to test primary and secondary color.
 - **Feature:** Added Deeplink Support to change settings keys by QR code.
+- **Feature:** Added implementation of `MiniAppMessageBridge.getIsDarkMode`.
 
 ### 5.2.1 (2023-05-23)
 **SDK**

--- a/miniapp/USERGUIDE.md
+++ b/miniapp/USERGUIDE.md
@@ -274,6 +274,7 @@ There are some methods have a default implementation but the host app can overri
 | getHostEnvironmentInfo       | ✅       |
 | sendJsonToHostApp            | 🚫       |
 | getHostAppThemeColors        | 🚫       |
+| getIsDarkMode                | 🚫       |
 
 The `UserInfoBridgeDispatcher`:
 
@@ -372,6 +373,16 @@ val miniAppMessageBridge = object: MiniAppMessageBridge() {
         onError: (message: String) -> Unit
     ) {
         onSuccess(HostAppThemeColors(primaryColor = "", secondaryColor = ""))
+    }
+
+    override fun getIsDarkMode(
+        onSuccess: (isDarkMode: Boolean) -> Unit,
+        onError: (message: String) -> Unit
+    ) {
+        when (activity.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) {
+            Configuration.UI_MODE_NIGHT_NO -> onSuccess(false) // Night mode is not active, we're using the light theme.
+            Configuration.UI_MODE_NIGHT_YES -> onSuccess(true) // Night mode is active, we're using dark theme.
+        }
     }
         
 }
@@ -554,6 +565,11 @@ The MiniApp is able to send the Universal Bridge in `json` string format.
 **API Docs:** [MiniAppMessageBridge.getHostAppThemeColors](api/com.rakuten.tech.mobile.miniapp.js/-mini-app-message-bridge/get-host-app-theme-colors.html)
 
 Your App should provide a primary and secondary color to the mini app which is the theme colors of the host app . The mini app can use those colors and change it's appearence.
+
+### Get Host App Dark Mode Status
+**API Docs:** [MiniAppMessageBridge.getIsDarkMode](api/com.rakuten.tech.mobile.miniapp.js/-mini-app-message-bridge/get-is-dark-mode.html)
+
+Your App should provide boolean value true if dark mode enabled in the device and false if it is disabled.
 
 ### User Info
 **API Docs:** [MiniAppMessageBridge.setUserInfoBridgeDispatcher](api/com.rakuten.tech.mobile.miniapp.js/-mini-app-message-bridge/set-user-info-bridge-dispatcher.html)

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/analytics/Type.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/analytics/Type.kt
@@ -42,5 +42,6 @@ internal enum class Actype(val value: String) {
     JSON_INFO("mini_app_send_json_to_host_app"),
     CLOSE_MINIAPP("mini_app_close"),
     GET_HOST_APP_THEME_COLORS("mini_app_get_host_app_theme_colors"),
+    GET_IS_DARK_MODE("mini_app_get_is_dark_mode"),
     DEFAULT("")
 }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MessageBridgeRatDispatcher.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MessageBridgeRatDispatcher.kt
@@ -49,6 +49,7 @@ internal class MessageBridgeRatDispatcher(private val miniAppAnalytics: MiniAppA
             ActionType.JSON_INFO.action -> Actype.JSON_INFO
             ActionType.CLOSE_MINIAPP.action -> Actype.CLOSE_MINIAPP
             ActionType.GET_HOST_APP_THEME_COLORS.action -> Actype.GET_HOST_APP_THEME_COLORS
+            ActionType.GET_IS_DARK_MODE.action -> Actype.GET_IS_DARK_MODE
             else -> Actype.DEFAULT
         }
     }

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridge.kt
@@ -202,6 +202,17 @@ open class MiniAppMessageBridge {
     }
 
     /**
+     * Get dark mode info from host app.
+     * You can also throw an [Exception] from this method to pass an error message to the mini app.
+     */
+    open fun getIsDarkMode(
+        onSuccess: (isDarkMode: Boolean) -> Unit,
+        onError: (message: String) -> Unit
+    ) {
+        throw MiniAppSdkException(ErrorBridgeMessage.NO_IMPL)
+    }
+
+    /**
      * Share content info [ShareInfo]. This info is provided by mini app.
      * @param content The content property of [ShareInfo] object.
      * @param callback The executed action status should be notified back to mini app.
@@ -307,6 +318,7 @@ open class MiniAppMessageBridge {
             ActionType.JSON_INFO.action -> onSendJsonToHostApp(callbackObj.id, jsonStr)
             ActionType.CLOSE_MINIAPP.action -> onCloseMiniApp(callbackObj)
             ActionType.GET_HOST_APP_THEME_COLORS.action -> onGetHostAppThemeColors(callbackObj)
+            ActionType.GET_IS_DARK_MODE.action -> onGetIsDarkMode(callbackObj.id)
         }
         if (this::ratDispatcher.isInitialized) ratDispatcher.sendAnalyticsSdkFeature(callbackObj.action)
     }
@@ -520,6 +532,18 @@ open class MiniAppMessageBridge {
             bridgeExecutor.postError(callbackId, Gson().toJson(errorBridgeModel))
         }
         getHostEnvironmentInfo(successCallback, errorCallback)
+    }
+
+    @SuppressWarnings("TooGenericExceptionCaught")
+    @VisibleForTesting
+    internal fun onGetIsDarkMode(callbackId: String) {
+        val successCallback = { isDarkMode: Boolean ->
+            bridgeExecutor.postValue(callbackId, isDarkMode.toString())
+        }
+        val errorCallback = { message: String ->
+            bridgeExecutor.postError(callbackId, message)
+        }
+        getIsDarkMode(successCallback, errorCallback)
     }
 
     @VisibleForTesting

--- a/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/Type.kt
+++ b/miniapp/src/main/java/com/rakuten/tech/mobile/miniapp/js/Type.kt
@@ -31,7 +31,8 @@ internal enum class ActionType(val action: String) {
     CONSUME_PURCHASE("consumeProductWith"),
     JSON_INFO("sendJsonToHostapp"),
     CLOSE_MINIAPP("closeMiniApp"),
-    GET_HOST_APP_THEME_COLORS("getHostAppThemeColors")
+    GET_HOST_APP_THEME_COLORS("getHostAppThemeColors"),
+    GET_IS_DARK_MODE("isDarkMode")
 }
 
 internal enum class DialogType {

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/BridgeCommon.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/BridgeCommon.kt
@@ -119,6 +119,17 @@ open class BridgeCommon {
                 onError.invoke(HostEnvironmentInfoError(infoErrMessage))
             }
         }
+
+        override fun getIsDarkMode(
+            onSuccess: (isDarkMode: Boolean) -> Unit,
+            onError: (message: String) -> Unit
+        ) {
+            if (mockIsValid) {
+                onSuccess(true)
+            } else {
+                onError(testErrorMessage)
+            }
+        }
     }
 
     fun createDefaultMiniAppMessageBridge(): MiniAppMessageBridge =

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MessageBridgeRatDispatcherSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MessageBridgeRatDispatcherSpec.kt
@@ -46,6 +46,7 @@ class MessageBridgeRatDispatcherSpec {
         ActionType.JSON_INFO.action to Actype.JSON_INFO,
         ActionType.CLOSE_MINIAPP.action to Actype.CLOSE_MINIAPP,
         ActionType.GET_HOST_APP_THEME_COLORS.action to Actype.GET_HOST_APP_THEME_COLORS,
+        ActionType.GET_IS_DARK_MODE.action to Actype.GET_IS_DARK_MODE,
         )
 
     @Test

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/MiniAppMessageBridgeSpec.kt
@@ -42,8 +42,13 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
         action = ActionType.GET_HOST_APP_THEME_COLORS.action, param = null, id = TEST_CALLBACK_ID
     )
 
+    private val darkModeCallbackObj = CallbackObj(
+        action = ActionType.GET_IS_DARK_MODE.action, param = null, id = TEST_CALLBACK_ID
+    )
+
     private val mauIdJsonStr = Gson().toJson(mauIdCallbackObj)
     private val themeJsonStr = Gson().toJson(themeCallbackObj)
+    private val darkModeJsonStr = Gson().toJson(darkModeCallbackObj)
 
     private val permissionCallbackObj = CallbackObj(
         action = ActionType.REQUEST_PERMISSION.action,
@@ -193,6 +198,13 @@ class MiniAppMessageBridgeSpec : BridgeCommon() {
         miniAppBridge.postMessage(themeJsonStr)
 
         verify(bridgeExecutor).postValue(TEST_CALLBACK_ID, Gson().toJson(TEST_CALLBACK_THEME))
+    }
+
+    @Test
+    fun `should be able to return dark mode info to miniapp`() {
+        miniAppBridge.postMessage(darkModeJsonStr)
+
+        verify(bridgeExecutor).postValue(TEST_CALLBACK_ID, "true")
     }
     /** end region*/
 

--- a/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/UnimplementedMessageBridgeSpec.kt
+++ b/miniapp/src/test/java/com/rakuten/tech/mobile/miniapp/js/UnimplementedMessageBridgeSpec.kt
@@ -38,4 +38,9 @@ class UnimplementedMessageBridgeSpec : BridgeCommon() {
     fun `getHostAppThemeColors should throw MiniAppSdkException when it is not implemented`() {
         unimplementedMessageBridge.getHostAppThemeColors(mock(), mock())
     }
+
+    @Test(expected = MiniAppSdkException::class)
+    fun `getIsDarkMode should throw MiniAppSdkException when it is not implemented`() {
+        unimplementedMessageBridge.getIsDarkMode(mock(), mock())
+    }
 }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/MessageBridgeHelper.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/MessageBridgeHelper.kt
@@ -96,9 +96,8 @@ fun getMessageBridge(
         onSuccess: (isDarkMode: Boolean) -> Unit,
         onError: (message: String) -> Unit
     ) {
-        val currentNightMode = activity.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
-        when (currentNightMode) {
-            Configuration.UI_MODE_NIGHT_NO -> onError("Not Activated") // Night mode is not active, we're using the light theme.
+        when (activity.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) {
+            Configuration.UI_MODE_NIGHT_NO -> onSuccess(false) // Night mode is not active, we're using the light theme.
             Configuration.UI_MODE_NIGHT_YES -> onSuccess(true) // Night mode is active, we're using dark theme.
         }
     }

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/MessageBridgeHelper.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/MessageBridgeHelper.kt
@@ -1,6 +1,7 @@
 package com.rakuten.tech.mobile.testapp.helper
 
 import android.app.Activity
+import android.content.res.Configuration
 import androidx.core.app.ActivityCompat
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppAccessTokenError
 import com.rakuten.tech.mobile.miniapp.errors.MiniAppPointsError
@@ -89,6 +90,17 @@ fun getMessageBridge(
         onError: (message: String) -> Unit
     ) {
         onSuccess(AppSettings.instance.colorTheme)
+    }
+
+    override fun getIsDarkMode(
+        onSuccess: (isDarkMode: Boolean) -> Unit,
+        onError: (message: String) -> Unit
+    ) {
+        val currentNightMode = activity.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        when (currentNightMode) {
+            Configuration.UI_MODE_NIGHT_NO -> onError("Not Activated") // Night mode is not active, we're using the light theme.
+            Configuration.UI_MODE_NIGHT_YES -> onSuccess(true) // Night mode is active, we're using dark theme.
+        }
     }
 }
 


### PR DESCRIPTION
# Description
Added a new interface to send to dark mode status to miniapp to change the mode of the miniapp as well.

## Links
MINI-6131

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
