### PR TITLE
[MINI-6206] Add clear button on analytic log page

### DIFF
--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/FileUtils.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/helper/FileUtils.kt
@@ -33,6 +33,13 @@ class FileUtils {
             )
         }
 
+        fun deleteLogs(context: Context) {
+            val logFile =
+                File(context.filesDir, "$ANALYTIC_LOG_FOLDER_NAME/$ANALYTIC_LOG_FILE_NAME")
+            if (logFile.exists())
+                logFile.delete()
+        }
+
         fun getAnalyticLogs(context: Context): String {
             val logFile =
                 File(context.filesDir, "$ANALYTIC_LOG_FOLDER_NAME/$ANALYTIC_LOG_FILE_NAME")

--- a/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QAAnalyticsLogsActivity.kt
+++ b/testapp/src/main/java/com/rakuten/tech/mobile/testapp/ui/userdata/QAAnalyticsLogsActivity.kt
@@ -3,6 +3,7 @@ package com.rakuten.tech.mobile.testapp.ui.userdata
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import android.view.Menu
 import android.view.MenuItem
 import androidx.databinding.DataBindingUtil
 import com.rakuten.tech.mobile.miniapp.testapp.R
@@ -40,6 +41,11 @@ class QAAnalyticsLogsActivity : BaseActivity() {
         binding.tvAnalyticsLogs.text = FileUtils.getAnalyticLogs(this)
     }
 
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.settings_qa_logs_menu, menu)
+        return true
+    }
+
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         super.onOptionsItemSelected(item)
         return when (item.itemId) {
@@ -47,8 +53,17 @@ class QAAnalyticsLogsActivity : BaseActivity() {
                 exitPage()
                 return true
             }
+            R.id.qa_logs_clear -> {
+                clearLogs()
+                return true
+            }
             else -> super.onOptionsItemSelected(item)
         }
+    }
+
+    private fun clearLogs(){
+        FileUtils.deleteLogs(this)
+        binding.tvAnalyticsLogs.text = ""
     }
 
     override fun onBackPressed() {

--- a/testapp/src/main/res/menu/settings_qa_logs_menu.xml
+++ b/testapp/src/main/res/menu/settings_qa_logs_menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/qa_logs_clear"
+        android:title="@string/action_clear"
+        app:showAsAction="always" />
+</menu>

--- a/testapp/src/main/res/values/strings.xml
+++ b/testapp/src/main/res/values/strings.xml
@@ -65,6 +65,7 @@
     <string name="action_go_input_url_details">Open a miniapp via url</string>
     <string name="action_load_miniapp_from_bundle">Load MiniApp From Bundle</string>
     <string name="action_save">Save</string>
+    <string name="action_clear">Clear</string>
     <string name="action_add">Add</string>
     <string name="action_cancel">CANCEL</string>
     <string name="action_update">Update</string>


### PR DESCRIPTION
# Description
Add `Clear` button to clear analytic logs.

## Links
MINI-6206

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md).
- [x] I have completed the [SDK Development Learning Path](https://github.com/rakutentech/android-miniapp/blob/master/.github/CONTRIBUTING.md#sdk-development-learning-path) (if submitting a feature PR)
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `./gradlew check` without errors
